### PR TITLE
Add mmh2o units

### DIFF
--- a/ccp/config/new_units.txt
+++ b/ccp/config/new_units.txt
@@ -1,3 +1,6 @@
 RPM = rpm * 1
 hour = 60 * minute = h = hr
 percent = 0.01*count
+cmh2o = cmH2O
+millimeterh2o = cmh2o / 10 = mmH2O = mmh2o
+meterh2o = cmh2o * 100 = mH2O = mh2o


### PR DESCRIPTION
Added units for mmh2o and mh2o.
Some aliases such as mmH2O have also been added.