### PR TITLE
Handle UnicodeEncodeError when setting REFPROP path

### DIFF
--- a/ccp/__init__.py
+++ b/ccp/__init__.py
@@ -67,10 +67,13 @@ from pathlib import Path as _Path
 import CoolProp.CoolProp as _CP
 from ctREFPROP.ctREFPROP import REFPROPFunctionLibrary as _REFPROPFunctionLibrary
 
+# import ccp.config as _config
+from . import config as _config
 # use _ to avoid polluting the namespace when importing
 
 try:
     _path = _Path(_os.environ["RPPREFIX"])
+    # _path = _Path("/home/raphael/REFPROP-cmåke/build")
 except KeyError:
     if _os.path.exists("C:\\Users\\Public\\REFPROP"):
         _os.environ["RPprefix"] = "C:\\Users\\Public\\REFPROP"
@@ -78,15 +81,23 @@ except KeyError:
     else:
         _path = _Path.cwd()
 
+# Check if path contains non-ASCII characters
 try:
-    _CP.set_config_string(_CP.ALTERNATIVE_REFPROP_PATH, str(_path))
+    unicode_error = False
+    str(_path).encode("ascii")
+    # Path is ASCII-safe, proceed normally
 except UnicodeEncodeError:
+    unicode_error = True
     _warnings.warn(
         f"Unable to set REFPROP path due to non-ASCII characters in path: {_path}\n"
         f"CoolProp does not support non-ASCII characters in paths. "
         f"Consider renaming the directory or using an ASCII-only path.\n"
         f"Proceeding without setting REFPROP path."
     )
+
+if not unicode_error:
+    _CP.set_config_string(_CP.ALTERNATIVE_REFPROP_PATH, str(_path))
+
 try:
     _RP = _REFPROPFunctionLibrary(_path)
     _RP.SETPATHdll(str(_path))
@@ -101,7 +112,6 @@ else:
 _library_path = _path / _shared_library
 
 # Auto-switch to HEOS if REFPROP is not available
-import ccp.config as _config
 
 if not _library_path.is_file():
     _warnings.warn(
@@ -112,11 +122,20 @@ if not _library_path.is_file():
 
 __version__ = "0.3.24"
 
-__version__full = (
-    f"ccp: {__version__} | "
-    + f'CP : {_CP.get_global_param_string("version")} | '
-    + f'REFPROP : {_CP.get_global_param_string("REFPROP_version")}'
-)
+with _warnings.catch_warnings():
+    if unicode_error:
+        _warnings.filterwarnings("ignore", category=Warning)
+        __version__full = (
+            f"ccp: {__version__} | "
+            + f'CP : {_CP.get_global_param_string("version")} | '
+            + f"REFPROP : not available"
+        )
+    else:
+        __version__full = (
+            f"ccp: {__version__} | "
+            + f'CP : {_CP.get_global_param_string("version")} | '
+            + f'REFPROP : {_CP.get_global_param_string("REFPROP_version")}'
+        )
 
 ###############################################################################
 # pint


### PR DESCRIPTION
## Summary

- Add try-except block to gracefully handle CoolProp's UnicodeEncodeError when paths contain non-ASCII characters
- When the error occurs, warn the user and proceed without setting the REFPROP path
- Allows ccp to continue using the HEOS backend instead of crashing on import

## Problem

CoolProp's Cython bindings use ASCII encoding instead of UTF-8 for string conversions to C++ `std::string`. This causes a `UnicodeEncodeError` when the REFPROP path contains non-ASCII characters (e.g., å, ö, ñ).

This is particularly problematic for users with:
- Non-ASCII usernames
- Directory names with non-ASCII characters
- International file systems

## Solution

Wrap the `set_config_string()` call in a try-except block that catches `UnicodeEncodeError` and provides a clear warning to the user. The library proceeds without setting the REFPROP path and automatically falls back to the HEOS backend.

## Test Plan

- [x] Tested with path containing 'å' character
- [x] Verified ccp imports successfully without crash
- [x] Confirmed appropriate warning is displayed
- [x] Verified automatic fallback to HEOS backend works