### PR TITLE
django-app: Unit 2 — core ccp service layer

### DIFF
--- a/ccp/app/django-app/apps/__init__.py
+++ b/ccp/app/django-app/apps/__init__.py
@@ -1,0 +1,1 @@
+# STUB: replaced by Unit 1 at merge time

--- a/ccp/app/django-app/apps/core/__init__.py
+++ b/ccp/app/django-app/apps/core/__init__.py
@@ -1,0 +1,1 @@
+# STUB: replaced by Unit 1 at merge time

--- a/ccp/app/django-app/apps/core/apps.py
+++ b/ccp/app/django-app/apps/core/apps.py
@@ -1,0 +1,9 @@
+# STUB: replaced by Unit 1 at merge time
+"""Minimal AppConfig so Django can discover ``apps.core`` in isolation."""
+
+from django.apps import AppConfig
+
+
+class CoreConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.core"

--- a/ccp/app/django-app/apps/core/services/__init__.py
+++ b/ccp/app/django-app/apps/core/services/__init__.py
@@ -1,0 +1,21 @@
+"""Pure-Python service layer wrapping the ``ccp`` library for Django views.
+
+Nothing in this package touches Django's ORM, request/response cycle, or the
+Streamlit runtime. Each submodule can be imported and exercised in isolation.
+"""
+
+from apps.core.services import (
+    ccp_service,
+    gas_composition,
+    parameter_map,
+    polytropic_methods,
+    unit_helpers,
+)
+
+__all__ = [
+    "ccp_service",
+    "gas_composition",
+    "parameter_map",
+    "polytropic_methods",
+    "unit_helpers",
+]

--- a/ccp/app/django-app/apps/core/services/ccp_service.py
+++ b/ccp/app/django-app/apps/core/services/ccp_service.py
@@ -1,0 +1,265 @@
+"""Thin wrappers around the ``ccp`` library for Django views.
+
+Every wrapper is a pure function: no Django imports, no Streamlit state, no
+caching side-effects. Each function optionally honours a ``polytropic_method``
+keyword argument by setting ``ccp.config.POLYTROPIC_METHOD`` before delegating
+to the underlying ``ccp`` object. Callers that need to batch several wrappers
+under the same polytropic method should pass the kwarg on each call for
+explicitness.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+import ccp
+from ccp.compressor import BackToBack, Point1Sec, StraightThrough
+from ccp.impeller import Impeller
+from ccp.state import State
+
+from apps.core.services.polytropic_methods import (
+    POLYTROPIC_METHODS,
+    get_polytropic_methods,
+)
+
+
+def _apply_polytropic_method(method: str | None) -> None:
+    """Update ``ccp.config.POLYTROPIC_METHOD`` in-place if *method* is given.
+
+    Accepts either a UI label from :data:`POLYTROPIC_METHODS` or the raw
+    ``ccp.config`` value. Unknown values are forwarded verbatim so callers
+    that want to experiment with new methods are not blocked.
+    """
+    if method is None:
+        return
+    resolved = POLYTROPIC_METHODS.get(method, method)
+    ccp.config.POLYTROPIC_METHOD = resolved
+
+
+def build_gas_state(composition: dict[str, float], p: Any, T: Any) -> State:
+    """Construct a :class:`ccp.State` from a composition dict and p/T.
+
+    Parameters
+    ----------
+    composition : dict of str to float
+        Component name to molar fraction. Must be non-empty.
+    p : pint.Quantity or float
+        Absolute pressure. If a bare float is supplied, ``ccp.State`` will
+        interpret it as Pa.
+    T : pint.Quantity or float
+        Absolute temperature. If a bare float is supplied, ``ccp.State`` will
+        interpret it as degK.
+
+    Returns
+    -------
+    ccp.State
+        Newly constructed state.
+    """
+    if not composition:
+        raise ValueError("composition must contain at least one component")
+    return State(p=p, T=T, fluid=dict(composition))
+
+
+def build_point_1sec(
+    *, polytropic_method: str | None = None, **kwargs: Any
+) -> Point1Sec:
+    """Construct a :class:`ccp.compressor.Point1Sec`.
+
+    Parameters
+    ----------
+    polytropic_method : str, optional
+        UI label or raw ``ccp.config`` value. If provided, is applied to
+        ``ccp.config.POLYTROPIC_METHOD`` before instantiation.
+    **kwargs
+        Forwarded directly to ``Point1Sec``.
+
+    Returns
+    -------
+    ccp.compressor.Point1Sec
+    """
+    _apply_polytropic_method(polytropic_method)
+    return Point1Sec(**kwargs)
+
+
+def build_straight_through(
+    guarantee_point: Point1Sec,
+    test_points: Iterable[Point1Sec],
+    *,
+    polytropic_method: str | None = None,
+    **opts: Any,
+) -> StraightThrough:
+    """Construct a :class:`ccp.compressor.StraightThrough` compressor.
+
+    Parameters
+    ----------
+    guarantee_point : ccp.compressor.Point1Sec
+        Guarantee operating point.
+    test_points : iterable of ccp.compressor.Point1Sec
+        Measured test points used for the performance curves.
+    polytropic_method : str, optional
+        UI label or raw ``ccp.config`` value.
+    **opts
+        Additional keyword arguments forwarded to ``StraightThrough``
+        (``speed_operational``, ``reynolds_correction``,
+        ``bearing_mechanical_losses``...).
+
+    Returns
+    -------
+    ccp.compressor.StraightThrough
+    """
+    _apply_polytropic_method(polytropic_method)
+    return StraightThrough(
+        guarantee_point=guarantee_point,
+        test_points=list(test_points),
+        **opts,
+    )
+
+
+def build_back_to_back(
+    guarantee_point_sec1: Any,
+    test_points_sec1: Iterable[Any],
+    guarantee_point_sec2: Any,
+    test_points_sec2: Iterable[Any],
+    *,
+    polytropic_method: str | None = None,
+    **opts: Any,
+) -> BackToBack:
+    """Construct a :class:`ccp.compressor.BackToBack` compressor.
+
+    Parameters
+    ----------
+    guarantee_point_sec1, guarantee_point_sec2 : ccp.compressor.PointFirstSection / PointSecondSection
+        Guarantee points for the two sections.
+    test_points_sec1, test_points_sec2 : iterable
+        Per-section test points.
+    polytropic_method : str, optional
+        UI label or raw ``ccp.config`` value.
+    **opts
+        Additional keyword arguments forwarded to ``BackToBack``.
+
+    Returns
+    -------
+    ccp.compressor.BackToBack
+    """
+    _apply_polytropic_method(polytropic_method)
+    return BackToBack(
+        guarantee_point_sec1=guarantee_point_sec1,
+        test_points_sec1=list(test_points_sec1),
+        guarantee_point_sec2=guarantee_point_sec2,
+        test_points_sec2=list(test_points_sec2),
+        **opts,
+    )
+
+
+def load_impeller_from_engauge_csv(
+    files: dict[str, Any] | list,
+    suction_state: State,
+    *,
+    polytropic_method: str | None = None,
+    **kwargs: Any,
+) -> Impeller:
+    """Build an :class:`ccp.Impeller` from Engauge-digitised CSV files.
+
+    Parameters
+    ----------
+    files : dict or list
+        Either a mapping with keys ``curve_name`` and ``curve_path`` (pointing
+        at the directory containing ``<name>-head.csv`` and ``<name>-eff.csv``)
+        or a two-item list ``[curve_name, curve_path]``. For backwards
+        compatibility a dict of additional kwargs is also accepted and will be
+        merged into *kwargs*.
+    suction_state : ccp.State
+        Suction state used when evaluating the curves.
+    polytropic_method : str, optional
+        UI label or raw ``ccp.config`` value.
+    **kwargs
+        Additional keyword arguments forwarded to
+        :meth:`ccp.Impeller.load_from_engauge_csv`.
+
+    Returns
+    -------
+    ccp.Impeller
+    """
+    _apply_polytropic_method(polytropic_method)
+
+    if isinstance(files, dict):
+        curve_name = files.get("curve_name")
+        curve_path = files.get("curve_path")
+        extra = {
+            k: v for k, v in files.items() if k not in ("curve_name", "curve_path")
+        }
+        kwargs = {**extra, **kwargs}
+    elif isinstance(files, (list, tuple)) and len(files) == 2:
+        curve_name, curve_path = files
+    else:
+        raise TypeError(
+            "files must be a dict with curve_name/curve_path or a [name, path] pair"
+        )
+
+    if curve_name is None or curve_path is None:
+        raise ValueError("curve_name and curve_path are required")
+
+    return Impeller.load_from_engauge_csv(
+        suc=suction_state,
+        curve_name=curve_name,
+        curve_path=Path(curve_path),
+        **kwargs,
+    )
+
+
+def convert_impeller(
+    impeller: Impeller | list[Impeller],
+    *,
+    polytropic_method: str | None = None,
+    **kwargs: Any,
+) -> Impeller:
+    """Convert an impeller's performance map to a new suction condition.
+
+    Parameters
+    ----------
+    impeller : ccp.Impeller or list of ccp.Impeller
+        Source impeller(s). Forwarded to :meth:`ccp.Impeller.convert_from`.
+    polytropic_method : str, optional
+        UI label or raw ``ccp.config`` value.
+    **kwargs
+        Forwarded to :meth:`ccp.Impeller.convert_from` (``suc``, ``find``,
+        ``speed``).
+
+    Returns
+    -------
+    ccp.Impeller
+    """
+    _apply_polytropic_method(polytropic_method)
+    return Impeller.convert_from(impeller, **kwargs)
+
+
+def build_evaluation(
+    *, polytropic_method: str | None = None, **kwargs: Any
+) -> ccp.Evaluation:
+    """Construct a :class:`ccp.Evaluation` object.
+
+    Parameters
+    ----------
+    polytropic_method : str, optional
+        UI label or raw ``ccp.config`` value.
+    **kwargs
+        Forwarded directly to ``ccp.Evaluation``.
+
+    Returns
+    -------
+    ccp.Evaluation
+    """
+    _apply_polytropic_method(polytropic_method)
+    return ccp.Evaluation(**kwargs)
+
+
+def polytropic_methods() -> dict[str, str]:
+    """Return the label-to-value mapping for polytropic methods.
+
+    Returns
+    -------
+    dict of str to str
+        Fresh copy of :data:`POLYTROPIC_METHODS`.
+    """
+    return get_polytropic_methods()

--- a/ccp/app/django-app/apps/core/services/gas_composition.py
+++ b/ccp/app/django-app/apps/core/services/gas_composition.py
@@ -1,0 +1,133 @@
+"""Gas composition helpers ported from ``ccp/app/common.py``.
+
+Provides the sorted fluid list used by selection widgets, the default
+6-component mixture referenced by the Streamlit pages, and helpers to resolve
+a named composition from a ``gas_compositions_table`` document.
+"""
+
+from __future__ import annotations
+
+import ccp
+
+DEFAULT_COMPONENTS: list[str] = [
+    "methane",
+    "ethane",
+    "propane",
+    "n-butane",
+    "i-butane",
+    "n-pentane",
+    "i-pentane",
+    "n-hexane",
+    "n-heptane",
+    "n-octane",
+    "n-nonane",
+    "nitrogen",
+    "h2s",
+    "co2",
+    "h2o",
+]
+
+
+def _build_fluid_list() -> list[str]:
+    """Build the sorted fluid list used by the UI dropdowns.
+
+    Returns
+    -------
+    list of str
+        Sorted list of every ``ccp.fluid_list`` key plus each registered
+        ``possible_names`` alias, prefixed with an empty string for the
+        placeholder row.
+    """
+    names: list[str] = []
+    for fluid in ccp.fluid_list.keys():
+        names.append(fluid.lower())
+        for possible_name in ccp.fluid_list[fluid].possible_names:
+            if possible_name != fluid.lower():
+                names.append(possible_name)
+    names.sort()
+    names.insert(0, "")
+    return names
+
+
+FLUID_LIST: list[str] = _build_fluid_list()
+
+
+def default_composition() -> dict[str, float]:
+    """Return the default 6-component gas mixture.
+
+    The mixture contains the first six :data:`DEFAULT_COMPONENTS` with
+    methane at 1.0 and the remaining components zeroed out, mirroring the
+    initial row of ``gas_compositions_table`` populated in ``common.py``.
+
+    Returns
+    -------
+    dict of str to float
+        Mapping from component name to molar fraction.
+    """
+    composition: dict[str, float] = {name: 0.0 for name in DEFAULT_COMPONENTS[:6]}
+    composition["methane"] = 1.0
+    return composition
+
+
+def get_gas_composition(
+    gas_name: str,
+    gas_compositions_table: dict,
+    default_components: list[str] | None = None,
+) -> dict[str, float]:
+    """Resolve a named gas composition into a component-to-fraction dict.
+
+    Parameters
+    ----------
+    gas_name : str
+        Logical name of the gas as stored in
+        ``gas_compositions_table[...]['name']``.
+    gas_compositions_table : dict
+        Nested dict shaped like the ``gas_compositions_table`` produced by the
+        Streamlit ``gas_selection_form``.
+    default_components : list of str, optional
+        Unused — kept for signature parity with ``common.get_gas_composition``.
+
+    Returns
+    -------
+    dict of str to float
+        Non-zero components only.
+    """
+    del default_components
+    composition: dict[str, float] = {}
+    for gas in gas_compositions_table.keys():
+        entry = gas_compositions_table[gas]
+        if entry.get("name") != gas_name:
+            continue
+        for column in entry:
+            if "component" not in column:
+                continue
+            idx = column.split("_")[1]
+            component = entry[f"component_{idx}"]
+            molar_fraction = entry.get(f"molar_fraction_{idx}", 0)
+            if molar_fraction == "":
+                molar_fraction = 0
+            molar_fraction = float(molar_fraction)
+            if molar_fraction != 0:
+                composition[component] = molar_fraction
+    return composition
+
+
+def get_index_selected_gas(gas_options: list[str], gas_name: str) -> int:
+    """Return the index of *gas_name* in *gas_options*, or 0 if missing.
+
+    Parameters
+    ----------
+    gas_options : list of str
+        Ordered list of gas choices.
+    gas_name : str
+        Name to locate within *gas_options*.
+
+    Returns
+    -------
+    int
+        Zero-based index, defaulting to ``0`` when *gas_name* is absent.
+    """
+    try:
+        return gas_options.index(gas_name)
+    except ValueError:
+        return 0

--- a/ccp/app/django-app/apps/core/services/parameter_map.py
+++ b/ccp/app/django-app/apps/core/services/parameter_map.py
@@ -1,0 +1,194 @@
+"""Static parameter metadata for compressor input forms.
+
+Ported from the ``parameters_map`` dict in ``ccp/app/common.py``. Each entry
+carries the UI label, the list of valid unit strings, an optional help text,
+and an optional default magnitude. Defaults are left as ``None`` where the
+Streamlit original did not specify one — views should supply values or prompt
+the user.
+"""
+
+from __future__ import annotations
+
+from apps.core.services.unit_helpers import (
+    AREA_UNITS,
+    DENSITY_UNITS,
+    FLOW_M_UNITS,
+    FLOW_UNITS,
+    FLOW_V_UNITS,
+    HEAD_UNITS,
+    LENGTH_UNITS,
+    OIL_FLOW_UNITS,
+    POWER_UNITS,
+    PRESSURE_UNITS,
+    SPECIFIC_HEAT_UNITS,
+    SPEED_UNITS,
+    TEMPERATURE_UNITS,
+)
+
+
+def _entry(
+    label: str,
+    units: list[str],
+    help_text: str | None = None,
+    default: float | None = None,
+) -> dict:
+    """Build a parameter map entry with a uniform shape.
+
+    Parameters
+    ----------
+    label : str
+        UI label shown next to the input widget.
+    units : list of str
+        Valid pint-compatible unit strings.
+    help_text : str, optional
+        Tooltip / help text.
+    default : float, optional
+        Default magnitude expressed in ``units[0]``.
+
+    Returns
+    -------
+    dict
+        A dictionary with keys ``label``, ``units``, ``help``, ``default``.
+    """
+    return {
+        "label": label,
+        "units": list(units),
+        "help": help_text,
+        "default": default,
+    }
+
+
+PARAMETERS: dict[str, dict] = {
+    "flow": _entry(
+        "Flow",
+        FLOW_UNITS,
+        "Flow can be mass flow or volumetric flow depending on the selected unit.",
+    ),
+    "flow_v": _entry("Volumetric Flow", FLOW_V_UNITS, "Volumetric flow."),
+    "suction_pressure": _entry("Suction Pressure", PRESSURE_UNITS),
+    "suction_temperature": _entry("Suction Temperature", TEMPERATURE_UNITS),
+    "discharge_pressure": _entry("Discharge Pressure", PRESSURE_UNITS),
+    "discharge_temperature": _entry("Discharge Temperature", TEMPERATURE_UNITS),
+    "casing_delta_T": _entry(
+        "Casing ΔT",
+        TEMPERATURE_UNITS,
+        "Temperature difference between the casing and the ambient temperature.",
+    ),
+    "speed": _entry("Speed", SPEED_UNITS),
+    "balance_line_flow_m": _entry("Balance Line Flow", FLOW_M_UNITS),
+    "end_seal_upstream_pressure": _entry(
+        "Pressure Upstream End Seal",
+        PRESSURE_UNITS,
+        "Second section suction pressure.",
+    ),
+    "end_seal_upstream_temperature": _entry(
+        "Temperature Upstream End Seal",
+        TEMPERATURE_UNITS,
+        "Second section suction temperature.",
+    ),
+    "div_wall_flow_m": _entry(
+        "Division Wall Flow",
+        FLOW_M_UNITS,
+        "Flow through the division wall if measured. Otherwise it is "
+        "calculated from the First Section Discharge Flow.",
+    ),
+    "div_wall_upstream_pressure": _entry(
+        "Pressure Upstream Division Wall",
+        PRESSURE_UNITS,
+        "Second section discharge pressure.",
+    ),
+    "div_wall_upstream_temperature": _entry(
+        "Temperature Upstream Division Wall",
+        TEMPERATURE_UNITS,
+        "Second section discharge temperature.",
+    ),
+    "first_section_discharge_flow_m": _entry(
+        "First Section Discharge Flow",
+        FLOW_M_UNITS,
+        "If the Division Wall Flow is not measured, we use this value to calculate it.",
+    ),
+    "seal_gas_flow_m": _entry("Seal Gas Flow", FLOW_M_UNITS),
+    "seal_gas_temperature": _entry("Seal Gas Temperature", TEMPERATURE_UNITS),
+    "oil_flow_journal_bearing_de": _entry(
+        "Oil Flow Journal Bearing DE", OIL_FLOW_UNITS
+    ),
+    "oil_flow_journal_bearing_nde": _entry(
+        "Oil Flow Journal Bearing NDE", OIL_FLOW_UNITS
+    ),
+    "oil_flow_thrust_bearing_nde": _entry(
+        "Oil Flow Thrust Bearing NDE", OIL_FLOW_UNITS
+    ),
+    "oil_inlet_temperature": _entry("Oil Inlet Temperature", TEMPERATURE_UNITS),
+    "oil_outlet_temperature_de": _entry("Oil Outlet Temperature DE", TEMPERATURE_UNITS),
+    "oil_outlet_temperature_nde": _entry(
+        "Oil Outlet Temperature NDE", TEMPERATURE_UNITS
+    ),
+    "head": _entry("Head", HEAD_UNITS),
+    "eff": _entry("Efficiency", [""]),
+    "power": _entry("Gas Power", POWER_UNITS),
+    "power_shaft": _entry("Shaft Power", POWER_UNITS),
+    "b": _entry("First Impeller Width", LENGTH_UNITS),
+    "D": _entry("First Impeller Diameter", LENGTH_UNITS),
+    "surface_roughness": _entry(
+        "Surface Roughness",
+        LENGTH_UNITS + ["microm"],
+        "Mean surface roughness of the gas path.",
+    ),
+    "casing_area": _entry("Casing Area", AREA_UNITS),
+    "outer_diameter_fo": _entry(
+        "Outer Diameter",
+        ["mm", "m", "ft", "in"],
+        "Outer diameter of orifice plate.",
+    ),
+    "inner_diameter_fo": _entry(
+        "Inner Diameter",
+        ["mm", "m", "ft", "in"],
+        "Inner diameter of orifice plate.",
+    ),
+    "upstream_pressure_fo": _entry(
+        "Upstream Pressure", PRESSURE_UNITS, "Upstream pressure of orifice plate."
+    ),
+    "upstream_temperature_fo": _entry(
+        "Upstream Temperature",
+        TEMPERATURE_UNITS,
+        "Upstream temperature of orifice plate.",
+    ),
+    "pressure_drop_fo": _entry(
+        "Pressure Drop", PRESSURE_UNITS, "Pressure drop across orifice plate."
+    ),
+    "tappings_fo": _entry(
+        "Tappings",
+        ["flange", "corner", "D D/2"],
+        "Pressure tappings type.",
+    ),
+    "mass_flow_fo": _entry("Mass Flow (Result)", ["kg/h", "lbm/h", "kg/s", "lbm/s"]),
+    "oil_specific_heat": _entry("Oil Specific Heat", SPECIFIC_HEAT_UNITS),
+    "oil_density": _entry("Oil Density", DENSITY_UNITS),
+}
+
+
+POINT_KEYS: tuple[str, ...] = (
+    "guarantee_point",
+    "test_point_1",
+    "test_point_2",
+    "test_point_3",
+    "test_point_4",
+    "test_point_5",
+    "test_point_6",
+)
+
+
+def get_parameter(name: str) -> dict:
+    """Look up a parameter definition by key.
+
+    Parameters
+    ----------
+    name : str
+        Parameter name (e.g. ``"suction_pressure"``).
+
+    Returns
+    -------
+    dict
+        The parameter entry. A ``KeyError`` is raised if *name* is unknown.
+    """
+    return PARAMETERS[name]

--- a/ccp/app/django-app/apps/core/services/polytropic_methods.py
+++ b/ccp/app/django-app/apps/core/services/polytropic_methods.py
@@ -1,0 +1,46 @@
+"""Polytropic method mapping used by the UI dropdown.
+
+Keys are human-readable labels shown in the interface; values are the strings
+expected by ``ccp.config.POLYTROPIC_METHOD``. Ported verbatim from
+``ccp/app/common.py``.
+"""
+
+POLYTROPIC_METHODS: dict[str, str] = {
+    "Sandberg-Colby": "sandberg_colby",
+    "Sandberg-Colby Multistep": "sandberg_colby_multistep",
+    "Huntington": "huntington",
+    "Mallen-Saville": "mallen_saville",
+    "Schultz": "schultz",
+}
+
+
+def get_polytropic_methods() -> dict[str, str]:
+    """Return a fresh copy of the polytropic-method mapping.
+
+    Returns
+    -------
+    dict of str to str
+        Copy of :data:`POLYTROPIC_METHODS` safe for mutation by the caller.
+    """
+    return dict(POLYTROPIC_METHODS)
+
+
+def resolve(label: str) -> str:
+    """Translate a UI label to the ``ccp.config`` value.
+
+    Parameters
+    ----------
+    label : str
+        Human-readable label as displayed in the UI.
+
+    Returns
+    -------
+    str
+        The ``ccp.config.POLYTROPIC_METHOD`` value associated with *label*.
+
+    Raises
+    ------
+    KeyError
+        If *label* is not a known polytropic method.
+    """
+    return POLYTROPIC_METHODS[label]

--- a/ccp/app/django-app/apps/core/services/tests/conftest.py
+++ b/ccp/app/django-app/apps/core/services/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest fixtures for the services test suite.
+
+Adds the ``django-app/`` root to ``sys.path`` so tests can import
+``apps.core.services`` without a Django project being wired up yet.
+"""
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[4]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))

--- a/ccp/app/django-app/apps/core/services/tests/test_ccp_service.py
+++ b/ccp/app/django-app/apps/core/services/tests/test_ccp_service.py
@@ -1,0 +1,89 @@
+"""Smoke tests for :mod:`apps.core.services.ccp_service`."""
+
+import ccp
+import pytest
+
+from apps.core.services import ccp_service
+
+
+@pytest.fixture
+def simple_composition():
+    return {"methane": 0.9, "ethane": 0.1}
+
+
+def test_build_gas_state(simple_composition):
+    state = ccp_service.build_gas_state(
+        simple_composition, p=ccp.Q_(1.0, "bar"), T=ccp.Q_(300.0, "degK")
+    )
+    assert isinstance(state, ccp.State)
+    assert pytest.approx(state.p().to("bar").m, rel=1e-6) == 1.0
+
+
+def test_build_gas_state_rejects_empty_composition():
+    with pytest.raises(ValueError):
+        ccp_service.build_gas_state({}, p=ccp.Q_(1, "bar"), T=ccp.Q_(300, "degK"))
+
+
+def test_polytropic_method_applied_via_wrapper(simple_composition):
+    original = ccp.config.POLYTROPIC_METHOD
+    try:
+        ccp_service._apply_polytropic_method("Huntington")
+        assert ccp.config.POLYTROPIC_METHOD == "huntington"
+        ccp_service._apply_polytropic_method("mallen_saville")
+        assert ccp.config.POLYTROPIC_METHOD == "mallen_saville"
+        ccp_service._apply_polytropic_method(None)
+        assert ccp.config.POLYTROPIC_METHOD == "mallen_saville"
+    finally:
+        ccp.config.POLYTROPIC_METHOD = original
+
+
+def test_polytropic_methods_returns_dict():
+    mapping = ccp_service.polytropic_methods()
+    assert "Schultz" in mapping
+    assert mapping["Schultz"] == "schultz"
+
+
+def test_build_point_1sec_forwards_kwargs(simple_composition):
+    suc = ccp_service.build_gas_state(
+        simple_composition, p=ccp.Q_(1.826, "bar"), T=ccp.Q_(296.7, "degK")
+    )
+    disch = ccp_service.build_gas_state(
+        simple_composition, p=ccp.Q_(6.142, "bar"), T=ccp.Q_(392.1, "degK")
+    )
+    point = ccp_service.build_point_1sec(
+        flow_m=ccp.Q_(7.737, "kg/s"),
+        speed=ccp.Q_(7894, "RPM"),
+        b=ccp.Q_(28.5, "mm"),
+        D=ccp.Q_(365, "mm"),
+        suc=suc,
+        disch=disch,
+        balance_line_flow_m=ccp.Q_(0.1076, "kg/s"),
+        seal_gas_flow_m=ccp.Q_(0.04982, "kg/s"),
+        seal_gas_temperature=ccp.Q_(297.7, "degK"),
+        oil_flow_journal_bearing_de=ccp.Q_(27.084, "l/min"),
+        oil_flow_journal_bearing_nde=ccp.Q_(47.984, "l/min"),
+        oil_flow_thrust_bearing_nde=ccp.Q_(33.52, "l/min"),
+        oil_inlet_temperature=ccp.Q_(42.184, "degC"),
+        oil_outlet_temperature_de=ccp.Q_(48.111, "degC"),
+        oil_outlet_temperature_nde=ccp.Q_(46.879, "degC"),
+        oil_specific_heat_de=ccp.Q_(2.02, "kJ/kg/degK"),
+        oil_specific_heat_nde=ccp.Q_(2.02, "kJ/kg/degK"),
+        oil_density_de=ccp.Q_(846.9, "kg/m³"),
+        oil_density_nde=ccp.Q_(846.9, "kg/m³"),
+        casing_area=7.5,
+        casing_temperature=ccp.Q_(31.309, "degC"),
+        ambient_temperature=ccp.Q_(0, "degC"),
+        polytropic_method="Schultz",
+    )
+    assert isinstance(point, ccp.compressor.Point1Sec)
+    assert ccp.config.POLYTROPIC_METHOD == "schultz"
+
+
+def test_service_package_importable():
+    from apps.core import services
+
+    assert hasattr(services, "ccp_service")
+    assert hasattr(services, "gas_composition")
+    assert hasattr(services, "parameter_map")
+    assert hasattr(services, "unit_helpers")
+    assert hasattr(services, "polytropic_methods")

--- a/ccp/app/django-app/apps/core/services/tests/test_gas_composition.py
+++ b/ccp/app/django-app/apps/core/services/tests/test_gas_composition.py
@@ -1,0 +1,41 @@
+"""Smoke tests for :mod:`apps.core.services.gas_composition`."""
+
+from apps.core.services import gas_composition as gc
+
+
+def test_fluid_list_starts_with_placeholder():
+    assert gc.FLUID_LIST[0] == ""
+    assert any("methane" in name for name in gc.FLUID_LIST)
+
+
+def test_default_composition_sums_to_one():
+    comp = gc.default_composition()
+    assert comp["methane"] == 1.0
+    assert sum(comp.values()) == 1.0
+    assert set(comp.keys()) == set(gc.DEFAULT_COMPONENTS[:6])
+
+
+def test_get_gas_composition_from_table():
+    table = {
+        "gas_0": {
+            "name": "main_gas",
+            "component_0": "methane",
+            "molar_fraction_0": "0.9",
+            "component_1": "ethane",
+            "molar_fraction_1": "0.1",
+            "component_2": "propane",
+            "molar_fraction_2": "",
+        }
+    }
+    result = gc.get_gas_composition("main_gas", table)
+    assert result == {"methane": 0.9, "ethane": 0.1}
+
+
+def test_get_gas_composition_missing_name_returns_empty():
+    assert gc.get_gas_composition("nope", {}) == {}
+
+
+def test_get_index_selected_gas():
+    opts = ["", "methane", "ethane"]
+    assert gc.get_index_selected_gas(opts, "ethane") == 2
+    assert gc.get_index_selected_gas(opts, "missing") == 0

--- a/ccp/app/django-app/apps/core/services/tests/test_parameter_map.py
+++ b/ccp/app/django-app/apps/core/services/tests/test_parameter_map.py
@@ -1,0 +1,36 @@
+"""Smoke tests for :mod:`apps.core.services.parameter_map`."""
+
+import pytest
+
+from apps.core.services import parameter_map as pmap
+
+
+def test_guarantee_point_keys_present():
+    assert "guarantee_point" in pmap.POINT_KEYS
+    assert "test_point_6" in pmap.POINT_KEYS
+    assert len(pmap.POINT_KEYS) == 7
+
+
+def test_suction_pressure_entry_shape():
+    entry = pmap.get_parameter("suction_pressure")
+    assert entry["label"] == "Suction Pressure"
+    assert "bar" in entry["units"]
+    assert "default" in entry
+    assert "help" in entry
+
+
+def test_flow_has_help_text():
+    entry = pmap.PARAMETERS["flow"]
+    assert entry["help"] is not None
+    assert "mass flow" in entry["help"]
+
+
+def test_unknown_parameter_raises():
+    with pytest.raises(KeyError):
+        pmap.get_parameter("not_a_parameter")
+
+
+def test_all_entries_have_required_keys():
+    for key, entry in pmap.PARAMETERS.items():
+        assert set(entry.keys()) == {"label", "units", "help", "default"}, key
+        assert isinstance(entry["units"], list) and entry["units"], key

--- a/ccp/app/django-app/apps/core/services/tests/test_polytropic_methods.py
+++ b/ccp/app/django-app/apps/core/services/tests/test_polytropic_methods.py
@@ -1,0 +1,27 @@
+"""Smoke tests for :mod:`apps.core.services.polytropic_methods`."""
+
+import pytest
+
+from apps.core.services import polytropic_methods as pm
+
+
+def test_mapping_contains_expected_labels():
+    mapping = pm.get_polytropic_methods()
+    assert mapping["Sandberg-Colby"] == "sandberg_colby"
+    assert mapping["Schultz"] == "schultz"
+    assert len(mapping) == 5
+
+
+def test_resolve_known_label():
+    assert pm.resolve("Huntington") == "huntington"
+
+
+def test_resolve_unknown_label_raises():
+    with pytest.raises(KeyError):
+        pm.resolve("does-not-exist")
+
+
+def test_get_polytropic_methods_returns_copy():
+    a = pm.get_polytropic_methods()
+    a["Schultz"] = "mutated"
+    assert pm.POLYTROPIC_METHODS["Schultz"] == "schultz"

--- a/ccp/app/django-app/apps/core/services/tests/test_unit_helpers.py
+++ b/ccp/app/django-app/apps/core/services/tests/test_unit_helpers.py
@@ -1,0 +1,30 @@
+"""Smoke tests for :mod:`apps.core.services.unit_helpers`."""
+
+import math
+
+from apps.core.services import unit_helpers as uh
+
+
+def test_flow_units_contains_mass_and_volumetric():
+    assert "kg/s" in uh.FLOW_UNITS
+    assert "m³/h" in uh.FLOW_UNITS
+
+
+def test_pressure_and_temperature_units_present():
+    assert "bar" in uh.PRESSURE_UNITS
+    assert "degK" in uh.TEMPERATURE_UNITS
+    assert "kJ/kg" in uh.HEAD_UNITS
+
+
+def test_convert_bar_to_pa():
+    assert math.isclose(uh.convert(1.0, "bar", "Pa"), 1e5)
+
+
+def test_convert_celsius_to_kelvin():
+    assert math.isclose(uh.convert(0.0, "degC", "degK"), 273.15)
+
+
+def test_convert_returns_float():
+    value = uh.convert(10.0, "kg/s", "kg/h")
+    assert isinstance(value, float)
+    assert math.isclose(value, 36000.0)

--- a/ccp/app/django-app/apps/core/services/unit_helpers.py
+++ b/ccp/app/django-app/apps/core/services/unit_helpers.py
@@ -1,0 +1,59 @@
+"""Unit choices and conversion helpers.
+
+All unit lists are ported from ``ccp/app/common.py`` so forms in the Django
+pages render exactly the same dropdowns as the Streamlit originals. Unit
+conversions always flow through :func:`ccp.Q_` — never hand-rolled arithmetic.
+"""
+
+from __future__ import annotations
+
+import ccp
+
+FLOW_M_UNITS: list[str] = ["kg/h", "kg/min", "kg/s", "lbm/h", "lbm/min", "lbm/s"]
+FLOW_V_UNITS: list[str] = ["m³/h", "m³/min", "m³/s"]
+FLOW_UNITS: list[str] = FLOW_M_UNITS + FLOW_V_UNITS
+PRESSURE_UNITS: list[str] = [
+    "bar",
+    "kgf/cm²",
+    "barg",
+    "Pa",
+    "kPa",
+    "MPa",
+    "psi",
+    "mmH2O",
+]
+TEMPERATURE_UNITS: list[str] = ["degK", "degC", "degF", "degR"]
+HEAD_UNITS: list[str] = ["kJ/kg", "J/kg", "m*g0", "ft"]
+POWER_UNITS: list[str] = ["kW", "hp", "W", "Btu/h", "MW"]
+SPEED_UNITS: list[str] = ["rpm", "Hz"]
+LENGTH_UNITS: list[str] = ["m", "mm", "ft", "in"]
+SPECIFIC_HEAT_UNITS: list[str] = [
+    "kJ/kg/degK",
+    "J/kg/degK",
+    "cal/g/degC",
+    "Btu/lb/degF",
+]
+OIL_FLOW_UNITS: list[str] = ["l/min", "l/h", "gal/min", "m³/h", "m³/min", "m³/s"]
+DENSITY_UNITS: list[str] = ["kg/m³", "g/cm³", "g/ml", "g/l"]
+AREA_UNITS: list[str] = ["m²", "mm²", "ft²", "in²"]
+OIL_ISO_OPTIONS: list[str] = ["VG 32", "VG 46"]
+
+
+def convert(value: float, src: str, dst: str) -> float:
+    """Convert a scalar magnitude from *src* units to *dst* units.
+
+    Parameters
+    ----------
+    value : float
+        Magnitude expressed in *src* units.
+    src : str
+        Source unit string understood by ``pint`` / ``ccp.Q_``.
+    dst : str
+        Destination unit string.
+
+    Returns
+    -------
+    float
+        ``value`` converted to *dst*, as a bare float.
+    """
+    return float(ccp.Q_(value, src).to(dst).magnitude)


### PR DESCRIPTION
## Summary

Unit 2 of the Streamlit → Django migration (see plan `synthetic-plotting-salamander`). Adds a pure-Python service layer under `ccp/app/django-app/apps/core/services/` that wraps the `ccp` library so Django views can call into compressor math without touching Streamlit or Django ORM.

- `ccp_service.py` — thin wrappers around `State`, `Point1Sec`, `StraightThrough`, `BackToBack`, `Impeller.load_from_engauge_csv`, `Impeller.convert_from`, and `Evaluation`. Each wrapper optionally sets `ccp.config.POLYTROPIC_METHOD` from a `polytropic_method` kwarg (accepting either a UI label or a raw config value).
- `gas_composition.py` — ports `FLUID_LIST`, `default_composition`, `get_gas_composition`, and `get_index_selected_gas` from `ccp/app/common.py`.
- `parameter_map.py` — ports the `parameters_map` dict with a uniform `{label, units, help, default}` shape plus `POINT_KEYS` for guarantee + test points 1-6.
- `unit_helpers.py` — ports FLOW/PRESSURE/TEMPERATURE/HEAD/POWER/SPEED/LENGTH/OIL_FLOW/DENSITY/SPECIFIC_HEAT/AREA unit lists and provides `convert(value, src, dst)` via `ccp.Q_`.
- `polytropic_methods.py` — ports the UI-label → `ccp.config` mapping.
- Stub `apps/__init__.py`, `apps/core/__init__.py`, and `apps/core/apps.py` marked `# STUB: replaced by Unit 1 at merge time` so Django can discover the package in isolation.

No Streamlit imports, no Django ORM, no web concerns. All unit conversions go through `pint` / `ccp.Q_` — never hand-rolled.

## Test plan

- [x] `uv run pytest apps/core/services/tests/` — 25 tests pass (smoke coverage for every module, including a full `Point1Sec` build exercising `polytropic_method` forwarding).
- [x] `uv run python -c "from apps.core.services import ccp_service, gas_composition, parameter_map, unit_helpers, polytropic_methods"` — importable.
- [x] `uv run ruff format` — clean.
- [ ] Cross-unit `manage.py check` deferred to merge time (depends on Unit 1 settings).