### PR TITLE
Add filter flag

### DIFF
--- a/ccp/data_io/processing.py
+++ b/ccp/data_io/processing.py
@@ -183,6 +183,7 @@ def filter_data(
     """
     fluctuation_df = fluctuation_data(df, window=window)
     mean_df = mean_data(df, window=window)
+    mean_df["valid"] = True
     # filter mean_df based on fluctuation_df max values
     if drop_invalid_values:
         for column, property_type in data_type.items():
@@ -204,8 +205,8 @@ def filter_data(
                     "Valid data types are: pressure, temperature and speed."
                 )
             mean_df.loc[fluctuation_df[column] > max_fluctuation, column] = None
+        mean_df = mean_df.dropna()
     else:
-        mean_df["valid"] = True
         for column, property_type in data_type.items():
             if property_type == "pressure":
                 max_fluctuation = pressure_fluctuation

--- a/ccp/data_io/processing.py
+++ b/ccp/data_io/processing.py
@@ -128,6 +128,7 @@ def filter_data(
     temperature_fluctuation=0.5,
     pressure_fluctuation=2,
     speed_fluctuation=0.5,
+    drop_invalid_values=True,
 ):
     """Filter data according to fluctuation values.
 
@@ -163,6 +164,10 @@ def filter_data(
     speed_fluctuation : float, optional
         Maximum fluctuation for speed data.
         The default is 0.5.
+    drop_invalid_values : bool, optional
+        Drop invalid values from the dataframe.
+        If false, a column 'valid' will be added to the dataframe with True for valid.
+        The default is True.
 
     Returns
     -------
@@ -179,24 +184,45 @@ def filter_data(
     fluctuation_df = fluctuation_data(df, window=window)
     mean_df = mean_data(df, window=window)
     # filter mean_df based on fluctuation_df max values
-    for column, property_type in data_type.items():
-        if property_type == "pressure":
-            max_fluctuation = pressure_fluctuation
-            # remove pressure values below 0
-            mean_df.loc[mean_df[column] < 0, column] = None
-        elif property_type == "temperature":
-            max_fluctuation = temperature_fluctuation
-            # remove temperature values below 0
-            mean_df.loc[mean_df[column] < 0, column] = None
-        elif property_type == "speed":
-            max_fluctuation = speed_fluctuation
-            # remove speed values below 1
-            mean_df.loc[mean_df[column] < 1, column] = None
-        else:
-            raise ValueError(
-                f"Invalid data type for column {column}. "
-                "Valid data types are: pressure, temperature and speed."
-            )
-        mean_df.loc[fluctuation_df[column] > max_fluctuation, column] = None
-    mean_df = mean_df.dropna()
+    if drop_invalid_values:
+        for column, property_type in data_type.items():
+            if property_type == "pressure":
+                max_fluctuation = pressure_fluctuation
+                # remove pressure values below 0
+                mean_df.loc[mean_df[column] < 0, column] = None
+            elif property_type == "temperature":
+                max_fluctuation = temperature_fluctuation
+                # remove temperature values below 0
+                mean_df.loc[mean_df[column] < 0, column] = None
+            elif property_type == "speed":
+                max_fluctuation = speed_fluctuation
+                # remove speed values below 1
+                mean_df.loc[mean_df[column] < 1, column] = None
+            else:
+                raise ValueError(
+                    f"Invalid data type for column {column}. "
+                    "Valid data types are: pressure, temperature and speed."
+                )
+            mean_df.loc[fluctuation_df[column] > max_fluctuation, column] = None
+    else:
+        mean_df["valid"] = True
+        for column, property_type in data_type.items():
+            if property_type == "pressure":
+                max_fluctuation = pressure_fluctuation
+                # remove pressure values below 0
+                mean_df.loc[mean_df[column] < 0, "valid"] = False
+            elif property_type == "temperature":
+                max_fluctuation = temperature_fluctuation
+                # remove temperature values below 0
+                mean_df.loc[mean_df[column] < 0, "valid"] = False
+            elif property_type == "speed":
+                max_fluctuation = speed_fluctuation
+                # remove speed values below 1
+                mean_df.loc[mean_df[column] < 1, "valid"] = False
+            else:
+                raise ValueError(
+                    f"Invalid data type for column {column}. "
+                    "Valid data types are: pressure, temperature and speed."
+                )
+            mean_df.loc[fluctuation_df[column] > max_fluctuation, "valid"] = False
     return mean_df

--- a/ccp/evaluation.py
+++ b/ccp/evaluation.py
@@ -443,9 +443,11 @@ class Evaluation:
 
 
 def create_points_parallel(x):
-    del x["imp_new"]
     if not x["valid"]:
         return None
+    # delete arguments not used for point calculation
+    del x["imp_new"]
+    del x["valid"]
     try:
         p = Point(**x)
     except:

--- a/ccp/evaluation.py
+++ b/ccp/evaluation.py
@@ -252,7 +252,7 @@ class Evaluation:
 
         return df
 
-    def calculate_points(self, data=None):
+    def calculate_points(self, data=None, drop_invalid_values=True):
         """Calculate the performance points for the given data.
 
         Parameters
@@ -261,6 +261,10 @@ class Evaluation:
             Data to be used for the calculation. If not provided, the data
             used in the initialization will be used.
             The default is None.
+        drop_invalid_values : bool, optional
+            Drop invalid values from the dataframe.
+            If false, a column 'valid' will be added to the dataframe with True for valid.
+            The default is True.
 
         Returns
         -------
@@ -278,6 +282,7 @@ class Evaluation:
                 temperature_fluctuation=self.temperature_fluctuation,
                 pressure_fluctuation=self.pressure_fluctuation,
                 speed_fluctuation=self.speed_fluctuation,
+                drop_invalid_values=drop_invalid_values,
             )
 
         df = self.calculate_flow(df)
@@ -310,6 +315,7 @@ class Evaluation:
                     fluid=self.operation_fluid,
                 ),
                 "imp_new": self.impellers_new[int(row.cluster)],
+                "valid": row.valid,
             }
 
             args_list.append(arg_dict)
@@ -320,35 +326,37 @@ class Evaluation:
             print("Calculating expected points...")
             expected_points += tqdm(pool.imap(get_interpolated_point, args_list))
 
-        # loop
-        df["eff"] = 0
-        df["head"] = 0
-        df["power"] = 0
-        df["p_disch"] = 0
-        df["expected_eff"] = 0
-        df["expected_head"] = 0
-        df["expected_power"] = 0
-        df["expected_p_disch"] = 0
-        df["delta_eff"] = 0
-        df["delta_head"] = 0
-        df["delta_power"] = 0
-        df["delta_p_disch"] = 0
+        # start column with -1, if this value remains, it means that the point was not calculated due to invalid data
+        df["eff"] = -1
+        df["head"] = -1
+        df["power"] = -1
+        df["p_disch"] = -1
+        df["expected_eff"] = -1
+        df["expected_head"] = -1
+        df["expected_power"] = -1
+        df["expected_p_disch"] = -1
+        df["delta_eff"] = -1
+        df["delta_head"] = -1
+        df["delta_power"] = -1
+        df["delta_p_disch"] = -1
 
         for i, point_op, point_expected in zip(df.index, points, expected_points):
-            df.loc[i, "eff"] = point_op.eff.m
-            df.loc[i, "head"] = point_op.head.m
-            df.loc[i, "power"] = point_op.power.m
-            df.loc[i, "p_disch"] = point_op.disch.p("bar").m
-            df.loc[i, "expected_eff"] = point_expected.eff.m
-            df.loc[i, "expected_head"] = point_expected.head.m
-            df.loc[i, "expected_power"] = point_expected.power.m
-            df.loc[i, "expected_p_disch"] = point_expected.disch.p("bar").m
-            df.loc[i, "delta_eff"] = (point_op.eff - point_expected.eff).m
-            df.loc[i, "delta_head"] = (point_op.head - point_expected.head).m
-            df.loc[i, "delta_power"] = (point_op.power - point_expected.power).m
-            df.loc[i, "delta_p_disch"] = (
-                point_op.disch.p("bar") - point_expected.disch.p("bar")
-            ).m
+            # if point_op is None, it means that the point was not calculated due to invalid data
+            if point_op is not None:
+                df.loc[i, "eff"] = point_op.eff.m
+                df.loc[i, "head"] = point_op.head.m
+                df.loc[i, "power"] = point_op.power.m
+                df.loc[i, "p_disch"] = point_op.disch.p("bar").m
+                df.loc[i, "expected_eff"] = point_expected.eff.m
+                df.loc[i, "expected_head"] = point_expected.head.m
+                df.loc[i, "expected_power"] = point_expected.power.m
+                df.loc[i, "expected_p_disch"] = point_expected.disch.p("bar").m
+                df.loc[i, "delta_eff"] = (point_op.eff - point_expected.eff).m
+                df.loc[i, "delta_head"] = (point_op.head - point_expected.head).m
+                df.loc[i, "delta_power"] = (point_op.power - point_expected.power).m
+                df.loc[i, "delta_p_disch"] = (
+                    point_op.disch.p("bar") - point_expected.disch.p("bar")
+                ).m
 
         # plot eff in plot with colormap showing the time
 
@@ -436,14 +444,19 @@ class Evaluation:
 
 def create_points_parallel(x):
     del x["imp_new"]
+    if not x["valid"]:
+        return None
     try:
         p = Point(**x)
     except:
         print("Error for point with args:", x)
+        return None
     return p
 
 
 def get_interpolated_point(x):
+    if not x["valid"]:
+        return None
     try:
         imp_new = x["imp_new"]
         expected_point = imp_new.point(flow_m=x["flow_m"], speed=x["speed"])

--- a/ccp/tests/test_evaluation.py
+++ b/ccp/tests/test_evaluation.py
@@ -274,3 +274,76 @@ def test_evaluation_calculate_points_delta_p():
 
     df_results = evaluation.calculate_points(df)
     assert_allclose(df_results["delta_eff"].mean(), 0.111338, rtol=1e-2)
+
+
+def test_evaluation_calculate_points_delta_p_flag():
+    data_path = Path(ccp.__file__).parent / "tests/data"
+    # load data.parquet
+    df = pd.read_parquet(data_path / "data_delta_p.parquet")
+    # load lp-sec1-caso-a
+    fluid_a = {
+        "methane": 58.976,
+        "ethane": 3.099,
+        "propane": 0.6,
+        "n-butane": 0.08,
+        "i-butane": 0.05,
+        "n-pentane": 0.01,
+        "i-pentane": 0.01,
+        "n2": 0.55,
+        "h2s": 0.02,
+        "co2": 36.605,
+    }
+    suc_a = ccp.State(
+        p=Q_(4, "bar"),
+        T=Q_(40, "degC"),
+        fluid=fluid_a,
+    )
+
+    imp_a = ccp.Impeller.load_from_engauge_csv(
+        suc=suc_a,
+        curve_name="eval-lp-sec1-caso-a",
+        curve_path=data_path,
+        flow_units="m³/h",
+        head_units="kJ/kg",
+    )
+
+    operation_fluid = {
+        "methane": 44.04,
+        "ethane": 3.18,
+        "propane": 0.66,
+        "n-butane": 0.15,
+        "i-butane": 0.05,
+        "n-pentane": 0.03,
+        "i-pentane": 0.02,
+        "n2": 0.25,
+        "h2s": 0.06,
+        "co2": 51.55,
+    }
+
+    evaluation = ccp.Evaluation(
+        data=df,
+        operation_fluid=operation_fluid,
+        data_units={
+            "ps": "bar",
+            "Ts": "degC",
+            "pd": "bar",
+            "Td": "degC",
+            "delta_p": "mmH2O",
+            "p_downstream": "bar",
+            "speed": "RPM",
+        },
+        impellers=[imp_a],
+        D=Q_(0.590550, "m"),
+        d=Q_(0.366130, "m"),
+        tappings="flange",
+        n_clusters=2,
+        calculate_points=False,
+    )
+
+    df_results = evaluation.calculate_points(df, drop_invalid_values=False)
+    # check mean with invalid values (-1)
+    assert_allclose(df_results["delta_eff"].mean(), -0.9206450982953476, rtol=1e-2)
+
+    # remove invalid values
+    df_results = df_results[df_results.valid]
+    assert_allclose(df_results["delta_eff"].mean(), 0.111338, rtol=1e-2)

--- a/ccp/tests/test_io.py
+++ b/ccp/tests/test_io.py
@@ -88,7 +88,9 @@ def test_filter_data():
     )
     assert_frame_equal(
         ccp.data_io.filter_data(df, data_type={"a": "pressure", "b": "temperature"}),
-        pd.DataFrame(index=pd.Index([5]), data={"a": [4.01], "b": [7.01]}),
+        pd.DataFrame(
+            index=pd.Index([5]), data={"a": [4.01], "b": [7.01], "valid": [True]}
+        ),
     )
 
 

--- a/ccp/tests/test_io.py
+++ b/ccp/tests/test_io.py
@@ -90,3 +90,57 @@ def test_filter_data():
         ccp.data_io.filter_data(df, data_type={"a": "pressure", "b": "temperature"}),
         pd.DataFrame(index=pd.Index([5]), data={"a": [4.01], "b": [7.01]}),
     )
+
+
+def test_filter_data_flag():
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 3, 4, 4.01, 4.02, 5, 6.01, 6.02, 6.04, 6.05],
+            "b": [4, 5, 6, 7, 7.01, 7.02, 8, 9, 10, 11, 12],
+        }
+    )
+    assert_frame_equal(
+        ccp.data_io.filter_data(
+            df,
+            data_type={"a": "pressure", "b": "temperature"},
+            drop_invalid_values=False,
+        ),
+        pd.DataFrame(
+            index=pd.Index(range(2, 11, 1)),
+            data={
+                "a": [
+                    2.0,
+                    3.0,
+                    3.67,
+                    4.01,
+                    4.343333333333333,
+                    5.01,
+                    5.676666666666667,
+                    6.023333333333333,
+                    6.036666666666666,
+                ],
+                "b": [
+                    5.0,
+                    6.0,
+                    6.669999999999999,
+                    7.010000000000001,
+                    7.343333333333334,
+                    8.006666666666666,
+                    9.0,
+                    10.0,
+                    11.0,
+                ],
+                "valid": [
+                    False,
+                    False,
+                    False,
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    False,
+                ],
+            },
+        ),
+    )


### PR DESCRIPTION
This adds an argument 'drop_invalid_values' that will give the user control wether or not they want to keep values that are outside the filter criteria for speed/pressure/temperature fluctuation.

If invalid values are kept, the columns for calculated eff, power etc. will be populated with -1 value and a 'valid' column will also be present at the DataFrame with boolean values.