### PR TITLE
django-app: Unit 10 — reports

### DIFF
--- a/ccp/app/django-app/apps/reports/__init__.py
+++ b/ccp/app/django-app/apps/reports/__init__.py
@@ -1,0 +1,1 @@
+"""Reports Django app (port of ``ccp/app/report.py``)."""

--- a/ccp/app/django-app/apps/reports/_stubs/__init__.py
+++ b/ccp/app/django-app/apps/reports/_stubs/__init__.py
@@ -1,0 +1,8 @@
+# STUB: replaced by Units 2, 3 at merge time.
+"""Local stubs used when cross-unit dependencies are unavailable.
+
+These modules mirror the public API contracts from
+``/home/raphaelts/.claude/plans/synthetic-plotting-salamander.md`` and are
+imported by :mod:`apps.reports` via ``try/except ImportError`` so the unit
+can be developed and tested in isolation.
+"""

--- a/ccp/app/django-app/apps/reports/_stubs/ccp_file_importer.py
+++ b/ccp/app/django-app/apps/reports/_stubs/ccp_file_importer.py
@@ -1,0 +1,9 @@
+# STUB: replaced by Unit 3 at merge time.
+"""Minimal fallback for :mod:`apps.core.storage.ccp_file_importer`."""
+
+from __future__ import annotations
+
+
+def load_ccp_file(fp) -> dict:  # pragma: no cover - stub
+    """Return an empty state dict (real impl loads a ``.ccp`` archive)."""
+    return {}

--- a/ccp/app/django-app/apps/reports/_stubs/ccp_service.py
+++ b/ccp/app/django-app/apps/reports/_stubs/ccp_service.py
@@ -1,0 +1,9 @@
+# STUB: replaced by Unit 2 at merge time.
+"""Minimal fallback for :mod:`apps.core.services.ccp_service`.
+
+Only the type-hint surface is needed by :mod:`apps.reports.services`.
+"""
+
+from typing import Any
+
+Evaluation = Any

--- a/ccp/app/django-app/apps/reports/_stubs/models.py
+++ b/ccp/app/django-app/apps/reports/_stubs/models.py
@@ -1,0 +1,16 @@
+# STUB: replaced by Unit 3 at merge time.
+"""Minimal fallback for :class:`apps.core.models.Session`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Session:
+    """Lightweight placeholder matching the MongoEngine ``Session`` document."""
+
+    name: str = ""
+    app_type: str = "performance_evaluation"
+    state: dict = field(default_factory=dict)
+    ccp_version: str = ""

--- a/ccp/app/django-app/apps/reports/_stubs/session_store.py
+++ b/ccp/app/django-app/apps/reports/_stubs/session_store.py
@@ -1,0 +1,21 @@
+# STUB: replaced by Unit 3 at merge time.
+"""In-memory fallback for :mod:`apps.core.session_store`."""
+
+from __future__ import annotations
+
+_STORE: dict[str, dict] = {}
+
+
+def get_session(session_id: str) -> dict | None:
+    """Return the cached session state for ``session_id`` or ``None``."""
+    return _STORE.get(session_id)
+
+
+def set_session(session_id: str, state: dict) -> None:
+    """Persist ``state`` under ``session_id`` in the in-memory store."""
+    _STORE[session_id] = state
+
+
+def clear_session(session_id: str) -> None:
+    """Remove ``session_id`` from the in-memory store if present."""
+    _STORE.pop(session_id, None)

--- a/ccp/app/django-app/apps/reports/apps.py
+++ b/ccp/app/django-app/apps/reports/apps.py
@@ -1,0 +1,12 @@
+"""AppConfig for the reports Django app."""
+
+from django.apps import AppConfig
+
+
+class ReportsConfig(AppConfig):
+    """Register :mod:`apps.reports` with Django."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.reports"
+    label = "reports"
+    verbose_name = "CCP Reports"

--- a/ccp/app/django-app/apps/reports/services.py
+++ b/ccp/app/django-app/apps/reports/services.py
@@ -1,0 +1,168 @@
+"""HTML report rendering for CCP performance evaluations.
+
+This module is the Django port of ``ccp/app/report.py``. It builds a
+self-contained HTML document with interactive Plotly figures that can be
+served inline or downloaded as an attachment.
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Mapping
+
+import plotly.io as pio
+from django.template.loader import render_to_string
+
+try:  # pragma: no cover - optional dependency
+    import markdown as _markdown
+except ImportError:  # pragma: no cover - offline fallback
+    _markdown = None
+
+try:  # type-hint only import - kept to satisfy the cross-unit contract.
+    from apps.core.services import ccp_service  # noqa: F401
+except ImportError:  # pragma: no cover - stub fallback
+    from apps.reports._stubs import ccp_service  # noqa: F401
+
+
+LOGO_PATH = Path(__file__).resolve().parents[3] / "ccp" / "app" / "assets" / "ccp.png"
+
+TREND_SECTION_TITLE = "Análise de Tendência"
+PERFORMANCE_SECTION_TITLE = "Curvas de Desempenho com Pontos Históricos"
+STATS_SECTION_TITLE = "Estatísticas Resumidas"
+
+TREND_SECTION_DESCRIPTION = (
+    "Os gráficos abaixo apresentam a evolução temporal dos desvios percentuais "
+    "entre os valores medidos e os valores esperados para eficiência, head, "
+    "potência e pressão de descarga. A linha tracejada vermelha indica o valor "
+    "de referência (desvio zero). Uma regressão linear com banda de confiança "
+    "de 95% é incluída para identificar tendências de degradação ou melhoria "
+    "ao longo do tempo."
+)
+PERFORMANCE_SECTION_DESCRIPTION = (
+    "Esta seção apresenta as curvas de desempenho do compressor (head, "
+    "potência, eficiência e pressão de descarga) em função da vazão volumétrica "
+    "de sucção. Os pontos operacionais medidos são sobrepostos às curvas "
+    "esperadas, permitindo a comparação direta entre o desempenho real e o "
+    "desempenho de projeto/garantia."
+)
+STATS_SECTION_DESCRIPTION = (
+    "A tabela a seguir apresenta as estatísticas descritivas dos desvios "
+    "calculados, incluindo média, desvio padrão, valores mínimo e máximo, e "
+    "quartis. Estes valores auxiliam na avaliação quantitativa do desempenho "
+    "do compressor ao longo do período analisado."
+)
+
+
+@lru_cache(maxsize=1)
+def _encode_logo() -> str:
+    """Return the CCP logo as a ``data:image/png;base64`` URI, or ``""``."""
+    try:
+        raw = LOGO_PATH.read_bytes()
+    except OSError:
+        return ""
+    return "data:image/png;base64," + base64.b64encode(raw).decode()
+
+
+def _figure_to_div(fig: Any, *, include_plotlyjs: bool) -> str:
+    """Render a single Plotly figure to an HTML ``<div>`` string."""
+    return pio.to_html(fig, full_html=False, include_plotlyjs=include_plotlyjs)
+
+
+def _ai_html(ai_summary: Any, key: str) -> str:
+    """Return the rendered ``<div class="ai-analysis">`` block or ``""``."""
+    if isinstance(ai_summary, Mapping):
+        text = ai_summary.get(key, "")
+    elif key == "trend" and isinstance(ai_summary, str):
+        text = ai_summary
+    else:
+        text = ""
+    if not text:
+        return ""
+    if _markdown is not None:
+        body = _markdown.markdown(text)
+    else:
+        body = "<p>" + str(text).replace("\n", "<br>") + "</p>"
+    return (
+        f'<div class="ai-analysis"><div class="ai-label">Análise IA</div>{body}</div>'
+    )
+
+
+def _stats_table_html(stats: Any) -> str:
+    """Render ``stats`` to an HTML table, tolerating ``None``/empty frames."""
+    if stats is None:
+        return "<p>Estatísticas resumidas não disponíveis.</p>"
+    to_html = getattr(stats, "to_html", None)
+    empty = getattr(stats, "empty", False)
+    if to_html is None or empty:
+        return "<p>Estatísticas resumidas não disponíveis.</p>"
+    return to_html(
+        classes="stats-table",
+        float_format=lambda x: f"{x:.4f}",
+    )
+
+
+def render_html_report(
+    evaluation: Any,
+    figures: Mapping[str, Any],
+    ai_summary: Any = "",
+) -> str:
+    """Render a standalone HTML performance report.
+
+    Parameters
+    ----------
+    evaluation : apps.core.services.ccp_service.Evaluation or None
+        Source evaluation. Only ``evaluation.name`` and
+        ``evaluation.summary_stats`` are read, both optionally; the figures
+        themselves come from ``figures``.
+    figures : mapping
+        Mapping with keys ``"trend"`` and ``"performance"`` each holding an
+        iterable of Plotly figures. Optional key ``"stats"`` may hold a
+        pandas DataFrame (otherwise read from ``evaluation.summary_stats``).
+    ai_summary : str or mapping, optional
+        Either a plain string (used for the trend section) or a mapping with
+        keys ``"trend"``, ``"performance"`` and ``"stats"`` as produced by
+        :mod:`apps.integrations.ai_analysis`.
+
+    Returns
+    -------
+    str
+        A complete HTML document (``<!DOCTYPE html>`` ... ``</html>``).
+    """
+    trend_figs = list(figures.get("trend") or [])
+    perf_figs = list(figures.get("performance") or [])
+    all_divs = [
+        _figure_to_div(fig, include_plotlyjs=(i == 0))
+        for i, fig in enumerate(trend_figs + perf_figs)
+    ]
+    trend_divs = all_divs[: len(trend_figs)]
+    perf_divs = all_divs[len(trend_figs) :]
+
+    stats_df = figures.get("stats")
+    if stats_df is None and evaluation is not None:
+        stats_df = getattr(evaluation, "summary_stats", None)
+
+    session_name = ""
+    if evaluation is not None:
+        session_name = getattr(evaluation, "name", "") or ""
+
+    context = {
+        "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M"),
+        "logo_data_uri": _encode_logo(),
+        "session_name": session_name,
+        "trend_title": TREND_SECTION_TITLE,
+        "trend_description": TREND_SECTION_DESCRIPTION,
+        "trend_divs": trend_divs,
+        "trend_ai_html": _ai_html(ai_summary, "trend"),
+        "performance_title": PERFORMANCE_SECTION_TITLE,
+        "performance_description": PERFORMANCE_SECTION_DESCRIPTION,
+        "perf_divs": perf_divs,
+        "performance_ai_html": _ai_html(ai_summary, "performance"),
+        "stats_title": STATS_SECTION_TITLE,
+        "stats_description": STATS_SECTION_DESCRIPTION,
+        "stats_table_html": _stats_table_html(stats_df),
+        "stats_ai_html": _ai_html(ai_summary, "stats"),
+    }
+    return render_to_string("reports/report.html", context)

--- a/ccp/app/django-app/apps/reports/static/reports/report.css
+++ b/ccp/app/django-app/apps/reports/static/reports/report.css
@@ -1,0 +1,155 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+body {
+    font-family: "SFMono-Regular", Menlo, Consolas, "Liberation Mono",
+                 "Courier New", monospace;
+    color: #2c3e50;
+    background: #ffffff;
+    line-height: 1.6;
+    padding: 2rem 3rem;
+    max-width: 1400px;
+    margin: 0 auto;
+}
+.header {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    border-bottom: 2px solid #e0e0e0;
+    padding-bottom: 1rem;
+    margin-bottom: 2rem;
+}
+.logo {
+    height: 60px;
+}
+.header-text h1 {
+    font-size: 1.6rem;
+    font-weight: 600;
+    color: #2c3e50;
+}
+.header-text .session-name {
+    font-size: 1.1rem;
+    font-weight: 400;
+    color: #444;
+}
+.header-text .timestamp {
+    font-size: 0.9rem;
+    color: #666;
+}
+nav.toc {
+    position: fixed;
+    top: 2rem;
+    right: 2rem;
+    width: 200px;
+    font-size: 0.85rem;
+    line-height: 1.8;
+}
+nav.toc .toc-title {
+    font-weight: 600;
+    color: #2c3e50;
+    margin-bottom: 0.4rem;
+}
+nav.toc ul {
+    list-style: none;
+    border-left: 3px solid #e0e0e0;
+    padding-left: 0.75rem;
+}
+nav.toc li {
+    padding: 0.1rem 0;
+}
+nav.toc a {
+    color: #555;
+    text-decoration: none;
+}
+nav.toc a:hover,
+nav.toc a.active {
+    color: #1f77b4;
+}
+nav.toc li.active {
+    border-left: 3px solid #1f77b4;
+    margin-left: -0.75rem;
+    padding-left: calc(0.75rem - 3px);
+}
+.main-content {
+    margin-right: 240px;
+}
+h2 {
+    font-size: 1.3rem;
+    font-weight: 600;
+    color: #2c3e50;
+    margin: 2rem 0 1rem 0;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid #e0e0e0;
+}
+.section-description {
+    color: #444;
+    font-size: 0.95rem;
+    margin-bottom: 1rem;
+    line-height: 1.5;
+}
+.ai-analysis {
+    background: #f0f4ff;
+    border-left: 4px solid #1f77b4;
+    border-radius: 0 6px 6px 0;
+    padding: 1rem 1.25rem;
+    margin: 1rem 0 1.5rem 0;
+    font-size: 0.93rem;
+    line-height: 1.6;
+    color: #2c3e50;
+}
+.ai-analysis .ai-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #1f77b4;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.5rem;
+}
+.plot-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+.plot-cell {
+    border: 1px solid #1f77b4;
+    border-radius: 6px;
+    padding: 0.5rem;
+    background: #fafafa;
+}
+.stats-table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1rem 0;
+    font-size: 0.9rem;
+}
+.stats-table th,
+.stats-table td {
+    border: 1px solid #ddd;
+    padding: 0.5rem 0.75rem;
+    text-align: right;
+}
+.stats-table th {
+    background: #f5f5f5;
+    font-weight: 600;
+    text-align: center;
+    color: #2c3e50;
+}
+.stats-table tr:nth-child(even) {
+    background: #fafafa;
+}
+.stats-table tr:hover {
+    background: #f0f0f0;
+}
+@media print {
+    nav.toc { display: none; }
+    .main-content { margin-right: 0; }
+    body { padding: 1rem; }
+    .plot-grid { break-inside: avoid; }
+}
+@media (max-width: 1000px) {
+    nav.toc { display: none; }
+    .main-content { margin-right: 0; }
+}

--- a/ccp/app/django-app/apps/reports/templates/reports/report.html
+++ b/ccp/app/django-app/apps/reports/templates/reports/report.html
@@ -1,0 +1,218 @@
+{% load static %}<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Relatório de Desempenho CCP — {{ timestamp }}</title>
+    <style>
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+body {
+    font-family: "SFMono-Regular", Menlo, Consolas, "Liberation Mono",
+                 "Courier New", monospace;
+    color: #2c3e50;
+    background: #ffffff;
+    line-height: 1.6;
+    padding: 2rem 3rem;
+    max-width: 1400px;
+    margin: 0 auto;
+}
+.header {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    border-bottom: 2px solid #e0e0e0;
+    padding-bottom: 1rem;
+    margin-bottom: 2rem;
+}
+.logo { height: 60px; }
+.header-text h1 {
+    font-size: 1.6rem;
+    font-weight: 600;
+    color: #2c3e50;
+}
+.header-text .session-name {
+    font-size: 1.1rem;
+    font-weight: 400;
+    color: #444;
+}
+.header-text .timestamp {
+    font-size: 0.9rem;
+    color: #666;
+}
+nav.toc {
+    position: fixed;
+    top: 2rem;
+    right: 2rem;
+    width: 200px;
+    font-size: 0.85rem;
+    line-height: 1.8;
+}
+nav.toc .toc-title {
+    font-weight: 600;
+    color: #2c3e50;
+    margin-bottom: 0.4rem;
+}
+nav.toc ul {
+    list-style: none;
+    border-left: 3px solid #e0e0e0;
+    padding-left: 0.75rem;
+}
+nav.toc li { padding: 0.1rem 0; }
+nav.toc a {
+    color: #555;
+    text-decoration: none;
+}
+nav.toc a:hover,
+nav.toc a.active { color: #1f77b4; }
+nav.toc li.active {
+    border-left: 3px solid #1f77b4;
+    margin-left: -0.75rem;
+    padding-left: calc(0.75rem - 3px);
+}
+.main-content { margin-right: 240px; }
+h2 {
+    font-size: 1.3rem;
+    font-weight: 600;
+    color: #2c3e50;
+    margin: 2rem 0 1rem 0;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid #e0e0e0;
+}
+.section-description {
+    color: #444;
+    font-size: 0.95rem;
+    margin-bottom: 1rem;
+    line-height: 1.5;
+}
+.ai-analysis {
+    background: #f0f4ff;
+    border-left: 4px solid #1f77b4;
+    border-radius: 0 6px 6px 0;
+    padding: 1rem 1.25rem;
+    margin: 1rem 0 1.5rem 0;
+    font-size: 0.93rem;
+    line-height: 1.6;
+    color: #2c3e50;
+}
+.ai-analysis .ai-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #1f77b4;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.5rem;
+}
+.plot-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+.plot-cell {
+    border: 1px solid #1f77b4;
+    border-radius: 6px;
+    padding: 0.5rem;
+    background: #fafafa;
+}
+.stats-table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1rem 0;
+    font-size: 0.9rem;
+}
+.stats-table th,
+.stats-table td {
+    border: 1px solid #ddd;
+    padding: 0.5rem 0.75rem;
+    text-align: right;
+}
+.stats-table th {
+    background: #f5f5f5;
+    font-weight: 600;
+    text-align: center;
+    color: #2c3e50;
+}
+.stats-table tr:nth-child(even) { background: #fafafa; }
+.stats-table tr:hover { background: #f0f0f0; }
+@media print {
+    nav.toc { display: none; }
+    .main-content { margin-right: 0; }
+    body { padding: 1rem; }
+    .plot-grid { break-inside: avoid; }
+}
+@media (max-width: 1000px) {
+    nav.toc { display: none; }
+    .main-content { margin-right: 0; }
+}
+    </style>
+</head>
+<body>
+    <nav class="toc">
+        <div class="toc-title">Nesta página</div>
+        <ul>
+            <li><a href="#tendencia">{{ trend_title }}</a></li>
+            <li><a href="#desempenho">{{ performance_title }}</a></li>
+            <li><a href="#estatisticas">{{ stats_title }}</a></li>
+        </ul>
+    </nav>
+
+    <div class="main-content">
+        <div class="header">
+            {% if logo_data_uri %}<img src="{{ logo_data_uri }}" alt="CCP Logo" class="logo">{% endif %}
+            <div class="header-text">
+                <h1>Relatório de Avaliação de Desempenho</h1>
+                {% if session_name %}<div class="session-name">{{ session_name }}</div>{% endif %}
+                <div class="timestamp">Gerado em {{ timestamp }}</div>
+            </div>
+        </div>
+
+        <h2 id="tendencia">{{ trend_title }}</h2>
+        <p class="section-description">{{ trend_description }}</p>
+        <div class="plot-grid">
+            {% for div in trend_divs %}<div class="plot-cell">{{ div|safe }}</div>{% endfor %}
+        </div>
+        {{ trend_ai_html|safe }}
+
+        <h2 id="desempenho">{{ performance_title }}</h2>
+        <p class="section-description">{{ performance_description }}</p>
+        <div class="plot-grid">
+            {% for div in perf_divs %}<div class="plot-cell">{{ div|safe }}</div>{% endfor %}
+        </div>
+        {{ performance_ai_html|safe }}
+
+        <h2 id="estatisticas">{{ stats_title }}</h2>
+        <p class="section-description">{{ stats_description }}</p>
+        {{ stats_table_html|safe }}
+        {{ stats_ai_html|safe }}
+    </div>
+
+    <script>
+        (function() {
+            const sections = document.querySelectorAll('h2[id]');
+            const tocLinks = document.querySelectorAll('nav.toc a');
+            const tocItems = document.querySelectorAll('nav.toc li');
+            function updateActive() {
+                let current = '';
+                sections.forEach(function(section) {
+                    const top = section.getBoundingClientRect().top;
+                    if (top <= 120) { current = section.getAttribute('id'); }
+                });
+                tocLinks.forEach(function(link, i) {
+                    link.classList.remove('active');
+                    tocItems[i].classList.remove('active');
+                    if (link.getAttribute('href') === '#' + current) {
+                        link.classList.add('active');
+                        tocItems[i].classList.add('active');
+                    }
+                });
+            }
+            window.addEventListener('scroll', updateActive);
+            updateActive();
+        })();
+    </script>
+</body>
+</html>

--- a/ccp/app/django-app/apps/reports/tests/conftest.py
+++ b/ccp/app/django-app/apps/reports/tests/conftest.py
@@ -1,0 +1,61 @@
+"""Local Django configuration for :mod:`apps.reports` tests.
+
+Unit 10 is developed in isolation: the project-level ``ccp_web`` settings
+module owned by Unit 1 may not exist yet in this worktree. This conftest
+provides a minimal, self-contained settings module so the reports app can
+be imported and exercised via ``pytest`` without any cross-unit wiring.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import django
+from django.conf import settings
+
+REPORTS_APP_DIR = Path(__file__).resolve().parents[1]
+DJANGO_APP_ROOT = REPORTS_APP_DIR.parents[1]
+
+
+def _ensure_django_configured() -> None:
+    if settings.configured:
+        return
+    if str(DJANGO_APP_ROOT) not in sys.path:
+        sys.path.insert(0, str(DJANGO_APP_ROOT))
+    settings.configure(
+        DEBUG=True,
+        SECRET_KEY="reports-tests-secret",
+        ALLOWED_HOSTS=["*"],
+        ROOT_URLCONF="apps.reports.tests.urls",
+        INSTALLED_APPS=[
+            "django.contrib.contenttypes",
+            "django.contrib.auth",
+            "django.contrib.staticfiles",
+            "apps.reports",
+        ],
+        MIDDLEWARE=[],
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": ":memory:",
+            }
+        },
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "DIRS": [],
+                "APP_DIRS": True,
+                "OPTIONS": {"context_processors": []},
+            }
+        ],
+        STATIC_URL="/static/",
+        USE_TZ=True,
+        DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+    )
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "")
+    django.setup()
+
+
+_ensure_django_configured()

--- a/ccp/app/django-app/apps/reports/tests/test_services.py
+++ b/ccp/app/django-app/apps/reports/tests/test_services.py
@@ -1,0 +1,58 @@
+"""Tests for :func:`apps.reports.services.render_html_report`."""
+
+from __future__ import annotations
+
+import plotly.graph_objects as go
+from apps.reports.services import (
+    PERFORMANCE_SECTION_TITLE,
+    STATS_SECTION_TITLE,
+    TREND_SECTION_TITLE,
+    render_html_report,
+)
+
+
+def _sample_figure(title: str) -> go.Figure:
+    return go.Figure(
+        data=[go.Scatter(x=[0, 1, 2], y=[0, 1, 4])], layout={"title": title}
+    )
+
+
+def test_render_html_report_contains_expected_sections():
+    figures = {
+        "trend": [_sample_figure("t1"), _sample_figure("t2")],
+        "performance": [_sample_figure("p1")],
+    }
+
+    html = render_html_report(evaluation=None, figures=figures)
+
+    assert "<html" in html
+    assert "</html>" in html
+    assert TREND_SECTION_TITLE in html
+    assert PERFORMANCE_SECTION_TITLE in html
+    assert STATS_SECTION_TITLE in html
+    # Plotly.js must be embedded exactly once (first figure ships it).
+    assert html.count("Plotly.newPlot") >= 3
+    # include_plotlyjs=True emits a huge inline script; cheap marker below.
+    assert "plotly" in html.lower()
+
+
+def test_render_html_report_handles_empty_ai_summary_and_no_eval():
+    html = render_html_report(
+        evaluation=None,
+        figures={"trend": [], "performance": []},
+        ai_summary="",
+    )
+    assert "Estatísticas resumidas não disponíveis" in html
+    assert 'class="ai-analysis"' not in html
+
+
+def test_render_html_report_accepts_ai_summary_mapping():
+    figures = {"trend": [_sample_figure("t")], "performance": [_sample_figure("p")]}
+    html = render_html_report(
+        evaluation=None,
+        figures=figures,
+        ai_summary={"trend": "**hello** trend", "performance": "perf text"},
+    )
+    assert "Análise IA" in html
+    assert "hello" in html
+    assert "perf text" in html

--- a/ccp/app/django-app/apps/reports/tests/test_views.py
+++ b/ccp/app/django-app/apps/reports/tests/test_views.py
@@ -1,0 +1,50 @@
+"""Tests for the :mod:`apps.reports.views` endpoints."""
+
+from __future__ import annotations
+
+import plotly.graph_objects as go
+from apps.reports._stubs import session_store
+from django.test import Client
+
+
+def _seed_session(session_id: str) -> None:
+    session_store.set_session(
+        session_id,
+        {
+            "evaluation": None,
+            "figures": {
+                "trend": [go.Figure(data=[go.Scatter(x=[0, 1], y=[0, 1])])],
+                "performance": [go.Figure(data=[go.Scatter(x=[0, 1], y=[1, 0])])],
+            },
+            "ai_summary": "",
+        },
+    )
+
+
+def test_report_view_returns_html_for_seeded_session():
+    session_id = "abc123"
+    _seed_session(session_id)
+
+    response = Client().get(f"/reports/{session_id}/")
+
+    assert response.status_code == 200
+    assert response["Content-Type"].startswith("text/html")
+    body = response.content.decode()
+    assert "<html" in body
+    assert "Relatório de Avaliação de Desempenho" in body
+
+
+def test_report_view_returns_404_when_session_missing():
+    response = Client().get("/reports/nonexistent/")
+    assert response.status_code == 404
+
+
+def test_report_download_sets_attachment_header():
+    session_id = "dl42"
+    _seed_session(session_id)
+
+    response = Client().get(f"/reports/{session_id}/download/")
+
+    assert response.status_code == 200
+    assert "attachment" in response["Content-Disposition"]
+    assert f"ccp_report_{session_id}.html" in response["Content-Disposition"]

--- a/ccp/app/django-app/apps/reports/tests/urls.py
+++ b/ccp/app/django-app/apps/reports/tests/urls.py
@@ -1,0 +1,7 @@
+"""Root URL conf used by :mod:`apps.reports` isolated tests."""
+
+from django.urls import include, path
+
+urlpatterns = [
+    path("reports/", include("apps.reports.urls", namespace="reports")),
+]

--- a/ccp/app/django-app/apps/reports/urls.py
+++ b/ccp/app/django-app/apps/reports/urls.py
@@ -1,0 +1,12 @@
+"""URL routes for :mod:`apps.reports`."""
+
+from django.urls import path
+
+from . import views
+
+app_name = "reports"
+
+urlpatterns = [
+    path("<str:session_id>/", views.report_view, name="detail"),
+    path("<str:session_id>/download/", views.report_download, name="download"),
+]

--- a/ccp/app/django-app/apps/reports/views.py
+++ b/ccp/app/django-app/apps/reports/views.py
@@ -1,0 +1,58 @@
+"""Views for :mod:`apps.reports`.
+
+Two endpoints are exposed:
+
+* ``GET /reports/<session_id>/`` — render the HTML report inline.
+* ``GET /reports/<session_id>/download/`` — same payload, served as an
+  ``attachment`` so browsers save it to disk.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.http import Http404, HttpRequest, HttpResponse
+
+from .services import render_html_report
+
+try:
+    from apps.core.session_store import get_session
+except ImportError:  # pragma: no cover - stub fallback
+    from apps.reports._stubs.session_store import get_session
+
+try:
+    from apps.core.storage import ccp_file_importer  # noqa: F401
+except ImportError:  # pragma: no cover - stub fallback
+    from apps.reports._stubs import ccp_file_importer  # noqa: F401
+
+
+def _load_report_payload(session_id: str) -> tuple[Any, dict, Any]:
+    """Load evaluation, figures and AI summary from the session store."""
+    state = get_session(session_id)
+    if state is None:
+        raise Http404(f"Session {session_id!r} not found")
+    evaluation = state.get("evaluation")
+    figures = state.get("figures") or {}
+    ai_summary = state.get("ai_summary", "")
+    return evaluation, figures, ai_summary
+
+
+def _build_response(session_id: str, *, attachment: bool) -> HttpResponse:
+    """Render the report and wrap it in an ``HttpResponse``."""
+    evaluation, figures, ai_summary = _load_report_payload(session_id)
+    html = render_html_report(evaluation, figures, ai_summary=ai_summary)
+    response = HttpResponse(html, content_type="text/html; charset=utf-8")
+    if attachment:
+        filename = f"ccp_report_{session_id}.html"
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    return response
+
+
+def report_view(request: HttpRequest, session_id: str) -> HttpResponse:
+    """Render the HTML performance report for ``session_id``."""
+    return _build_response(session_id, attachment=False)
+
+
+def report_download(request: HttpRequest, session_id: str) -> HttpResponse:
+    """Return the HTML report as a downloadable attachment."""
+    return _build_response(session_id, attachment=True)


### PR DESCRIPTION
## Summary
- Port `ccp/app/report.py` to a Django `apps.reports` app that serves self-contained HTML performance reports with embedded Plotly figures.
- Expose `GET /reports/<session_id>/` (inline) and `/reports/<session_id>/download/` (attachment) backed by `apps.core.session_store` with graceful stub fallback.
- Preserve the Portuguese section titles/descriptions and match the Streamlit look (monospace, `#2c3e50` accents, tableau-coloured plot borders).

## Details
- `services.render_html_report(evaluation, figures, ai_summary)` renders a Django template with `plotly.io.to_html`. The first figure ships `plotly.js` inline (`include_plotlyjs=True`); all subsequent figures reuse it (`include_plotlyjs=False`), so reports remain fully offline-viewable.
- Template `templates/reports/report.html` does NOT extend `base.html` — reports are downloadable artefacts and must be self-contained. CSS is inlined in the template; a mirror copy lives at `static/reports/report.css` for in-app styling.
- Cross-unit imports (`apps.core.services.ccp_service`, `apps.core.storage.ccp_file_importer`, `apps.core.session_store`, `apps.core.models.Session`) are wrapped in `try/except ImportError` with local stubs under `apps/reports/_stubs/` so the unit works in isolation before Units 2/3 land.
- `tests/conftest.py` configures a minimal Django settings module locally so `pytest apps/reports/tests/` and `manage.py check` succeed without the (not-yet-existing) `ccp_web` project wiring.

## Test plan
- [x] `uv run pytest apps/reports/tests/` — 6 passed
- [x] `django.core.management.call_command("check")` via the local settings — no issues
- [x] Ruff format + lint clean
- [x] Runserver smoke: `GET /reports/<fake>/` returns 404 (no session) with no traceback; endpoint reachable