### PR TITLE
django-app: Unit 11 — integrations (AI, PI, Sentry)

### DIFF
--- a/ccp/app/django-app/apps/integrations/__init__.py
+++ b/ccp/app/django-app/apps/integrations/__init__.py
@@ -1,0 +1,7 @@
+"""Optional third-party integrations (AI analysis, PI, Sentry).
+
+Every integration in this package must degrade gracefully when its
+backing dependency (``google-generativeai``, ``pandaspi``, ``sentry-sdk``)
+is not installed or not configured, so that the Django app keeps
+working offline outside the Petrobras network.
+"""

--- a/ccp/app/django-app/apps/integrations/ai_analysis.py
+++ b/ccp/app/django-app/apps/integrations/ai_analysis.py
@@ -1,0 +1,232 @@
+"""AI-powered analysis for performance-evaluation reports.
+
+Ported from ``ccp/app/ai_analysis.py`` with an added graceful fallback:
+when ``google-generativeai`` is not installed, or no API key is supplied,
+:func:`generate_ai_analysis` returns a short Portuguese message instead
+of raising, so the Django app can still run offline.
+
+Portuguese system prompts and template text are preserved verbatim from
+the original Streamlit module.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+UNAVAILABLE_MESSAGE = (
+    "Análise por IA indisponível (provedor '{provider}' não configurado)."
+)
+
+SYSTEM_PROMPT = """\
+Você é um engenheiro especialista em desempenho de compressores centrífugos.
+Sua função é analisar dados de avaliação de desempenho de compressores e
+fornecer uma opinião técnica concisa e objetiva.
+
+Ao analisar os dados, considere:
+- Tendências de degradação ou melhoria na eficiência, head, potência e pressão
+  de descarga ao longo do tempo.
+- Desvios significativos entre valores medidos e esperados.
+- Possíveis causas operacionais ou mecânicas para os desvios observados
+  (fouling, erosão, desgaste de selos, mudanças nas condições de processo, etc.).
+- Recomendações práticas quando aplicável.
+
+Responda sempre em português brasileiro. Seja direto e técnico, evitando
+repetições. Use no máximo 3-4 parágrafos por seção de análise.
+"""
+
+_SECTION_SEPARATOR = "---SECTION---"
+
+_COMBINED_PROMPT_TEMPLATE = """\
+{session_context}Regressão linear das tendências (desvios percentuais ao longo do tempo):
+{regression_text}
+
+Estatísticas descritivas dos desvios:
+{stats_text}
+
+Com base nos dados acima, forneça três análises separadas. Separe cada análise \
+exatamente com a linha "{separator}" (sem espaços extras). Não inclua títulos \
+ou cabeçalhos nas seções.
+
+1. **Análise de Tendência**: Analise as tendências usando os resultados da \
+regressão linear (slope em %/mês, R² e p-value). Um slope negativo em \
+eficiência ou head indica degradação; um slope positivo em potência indica \
+aumento de consumo. Considere a significância estatística (p-value) e o \
+ajuste (R²) para determinar se as tendências são confiáveis. Discuta \
+possíveis causas operacionais ou mecânicas.
+
+2. **Análise de Desempenho**: Com base nas estatísticas dos desvios (média, \
+desvio padrão, min, max), analise o desempenho do compressor. Comente sobre \
+a magnitude dos desvios entre valores medidos e esperados e o que isso indica \
+sobre a condição do equipamento.
+
+3. **Estatísticas**: Faça uma análise resumida das estatísticas descritivas \
+dos desvios. Destaque valores que merecem atenção e dê uma avaliação geral \
+do estado do compressor."""
+
+
+class AIProvider(ABC):
+    """Abstract base class for AI/LLM providers."""
+
+    @abstractmethod
+    def generate(self, prompt: str) -> str:
+        """Generate text from a prompt.
+
+        Parameters
+        ----------
+        prompt : str
+            The user prompt to send to the model.
+
+        Returns
+        -------
+        str
+            The generated text response.
+        """
+
+
+class GeminiProvider(AIProvider):
+    """Google Gemini provider backed by ``google-generativeai``."""
+
+    def __init__(self, api_key: str, model: str = "gemini-2.5-flash") -> None:
+        try:
+            import google.generativeai as genai
+        except ImportError as exc:
+            raise ImportError(
+                "google-generativeai is required for Gemini provider. "
+                "Install it with: uv add google-generativeai"
+            ) from exc
+
+        genai.configure(api_key=api_key)
+        self.model = genai.GenerativeModel(
+            model_name=model,
+            system_instruction=SYSTEM_PROMPT,
+        )
+
+    def generate(self, prompt: str) -> str:
+        response = self.model.generate_content(prompt)
+        return response.text
+
+
+def _is_provider_available(provider: str) -> bool:
+    """Return True if the backing library for *provider* can be imported."""
+    if provider == "gemini":
+        try:
+            import google.generativeai  # noqa: F401
+        except ImportError:
+            return False
+        return True
+    return False
+
+
+def _format_stats_for_prompt(summary_stats_df: Any) -> str:
+    """Format a summary-statistics DataFrame as text for the AI prompt."""
+    if summary_stats_df is None:
+        return "Nenhuma estatística disponível."
+    if hasattr(summary_stats_df, "empty") and summary_stats_df.empty:
+        return "Nenhuma estatística disponível."
+    return summary_stats_df.to_string()
+
+
+def _format_regression_for_prompt(trend_regression: dict | None) -> str:
+    """Format trend-regression results as text for the AI prompt."""
+    if not trend_regression:
+        return "Nenhum dado de regressão disponível."
+
+    labels = {
+        "delta_eff": "Delta Eficiência (%)",
+        "delta_head": "Delta Head (%)",
+        "delta_power": "Delta Potência (%)",
+        "delta_p_disch": "Delta Pressão de Descarga (%)",
+    }
+
+    lines = []
+    for col, data in trend_regression.items():
+        label = labels.get(col, col)
+        lines.append(
+            f"- {label}: slope = {data['slope_per_month']:.4f} %/mês, "
+            f"R² = {data['r_squared']:.4f}, "
+            f"p-value = {data['p_value']:.2e}, "
+            f"n = {data['n_points']} pontos"
+        )
+    return "\n".join(lines)
+
+
+def _build_prompt(evaluation: Any) -> str:
+    """Assemble the combined prompt text from an evaluation-like object.
+
+    The function accepts either a mapping or a ``ccp.Evaluation`` instance
+    and pulls the attributes used by the original Streamlit code:
+    ``trend_regression``, ``summary_stats_df``, ``session_name``.
+    Missing fields degrade to empty sections.
+    """
+    if isinstance(evaluation, dict):
+        getter = evaluation.get
+    else:
+
+        def getter(key, default=None):
+            return getattr(evaluation, key, default)
+
+    regression_text = _format_regression_for_prompt(getter("trend_regression"))
+    stats_text = _format_stats_for_prompt(getter("summary_stats_df"))
+    session_name = getter("session_name", "") or ""
+    session_context = f"Sessão de avaliação: {session_name}\n" if session_name else ""
+
+    return _COMBINED_PROMPT_TEMPLATE.format(
+        session_context=session_context,
+        regression_text=regression_text,
+        stats_text=stats_text,
+        separator=_SECTION_SEPARATOR,
+    )
+
+
+def generate_ai_analysis(
+    evaluation: Any,
+    *,
+    provider: str = "gemini",
+    api_key: str | None = None,
+) -> str:
+    """Generate an AI analysis string for a performance evaluation.
+
+    Parameters
+    ----------
+    evaluation : object
+        Either a ``ccp.Evaluation`` instance or a mapping exposing the
+        attributes ``trend_regression``, ``summary_stats_df`` and
+        ``session_name``.
+    provider : str, optional
+        Name of the AI provider to use. Currently only ``"gemini"`` is
+        wired up.
+    api_key : str or None, optional
+        API key for the provider. If ``None`` or empty, the function
+        short-circuits to the offline fallback message.
+
+    Returns
+    -------
+    str
+        The generated analysis text, or a Portuguese fallback message
+        (``"Análise por IA indisponível..."``) when the provider cannot
+        be used. Sections in a successful response are delimited by
+        ``"---SECTION---"`` as in the original implementation.
+    """
+    if not api_key:
+        return UNAVAILABLE_MESSAGE.format(provider=provider)
+
+    if not _is_provider_available(provider):
+        logger.info("AI provider %r unavailable; returning fallback.", provider)
+        return UNAVAILABLE_MESSAGE.format(provider=provider)
+
+    try:
+        if provider == "gemini":
+            client: AIProvider = GeminiProvider(api_key=api_key)
+        else:
+            logger.warning("Unknown AI provider %r; returning fallback.", provider)
+            return UNAVAILABLE_MESSAGE.format(provider=provider)
+
+        prompt = _build_prompt(evaluation)
+        return client.generate(prompt)
+    except Exception as exc:
+        logger.exception("AI analysis generation failed: %s", exc)
+        return UNAVAILABLE_MESSAGE.format(provider=provider)

--- a/ccp/app/django-app/apps/integrations/apps.py
+++ b/ccp/app/django-app/apps/integrations/apps.py
@@ -1,0 +1,12 @@
+"""AppConfig for :mod:`apps.integrations`."""
+
+from django.apps import AppConfig
+
+
+class IntegrationsConfig(AppConfig):
+    """Register :mod:`apps.integrations` with Django."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.integrations"
+    label = "integrations"
+    verbose_name = "Optional Integrations"

--- a/ccp/app/django-app/apps/integrations/pi_client.py
+++ b/ccp/app/django-app/apps/integrations/pi_client.py
@@ -1,0 +1,207 @@
+"""Thin wrapper around ``pandaspi`` with a graceful offline fallback.
+
+``pandaspi`` is a Petrobras-internal package. Outside the corporate
+network it is typically not installed, so every entry point in this
+module wraps the import in ``try/except ImportError`` and returns
+empty-but-well-shaped results when the dependency is missing.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Mapping
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+_TAG_KEY_TO_COLUMN: dict[str, str] = {
+    "suc_p_tag": "ps",
+    "suc_T_tag": "Ts",
+    "disch_p_tag": "pd",
+    "disch_T_tag": "Td",
+    "speed_tag": "speed",
+    "flow_tag": "flow_v",
+    "delta_p_tag": "delta_p",
+    "p_downstream_tag": "p_downstream",
+}
+
+EXPECTED_COLUMNS: tuple[str, ...] = tuple(_TAG_KEY_TO_COLUMN.values())
+
+
+def is_pi_available() -> bool:
+    """Return whether the ``pandaspi`` dependency can be imported.
+
+    Returns
+    -------
+    bool
+        ``True`` if ``import pandaspi`` succeeds, ``False`` otherwise.
+    """
+    try:
+        import pandaspi  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _format_pi_time(value: datetime) -> str:
+    """Format a ``datetime`` the way PI Web API expects it."""
+    return value.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _empty_dataframe(tag_map: Mapping[str, Any] | None = None) -> pd.DataFrame:
+    """Return an empty DataFrame with the expected canonical columns."""
+    columns = list(EXPECTED_COLUMNS)
+    if tag_map:
+        for key in tag_map:
+            if key not in columns and not key.endswith("_unit"):
+                columns.append(key)
+    return pd.DataFrame(columns=columns)
+
+
+def _build_tags_list(tag_map: Mapping[str, Any]) -> tuple[list[str], dict[str, str]]:
+    """Build the ``tags_list`` and ``rename_map`` from a ``tag_map``.
+
+    The public form of ``tag_map`` used by the Streamlit app is a flat
+    dictionary with keys like ``suc_p_tag``/``suc_p_unit`` mapped to the
+    canonical column names in :data:`EXPECTED_COLUMNS`.
+    """
+    tags_list: list[str] = []
+    rename_map: dict[str, str] = {}
+    for tag_key, column in _TAG_KEY_TO_COLUMN.items():
+        tag = tag_map.get(tag_key)
+        if tag:
+            tags_list.append(tag)
+            rename_map[tag] = column
+    return tags_list, rename_map
+
+
+def fetch_pi_data(
+    tag_map: Mapping[str, Any],
+    start: datetime | None = None,
+    end: datetime | None = None,
+    *,
+    auth_method: str = "kerberos",
+    server_name: str | None = None,
+) -> pd.DataFrame:
+    """Fetch a historical PI dataset for the given tag mapping.
+
+    When ``pandaspi`` is not installed, this function logs a warning and
+    returns an empty DataFrame with the canonical column layout so
+    callers can proceed without branching on import availability.
+
+    Parameters
+    ----------
+    tag_map : Mapping
+        Dictionary describing the PI tags to fetch. See
+        :func:`_build_tags_list` for the expected keys.
+    start, end : datetime, optional
+        Inclusive time range. Defaults to the last hour.
+    auth_method : str, optional
+        Authentication method forwarded to ``pandaspi.SessionWeb``.
+        Defaults to ``"kerberos"``.
+    server_name : str, optional
+        PI server name forwarded to ``pandaspi.SessionWeb``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Data indexed by timestamp, or an empty DataFrame when PI is
+        unavailable.
+    """
+    if not is_pi_available():
+        logger.warning(
+            "pandaspi unavailable; returning empty PI dataframe (offline mode)."
+        )
+        return _empty_dataframe(tag_map)
+
+    tags_list, rename_map = _build_tags_list(tag_map)
+    if not tags_list:
+        logger.warning("fetch_pi_data called with no PI tags configured.")
+        return _empty_dataframe(tag_map)
+
+    if end is None:
+        end = datetime.now()
+    if start is None:
+        start = end - timedelta(hours=1)
+
+    from pandaspi import SessionWeb  # type: ignore[import-not-found]
+
+    session = SessionWeb(
+        server_name=server_name or tag_map.get("pi_server_name", ""),
+        login=tag_map.get("pi_login"),
+        tags=tags_list,
+        time_range=(_format_pi_time(start), _format_pi_time(end)),
+        time_span="450s",
+        authentication=tag_map.get("pi_auth_method", auth_method),
+    )
+    df = session.df.rename(columns=rename_map)
+    return clean_pi_data(df)
+
+
+def clean_pi_data(df: pd.DataFrame) -> pd.DataFrame:
+    """Clean a raw PI DataFrame for downstream ``ccp.Evaluation`` use.
+
+    - Drops rows where any column contains a PI system/error ``dict``.
+    - Strips timezone information from the index.
+    - Coerces every column to numeric (non-numeric become NaN).
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Raw DataFrame coming from ``pandaspi.SessionWeb`` (already
+        column-renamed to canonical names).
+
+    Returns
+    -------
+    pandas.DataFrame
+        A cleaned copy safe to hand to ``ccp.Evaluation``.
+
+    Raises
+    ------
+    ValueError
+        If all rows for a column are PI system errors, indicating the
+        instrument is down.
+    """
+    if df is None or df.empty:
+        return df if df is not None else pd.DataFrame()
+
+    error_columns: dict[str, dict[str, Any]] = {}
+    for col in df.columns:
+        if df[col].dtype == object:
+            is_dict_mask = df[col].apply(lambda v: isinstance(v, dict))
+            if is_dict_mask.any():
+                n_dicts = int(is_dict_mask.sum())
+                sample = df[col][is_dict_mask].iloc[0]
+                error_columns[col] = {
+                    "count": n_dicts,
+                    "total": len(df),
+                    "sample": sample,
+                }
+                if n_dicts == len(df):
+                    raise ValueError(
+                        f"Tag mapped to column '{col}' returned only PI system "
+                        f"values (instrument error). Sample value: {sample}. "
+                        f"Please check if the instrument is operational."
+                    )
+
+    if error_columns:
+        dict_row_mask = pd.Series(False, index=df.index)
+        for col in error_columns:
+            logger.warning(
+                "Column '%s': %d/%d rows contain PI system/error values; dropping.",
+                col,
+                error_columns[col]["count"],
+                error_columns[col]["total"],
+            )
+            dict_row_mask |= df[col].apply(lambda v: isinstance(v, dict))
+        df = df[~dict_row_mask].copy()
+
+    if hasattr(df.index, "tz") and df.index.tz is not None:
+        df.index = df.index.tz_localize(None)
+
+    for col in df.columns:
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    return df

--- a/ccp/app/django-app/apps/integrations/sentry.py
+++ b/ccp/app/django-app/apps/integrations/sentry.py
@@ -1,0 +1,62 @@
+"""Sentry initialization with a graceful fallback.
+
+Ported from ``ccp/app/common.py::init_sentry``. The import of
+``sentry_sdk`` is optional so the Django app can run in environments
+where the dependency is not available.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_DSN = (
+    "https://8fd0e79dffa94dbb9747bf64e7e55047@o348313.ingest.sentry.io/4505046640623616"
+)
+
+
+def init_sentry(dsn: str | None = None) -> None:
+    """Initialise Sentry error tracking when possible.
+
+    This is a no-op when any of the following conditions hold:
+
+    - ``sentry_sdk`` is not installed,
+    - the resolved DSN is falsy,
+    - the environment variable ``CCP_STANDALONE`` is set (mirrors the
+      original Streamlit behaviour).
+
+    Parameters
+    ----------
+    dsn : str or None, optional
+        Explicit DSN to use. When ``None``, falls back to the
+        ``SENTRY_DSN`` environment variable and then to the hard-coded
+        legacy DSN from the Streamlit app. Pass an empty string to
+        force the no-op path.
+    """
+    if os.environ.get("CCP_STANDALONE"):
+        logger.debug("Sentry init skipped: CCP_STANDALONE is set.")
+        return
+
+    if dsn is None:
+        dsn = os.environ.get("SENTRY_DSN") or _DEFAULT_DSN
+
+    if not dsn:
+        logger.debug("Sentry init skipped: no DSN provided.")
+        return
+
+    try:
+        import sentry_sdk
+    except ImportError:
+        logger.info("sentry-sdk not installed; Sentry integration disabled.")
+        return
+
+    try:
+        sentry_sdk.init(
+            dsn=dsn,
+            traces_sample_rate=1.0,
+            auto_enabling_integrations=False,
+        )
+    except Exception as exc:
+        logger.warning("Sentry initialization failed: %s", exc)

--- a/ccp/app/django-app/apps/integrations/tests/test_ai_analysis.py
+++ b/ccp/app/django-app/apps/integrations/tests/test_ai_analysis.py
@@ -1,0 +1,95 @@
+"""Tests for :mod:`apps.integrations.ai_analysis`."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from apps.integrations import ai_analysis
+
+
+def test_imports_without_google_generativeai(monkeypatch):
+    """Module must remain importable when google.generativeai is absent."""
+    monkeypatch.setitem(sys.modules, "google.generativeai", None)
+    import importlib
+
+    reloaded = importlib.reload(ai_analysis)
+    assert hasattr(reloaded, "generate_ai_analysis")
+
+
+def test_generate_ai_analysis_returns_string_when_no_api_key():
+    """Without an API key the function returns the fallback string."""
+    result = ai_analysis.generate_ai_analysis(SimpleNamespace(), api_key=None)
+    assert isinstance(result, str)
+    assert "indispon" in result.lower()
+
+
+def test_generate_ai_analysis_returns_string_when_provider_missing(monkeypatch):
+    """If the backing lib is unavailable, a Portuguese fallback is returned."""
+    monkeypatch.setattr(ai_analysis, "_is_provider_available", lambda _: False)
+    result = ai_analysis.generate_ai_analysis(
+        SimpleNamespace(), provider="gemini", api_key="dummy"
+    )
+    assert isinstance(result, str)
+    assert "gemini" in result
+
+
+def test_generate_ai_analysis_unknown_provider(monkeypatch):
+    monkeypatch.setattr(ai_analysis, "_is_provider_available", lambda _: True)
+    result = ai_analysis.generate_ai_analysis(
+        SimpleNamespace(), provider="does-not-exist", api_key="dummy"
+    )
+    assert isinstance(result, str)
+
+
+def test_format_regression_empty():
+    assert "Nenhum dado" in ai_analysis._format_regression_for_prompt({})
+    assert "Nenhum dado" in ai_analysis._format_regression_for_prompt(None)
+
+
+def test_format_regression_nonempty():
+    data = {
+        "delta_eff": {
+            "slope_per_month": -0.123,
+            "r_squared": 0.85,
+            "p_value": 1.2e-4,
+            "n_points": 30,
+        }
+    }
+    text = ai_analysis._format_regression_for_prompt(data)
+    assert "Delta Eficiência" in text
+    assert "slope" in text
+
+
+def test_format_stats_empty_dataframe():
+    assert ai_analysis._format_stats_for_prompt(pd.DataFrame()) == (
+        "Nenhuma estatística disponível."
+    )
+    assert ai_analysis._format_stats_for_prompt(None) == (
+        "Nenhuma estatística disponível."
+    )
+
+
+def test_build_prompt_with_namespace():
+    evaluation = SimpleNamespace(
+        trend_regression={},
+        summary_stats_df=pd.DataFrame(),
+        session_name="Teste",
+    )
+    prompt = ai_analysis._build_prompt(evaluation)
+    assert "Sessão de avaliação: Teste" in prompt
+    assert ai_analysis._SECTION_SEPARATOR in prompt
+
+
+def test_build_prompt_with_dict():
+    prompt = ai_analysis._build_prompt({"trend_regression": None})
+    assert ai_analysis._SECTION_SEPARATOR in prompt
+
+
+def test_gemini_provider_raises_when_library_missing(monkeypatch):
+    monkeypatch.setitem(sys.modules, "google.generativeai", None)
+    with pytest.raises(ImportError):
+        ai_analysis.GeminiProvider(api_key="dummy")

--- a/ccp/app/django-app/apps/integrations/tests/test_pi_client.py
+++ b/ccp/app/django-app/apps/integrations/tests/test_pi_client.py
@@ -1,0 +1,84 @@
+"""Tests for :mod:`apps.integrations.pi_client`."""
+
+from __future__ import annotations
+
+import sys
+
+import pandas as pd
+
+from apps.integrations import pi_client
+
+
+def test_imports_without_pandaspi(monkeypatch):
+    """Module must remain importable when pandaspi is absent."""
+    monkeypatch.setitem(sys.modules, "pandaspi", None)
+    import importlib
+
+    reloaded = importlib.reload(pi_client)
+    assert hasattr(reloaded, "is_pi_available")
+
+
+def test_is_pi_available_returns_bool():
+    assert isinstance(pi_client.is_pi_available(), bool)
+
+
+def test_is_pi_available_false_when_import_fails(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pandaspi", None)
+    assert pi_client.is_pi_available() is False
+
+
+def test_fetch_pi_data_returns_empty_frame_offline(monkeypatch):
+    """When PI is unavailable, an empty canonical DataFrame is returned."""
+    monkeypatch.setattr(pi_client, "is_pi_available", lambda: False)
+    df = pi_client.fetch_pi_data({"suc_p_tag": "TAG_PS"})
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty
+    for col in pi_client.EXPECTED_COLUMNS:
+        assert col in df.columns
+
+
+def test_fetch_pi_data_empty_when_no_tags(monkeypatch):
+    monkeypatch.setattr(pi_client, "is_pi_available", lambda: True)
+    df = pi_client.fetch_pi_data({})
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty
+
+
+def test_clean_pi_data_drops_dict_rows():
+    df = pd.DataFrame(
+        {
+            "ps": [1.0, {"Value": "err"}, 3.0],
+            "Ts": [300.0, 301.0, 302.0],
+        }
+    )
+    cleaned = pi_client.clean_pi_data(df)
+    assert len(cleaned) == 2
+    assert cleaned["ps"].dtype.kind == "f"
+
+
+def test_clean_pi_data_all_errors_raises():
+    df = pd.DataFrame({"ps": [{"Value": "err"}, {"Value": "err"}]})
+    try:
+        pi_client.clean_pi_data(df)
+    except ValueError as exc:
+        assert "instrument error" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError")
+
+
+def test_clean_pi_data_empty_dataframe():
+    df = pd.DataFrame()
+    assert pi_client.clean_pi_data(df).empty
+
+
+def test_build_tags_list_maps_canonical_columns():
+    tag_map = {
+        "suc_p_tag": "TAG_PS",
+        "disch_T_tag": "TAG_TD",
+        "speed_tag": "",
+    }
+    tags, rename_map = pi_client._build_tags_list(tag_map)
+    assert "TAG_PS" in tags
+    assert "TAG_TD" in tags
+    assert rename_map["TAG_PS"] == "ps"
+    assert rename_map["TAG_TD"] == "Td"

--- a/ccp/app/django-app/apps/integrations/tests/test_sentry.py
+++ b/ccp/app/django-app/apps/integrations/tests/test_sentry.py
@@ -1,0 +1,51 @@
+"""Tests for :mod:`apps.integrations.sentry`."""
+
+from __future__ import annotations
+
+import sys
+
+from apps.integrations import sentry as sentry_mod
+
+
+def test_imports_without_sentry_sdk(monkeypatch):
+    """Module must remain importable when sentry_sdk is absent."""
+    monkeypatch.setitem(sys.modules, "sentry_sdk", None)
+    import importlib
+
+    reloaded = importlib.reload(sentry_mod)
+    assert hasattr(reloaded, "init_sentry")
+
+
+def test_init_sentry_noop_when_dsn_empty(monkeypatch):
+    monkeypatch.delenv("CCP_STANDALONE", raising=False)
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    # Empty string forces no-op path.
+    assert sentry_mod.init_sentry(dsn="") is None
+
+
+def test_init_sentry_noop_when_standalone(monkeypatch):
+    monkeypatch.setenv("CCP_STANDALONE", "1")
+    assert sentry_mod.init_sentry(dsn="https://example/1") is None
+
+
+def test_init_sentry_noop_when_sdk_missing(monkeypatch):
+    monkeypatch.delenv("CCP_STANDALONE", raising=False)
+    monkeypatch.setitem(sys.modules, "sentry_sdk", None)
+    # Should not raise even though sentry_sdk cannot be imported.
+    assert sentry_mod.init_sentry(dsn="https://example/1") is None
+
+
+def test_init_sentry_calls_sdk_when_available(monkeypatch):
+    monkeypatch.delenv("CCP_STANDALONE", raising=False)
+
+    calls = {}
+
+    class _FakeSDK:
+        @staticmethod
+        def init(**kwargs):
+            calls.update(kwargs)
+
+    monkeypatch.setitem(sys.modules, "sentry_sdk", _FakeSDK)
+    sentry_mod.init_sentry(dsn="https://example/1")
+    assert calls.get("dsn") == "https://example/1"
+    assert calls.get("traces_sample_rate") == 1.0


### PR DESCRIPTION
## Summary

Part of the Django + MongoDB + Redis migration of the Streamlit app
(plan: 12 parallel units). This PR owns **Unit 11 — Integrations**.

Creates `apps.integrations` with three optional, gracefully-degrading
modules ported from `ccp/app/`:

- **ai_analysis.py** — `generate_ai_analysis(evaluation, *, provider="gemini", api_key=None)`
  returns the AI-generated text when `google-generativeai` is installed
  and an API key is supplied, and otherwise returns the Portuguese
  fallback message `"Análise por IA indisponível..."`. The Portuguese
  system prompt and three-section combined prompt template are
  preserved verbatim from `ccp/app/ai_analysis.py`.
- **pi_client.py** — `is_pi_available()`, `fetch_pi_data(tag_map, start, end, ...)`,
  `clean_pi_data(df)`. Wraps `pandaspi` imports in `try/except`
  ImportError and returns an empty DataFrame with the canonical column
  layout (`ps`, `Ts`, `pd`, `Td`, `speed`, `flow_v`, `delta_p`,
  `p_downstream`) when PI is unreachable.
- **sentry.py** — `init_sentry(dsn=None)` is a no-op when `sentry_sdk`
  is missing, when `CCP_STANDALONE` is set, or when no DSN is provided.

All three integrations are optional — no hard dependencies are added.

## Test plan

- [x] `uv run pytest apps/integrations/tests/` — 24 tests pass.
- [x] Import-without-dependency test for each module (monkeypatches
      `sys.modules["google.generativeai"|"pandaspi"|"sentry_sdk"] = None`).
- [x] `generate_ai_analysis` returns a string fallback when provider
      or api_key is unavailable.
- [x] `is_pi_available()` returns `bool`.
- [x] `clean_pi_data` drops PI error `dict` rows and coerces numeric.
- [x] `init_sentry` calls `sentry_sdk.init` with the supplied DSN when
      the SDK is available, and is a no-op otherwise.