### PR TITLE
Implement seal gas checkbox

### DIFF
--- a/ccp/app/.streamlit/config.toml
+++ b/ccp/app/.streamlit/config.toml
@@ -107,12 +107,12 @@ baseUrlPath = ""
 # Enables support for Cross-Origin Request Sharing (CORS) protection, for added security.
 # Due to conflicts between CORS and XSRF, if `server.enableXsrfProtection` is on and `server.enableCORS` is off at the same time, we will prioritize `server.enableXsrfProtection`.
 # Default: true
-enableCORS = true
+enableCORS = false
 
 # Enables support for Cross-Site Request Forgery (XSRF) protection, for added security.
 # Due to conflicts between CORS and XSRF, if `server.enableXsrfProtection` is on and `server.enableCORS` is off at the same time, we will prioritize `server.enableXsrfProtection`.
 # Default: true
-enableXsrfProtection = true
+enableXsrfProtection = false
 
 # Max size, in megabytes, for files uploaded with the file_uploader.
 # Default: 200

--- a/ccp/app/ccp_app_back_to_back.py
+++ b/ccp/app/ccp_app_back_to_back.py
@@ -238,8 +238,20 @@ def main():
             "Calculate Leakages", value=True, disabled=True, help="Not yet implemented"
         )
         seal_gas_flow = st.checkbox(
-            "Seal Gas Flow", value=True, disabled=True, help="Not yet implemented"
+            "Seal Gas Flow",
+            value=True,
         )
+
+        # add a disabled flag in the parameters_map dict based on the checkbox
+        if seal_gas_flow:
+            parameters_map["seal_gas_flow_m"]["disabled"] = False
+            parameters_map["seal_gas_temperature"]["disabled"] = False
+        else:
+            parameters_map["seal_gas_flow_m"]["disabled"] = True
+            parameters_map["seal_gas_temperature"]["disabled"] = True
+            parameters_map["seal_gas_flow_m"]["value"] = ""
+            parameters_map["seal_gas_temperature"]["value"] = ""
+
         variable_speed = st.checkbox("Variable Speed", value=True)
         # add text input for the ambient pressure
         st.text("Ambient Pressure")
@@ -536,6 +548,7 @@ def main():
                             options=parameters_map[parameter]["units"],
                             key=f"{parameter}_units_section_1",
                             label_visibility="collapsed",
+                            disabled=parameters_map[parameter].get("disabled", False),
                         )
                     else:
                         parameters_map[parameter]["section_1"][f"point_{i - 1}"][
@@ -544,6 +557,7 @@ def main():
                             f"{parameter} value.",
                             key=f"{parameter}_section_1_point_{i - 1}",
                             label_visibility="collapsed",
+                            disabled=parameters_map[parameter].get("disabled", False),
                         )
                         check_correct_separator(
                             parameters_map[parameter]["section_1"][f"point_{i - 1}"][
@@ -616,6 +630,7 @@ def main():
                             options=parameters_map[parameter]["units"],
                             key=f"{parameter}_units_section_2",
                             label_visibility="collapsed",
+                            disabled=parameters_map[parameter].get("disabled", False),
                         )
                     else:
                         parameters_map[parameter]["section_2"][f"point_{i - 1}"][
@@ -624,6 +639,7 @@ def main():
                             f"{parameter} value.",
                             key=f"{parameter}_section_2_point_{i - 1}",
                             label_visibility="collapsed",
+                            disabled=parameters_map[parameter].get("disabled", False),
                         )
                         check_correct_separator(
                             parameters_map[parameter]["section_2"][f"point_{i - 1}"][
@@ -900,7 +916,8 @@ def main():
                         else:
                             kwargs["balance_line_flow_m"] = None
                         if (
-                            st.session_state[f"seal_gas_flow_m_{section}_point_{i}"]
+                            seal_gas_flow
+                            and st.session_state[f"seal_gas_flow_m_{section}_point_{i}"]
                             != ""
                         ):
                             kwargs["seal_gas_flow_m"] = Q_(
@@ -998,7 +1015,8 @@ def main():
                                 ]["test_units"],
                             )
                             if (
-                                st.session_state[
+                                seal_gas_flow
+                                and st.session_state[
                                     f"seal_gas_temperature_{section}_point_{i}"
                                 ]
                                 != ""

--- a/ccp/app/ccp_app_straight_through.py
+++ b/ccp/app/ccp_app_straight_through.py
@@ -228,6 +228,17 @@ def main():
         calculate_leakages = st.checkbox("Calculate Leakages", value=True)
         seal_gas_flow = st.checkbox("Seal Gas Flow", value=True)
         variable_speed = st.checkbox("Variable Speed", value=True)
+
+        # add a disabled flag in the parameters_map dict based on the checkbox
+        if seal_gas_flow:
+            parameters_map["seal_gas_flow_m"]["disabled"] = False
+            parameters_map["seal_gas_temperature"]["disabled"] = False
+        else:
+            parameters_map["seal_gas_flow_m"]["disabled"] = True
+            parameters_map["seal_gas_temperature"]["disabled"] = True
+            parameters_map["seal_gas_flow_m"]["value"] = ""
+            parameters_map["seal_gas_temperature"]["value"] = ""
+
         # add text input for the ambient pressure
         st.text("Ambient Pressure")
         ambient_pressure_magnitude_col, ambient_pressure_unit_col = st.columns(2)
@@ -483,6 +494,7 @@ def main():
                         options=parameters_map[parameter]["units"],
                         key=f"{parameter}_units",
                         label_visibility="collapsed",
+                        disabled=parameters_map[parameter].get("disabled", False),
                     )
                 else:
                     parameters_map[parameter]["points"][f"point_{i - 1}"][
@@ -491,6 +503,7 @@ def main():
                         f"{parameter} value.",
                         key=f"{parameter}_point_{i - 1}",
                         label_visibility="collapsed",
+                        disabled=parameters_map[parameter].get("disabled", False),
                     )
 
     with st.expander("Flowrate Calculation", expanded=st.session_state.expander_state):
@@ -871,7 +884,10 @@ def main():
                         )
                     else:
                         kwargs["balance_line_flow_m"] = None
-                    if st.session_state[f"seal_gas_flow_m_point_{i}"] != "":
+                    if (
+                        seal_gas_flow
+                        and st.session_state[f"seal_gas_flow_m_point_{i}"] != ""
+                    ):
                         kwargs["seal_gas_flow_m"] = Q_(
                             float(st.session_state[f"seal_gas_flow_m_point_{i}"]),
                             parameters_map["seal_gas_flow_m"]["points"]["test_units"],
@@ -880,7 +896,10 @@ def main():
                         kwargs["seal_gas_flow_m"] = Q_(
                             0, parameters_map["seal_gas_flow_m"]["points"]["test_units"]
                         )
-                    if st.session_state[f"seal_gas_temperature_point_{i}"] != "":
+                    if (
+                        seal_gas_flow
+                        and st.session_state[f"seal_gas_temperature_point_{i}"] != ""
+                    ):
                         kwargs["seal_gas_temperature"] = Q_(
                             float(st.session_state[f"seal_gas_temperature_point_{i}"]),
                             parameters_map["seal_gas_temperature"]["points"][


### PR DESCRIPTION
Now if the checkbox is not marked, streamlit will automatically disable
the text input for seal gas flow and seal gas temperature, and the
calculation will consider a 0 seal gas flow and 0 seal gas temperature,
even if the text input box is filled with a different value.