### PR TITLE
django-app: Unit 12 — Excel export & file upload endpoints

### DIFF
--- a/ccp/app/django-app/apps/__init__.py
+++ b/ccp/app/django-app/apps/__init__.py
@@ -1,0 +1,1 @@
+# STUB: replaced by Unit 1 at merge time.

--- a/ccp/app/django-app/apps/core/__init__.py
+++ b/ccp/app/django-app/apps/core/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "apps.core.apps.CoreConfig"

--- a/ccp/app/django-app/apps/core/_stubs/__init__.py
+++ b/ccp/app/django-app/apps/core/_stubs/__init__.py
@@ -1,0 +1,3 @@
+# STUB: Unit 12 local stubs for cross-unit imports.
+# These modules will be provided by Unit 3 at merge time; Unit 12
+# imports fall back here when the real modules are unavailable.

--- a/ccp/app/django-app/apps/core/_stubs/ccp_file_exporter.py
+++ b/ccp/app/django-app/apps/core/_stubs/ccp_file_exporter.py
@@ -1,0 +1,39 @@
+"""Exporter stub for .ccp archive files.
+
+# STUB: replaced by Unit 3 (apps.core.storage.ccp_file_exporter) at merge time.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from typing import Any
+
+
+def export_ccp_file(state: dict[str, Any]) -> bytes:
+    """Serialize a session state dictionary into a .ccp archive.
+
+    Parameters
+    ----------
+    state : dict
+        Session state dictionary to archive.
+
+    Returns
+    -------
+    bytes
+        Bytes of a ZIP archive containing ``session_state.json``.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        serializable = {k: v for k, v in state.items() if _json_safe(v)}
+        zf.writestr("session_state.json", json.dumps(serializable, default=str))
+    return buf.getvalue()
+
+
+def _json_safe(value: Any) -> bool:
+    try:
+        json.dumps(value, default=str)
+    except (TypeError, ValueError):
+        return False
+    return True

--- a/ccp/app/django-app/apps/core/_stubs/ccp_file_importer.py
+++ b/ccp/app/django-app/apps/core/_stubs/ccp_file_importer.py
@@ -1,0 +1,46 @@
+"""Importer stub for .ccp archive files.
+
+# STUB: replaced by Unit 3 (apps.core.storage.ccp_file_importer) at merge time.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from typing import IO, Any
+
+
+def load_ccp_file(fp: IO[bytes]) -> dict[str, Any]:
+    """Load a .ccp archive into a session state dictionary.
+
+    Parameters
+    ----------
+    fp : file-like
+        Binary file-like object pointing at a .ccp ZIP archive.
+
+    Returns
+    -------
+    dict
+        Session state dictionary. The stub implementation reads
+        ``session_state.json`` from the archive when present, otherwise
+        returns a dictionary listing the archive's file names.
+    """
+    fp.seek(0)
+    state: dict[str, Any] = {}
+    try:
+        with zipfile.ZipFile(fp) as zf:
+            names = zf.namelist()
+            state["_archive_files"] = names
+            if "session_state.json" in names:
+                with zf.open("session_state.json") as fh:
+                    try:
+                        state.update(json.load(fh))
+                    except json.JSONDecodeError:
+                        pass
+    except zipfile.BadZipFile:
+        state["_archive_files"] = []
+    try:
+        fp.seek(0)
+    except Exception:
+        pass
+    return state

--- a/ccp/app/django-app/apps/core/_stubs/models.py
+++ b/ccp/app/django-app/apps/core/_stubs/models.py
@@ -1,0 +1,20 @@
+"""Models stub.
+
+# STUB: replaced by Unit 3 (apps.core.models) at merge time with a
+# MongoEngine Document.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class Session:
+    """Lightweight in-memory stand-in for the real MongoEngine document."""
+
+    name: str = ""
+    app_type: str = ""
+    state: dict[str, Any] = field(default_factory=dict)
+    ccp_version: str = ""

--- a/ccp/app/django-app/apps/core/_stubs/session_store.py
+++ b/ccp/app/django-app/apps/core/_stubs/session_store.py
@@ -1,0 +1,33 @@
+"""Session store stub.
+
+# STUB: replaced by Unit 3 (apps.core.session_store) at merge time. This
+# stub uses an in-process dictionary so Unit 12 views can be exercised
+# without Redis running.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+_SESSIONS: dict[str, dict[str, Any]] = {}
+
+
+def new_session_id() -> str:
+    """Return a fresh random session identifier."""
+    return uuid.uuid4().hex
+
+
+def get_session(session_id: str) -> dict[str, Any]:
+    """Return the state dict for ``session_id`` or an empty dict."""
+    return dict(_SESSIONS.get(session_id, {}))
+
+
+def set_session(session_id: str, state: dict[str, Any]) -> None:
+    """Persist ``state`` under ``session_id``."""
+    _SESSIONS[session_id] = state
+
+
+def clear_session(session_id: str) -> None:
+    """Remove ``session_id`` from the store."""
+    _SESSIONS.pop(session_id, None)

--- a/ccp/app/django-app/apps/core/apps.py
+++ b/ccp/app/django-app/apps/core/apps.py
@@ -1,0 +1,14 @@
+"""AppConfig for apps.core.
+
+# STUB: replaced by Unit 3 at merge time with MongoEngine wiring.
+"""
+
+from django.apps import AppConfig
+
+
+class CoreConfig(AppConfig):
+    """Django app config for the shared core app."""
+
+    name = "apps.core"
+    label = "core"
+    verbose_name = "CCP Core"

--- a/ccp/app/django-app/apps/core/exports/__init__.py
+++ b/ccp/app/django-app/apps/core/exports/__init__.py
@@ -1,0 +1,5 @@
+"""Workbook export helpers for ccp sessions."""
+
+from apps.core.exports.to_excel import session_to_excel
+
+__all__ = ["session_to_excel"]

--- a/ccp/app/django-app/apps/core/exports/to_excel.py
+++ b/ccp/app/django-app/apps/core/exports/to_excel.py
@@ -1,0 +1,154 @@
+"""Excel export for ccp session state.
+
+Ports :func:`ccp.app.common.to_excel` (a thin pandas wrapper that only
+produced a single-sheet workbook from a DataFrame) into a richer
+``session_to_excel`` that serialises the whole session into a workbook
+mirroring the sheet layout downloaded by the Streamlit app. Portuguese
+sheet and column names are preserved.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any, Iterable, Mapping
+
+import pandas as pd
+
+
+SHEET_PARAMETROS = "Parametros"
+SHEET_GARANTIA = "Ponto de Garantia"
+SHEET_TESTE = "Pontos de Teste"
+SHEET_RESULTADOS = "Resultados"
+SHEET_GRAFICOS = "Graficos"
+
+
+def session_to_excel(state: Mapping[str, Any]) -> bytes:
+    """Serialize a session state dictionary to an ``.xlsx`` workbook.
+
+    The workbook contains up to five sheets (all in Portuguese to match
+    the Streamlit download):
+
+    - ``Parametros`` -- scalar parameters from the session.
+    - ``Ponto de Garantia`` -- guarantee-point inputs.
+    - ``Pontos de Teste`` -- test-point inputs.
+    - ``Resultados`` -- a pre-computed results DataFrame, when present.
+    - ``Graficos`` -- references (not binary) to plot payloads stored
+      in the session so the file stays portable without embedded PNGs.
+
+    Parameters
+    ----------
+    state : Mapping[str, Any]
+        Session state dictionary. Missing keys are silently skipped; an
+        empty state still produces a valid (but minimal) workbook.
+
+    Returns
+    -------
+    bytes
+        The bytes of the generated ``.xlsx`` workbook.
+    """
+    buf = io.BytesIO()
+    engine = _pick_engine()
+    with pd.ExcelWriter(buf, engine=engine) as writer:
+        _write_parameters_sheet(writer, state)
+        _write_points_sheet(
+            writer, SHEET_GARANTIA, _coerce_points(state.get("guarantee_point"))
+        )
+        _write_points_sheet(
+            writer, SHEET_TESTE, _coerce_points(state.get("test_points"))
+        )
+        _write_results_sheet(writer, state)
+        _write_plots_sheet(writer, state)
+    return buf.getvalue()
+
+
+def _pick_engine() -> str:
+    """Return the first available pandas Excel engine.
+
+    Prefers ``xlsxwriter`` (matching the original Streamlit helper),
+    falling back to ``openpyxl``.
+    """
+    try:
+        import xlsxwriter  # noqa: F401
+
+        return "xlsxwriter"
+    except ImportError:
+        return "openpyxl"
+
+
+def _write_parameters_sheet(writer: pd.ExcelWriter, state: Mapping[str, Any]) -> None:
+    params = state.get("parameters") or state.get("parametros") or {}
+    rows = []
+    if isinstance(params, Mapping):
+        for key, value in params.items():
+            if isinstance(value, Mapping):
+                rows.append(
+                    {
+                        "Parametro": key,
+                        "Valor": value.get("value", value.get("valor")),
+                        "Unidade": value.get("units", value.get("unidade")),
+                    }
+                )
+            else:
+                rows.append({"Parametro": key, "Valor": value, "Unidade": None})
+    for scalar_key in ("speed", "rotor_name", "tag", "case_name"):
+        if scalar_key in state and not any(r["Parametro"] == scalar_key for r in rows):
+            rows.append(
+                {"Parametro": scalar_key, "Valor": state[scalar_key], "Unidade": None}
+            )
+    df = pd.DataFrame(rows or [{"Parametro": None, "Valor": None, "Unidade": None}])
+    df.to_excel(writer, sheet_name=SHEET_PARAMETROS, index=False)
+
+
+def _coerce_points(points: Any) -> list[dict[str, Any]]:
+    """Normalise the many shapes a session may hold for points."""
+    if points is None:
+        return []
+    if isinstance(points, Mapping):
+        if all(isinstance(v, Mapping) for v in points.values()):
+            return [{"Nome": k, **dict(v)} for k, v in points.items()]
+        return [dict(points)]
+    if isinstance(points, Iterable):
+        out = []
+        for item in points:
+            if isinstance(item, Mapping):
+                out.append(dict(item))
+        return out
+    return []
+
+
+def _write_points_sheet(
+    writer: pd.ExcelWriter, sheet: str, rows: list[dict[str, Any]]
+) -> None:
+    df = pd.DataFrame(rows) if rows else pd.DataFrame([{"Ponto": None}])
+    df.to_excel(writer, sheet_name=sheet, index=False)
+
+
+def _write_results_sheet(writer: pd.ExcelWriter, state: Mapping[str, Any]) -> None:
+    results = state.get("results") or state.get("resultados")
+    if isinstance(results, pd.DataFrame):
+        df = results
+    elif isinstance(results, Mapping):
+        df = pd.DataFrame(results)
+    elif isinstance(results, list):
+        df = pd.DataFrame(results)
+    else:
+        df = pd.DataFrame([{"Resultado": None}])
+    df.to_excel(writer, sheet_name=SHEET_RESULTADOS, index=False)
+
+
+def _write_plots_sheet(writer: pd.ExcelWriter, state: Mapping[str, Any]) -> None:
+    plots = state.get("plots") or state.get("graficos") or {}
+    rows = []
+    if isinstance(plots, Mapping):
+        for name, payload in plots.items():
+            rows.append(
+                {
+                    "Grafico": name,
+                    "Tipo": type(payload).__name__,
+                    "Tamanho (bytes)": len(payload)
+                    if hasattr(payload, "__len__")
+                    else None,
+                }
+            )
+    df = pd.DataFrame(rows) if rows else pd.DataFrame([{"Grafico": None}])
+    df.to_excel(writer, sheet_name=SHEET_GRAFICOS, index=False)

--- a/ccp/app/django-app/apps/core/tests/conftest.py
+++ b/ccp/app/django-app/apps/core/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Pytest bootstrap for Unit 12 tests.
+
+Ensures the Unit 12 local scaffold settings are loaded before Django
+imports are executed. Unit 1 will replace these settings at merge time.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import django
+
+
+def pytest_configure(config):
+    root = Path(__file__).resolve().parents[3]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ccp_web.settings")
+    django.setup()

--- a/ccp/app/django-app/apps/core/tests/test_file_upload.py
+++ b/ccp/app/django-app/apps/core/tests/test_file_upload.py
@@ -1,0 +1,111 @@
+"""Tests for the core upload/download HTTP views."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import openpyxl
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import Client, override_settings
+from django.urls import reverse
+
+EXAMPLE_CCP = Path(__file__).resolve().parents[4] / "example_straight.ccp"
+
+
+@pytest.fixture()
+def client() -> Client:
+    return Client()
+
+
+def test_example_ccp_file_exists():
+    assert EXAMPLE_CCP.exists(), f"fixture missing: {EXAMPLE_CCP}"
+
+
+def test_upload_ccp_returns_session_id(client):
+    payload = EXAMPLE_CCP.read_bytes()
+    upload = SimpleUploadedFile(
+        "example_straight.ccp", payload, content_type="application/zip"
+    )
+    resp = client.post(reverse("core:upload-ccp"), {"file": upload})
+    assert resp.status_code == 200, resp.content
+    data = resp.json()
+    assert "session_id" in data
+    assert data["name"] == "example_straight.ccp"
+    assert isinstance(data["keys"], list)
+
+
+def test_upload_ccp_missing_file_returns_400(client):
+    resp = client.post(reverse("core:upload-ccp"))
+    assert resp.status_code == 400
+    assert "missing" in resp.json()["error"]
+
+
+@override_settings(CCP_MAX_UPLOAD_SIZE=16)
+def test_upload_ccp_rejects_oversize(client):
+    upload = SimpleUploadedFile(
+        "too_big.ccp", b"x" * 1024, content_type="application/zip"
+    )
+    resp = client.post(reverse("core:upload-ccp"), {"file": upload})
+    assert resp.status_code == 413
+
+
+def test_upload_csv_echoes_content(client):
+    upload = SimpleUploadedFile(
+        "curve.csv", b"x,y\n1,2\n3,4\n", content_type="text/csv"
+    )
+    resp = client.post(reverse("core:upload-csv"), {"file": upload})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "x,y" in data["content"]
+    assert data["name"] == "curve.csv"
+
+
+def test_upload_curve_png_round_trip(client):
+    fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+    upload = SimpleUploadedFile("head.png", fake_png, content_type="image/png")
+    resp = client.post(
+        reverse("core:upload-curve-png"),
+        {"file": upload, "key": "head"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["key"] == "head"
+    assert data["bytes"] == len(fake_png)
+    assert "session_id" in data
+
+
+def test_download_ccp_round_trip(client):
+    payload = EXAMPLE_CCP.read_bytes()
+    upload = SimpleUploadedFile(
+        "example_straight.ccp", payload, content_type="application/zip"
+    )
+    upload_resp = client.post(reverse("core:upload-ccp"), {"file": upload})
+    session_id = upload_resp.json()["session_id"]
+
+    resp = client.get(reverse("core:download-ccp", args=[session_id]))
+    assert resp.status_code == 200
+    assert resp["Content-Type"] == "application/zip"
+    assert b"PK" in resp.content[:4]
+    assert ".ccp" in resp["Content-Disposition"]
+
+
+def test_download_excel_round_trip(client):
+    payload = EXAMPLE_CCP.read_bytes()
+    upload = SimpleUploadedFile(
+        "example_straight.ccp", payload, content_type="application/zip"
+    )
+    upload_resp = client.post(reverse("core:upload-ccp"), {"file": upload})
+    session_id = upload_resp.json()["session_id"]
+
+    resp = client.get(reverse("core:download-excel", args=[session_id]))
+    assert resp.status_code == 200
+    assert "spreadsheetml" in resp["Content-Type"]
+    wb = openpyxl.load_workbook(io.BytesIO(resp.content))
+    assert "Parametros" in wb.sheetnames
+
+
+def test_download_ccp_unknown_session_404(client):
+    resp = client.get(reverse("core:download-ccp", args=["does-not-exist"]))
+    assert resp.status_code == 404

--- a/ccp/app/django-app/apps/core/tests/test_to_excel.py
+++ b/ccp/app/django-app/apps/core/tests/test_to_excel.py
@@ -1,0 +1,83 @@
+"""Tests for :mod:`apps.core.exports.to_excel`."""
+
+from __future__ import annotations
+
+import io
+
+import openpyxl
+import pytest
+
+from apps.core.exports.to_excel import (
+    SHEET_GARANTIA,
+    SHEET_GRAFICOS,
+    SHEET_PARAMETROS,
+    SHEET_RESULTADOS,
+    SHEET_TESTE,
+    session_to_excel,
+)
+
+
+@pytest.fixture()
+def sample_state() -> dict:
+    return {
+        "parameters": {
+            "speed": {"value": 12000, "units": "rpm"},
+            "rotor_name": {"value": "R1", "units": None},
+        },
+        "guarantee_point": {
+            "flow_m": 15.0,
+            "ps": 1.0,
+            "Ts": 300.0,
+            "pd": 3.0,
+            "Td": 420.0,
+        },
+        "test_points": [
+            {"Nome": "T1", "flow_m": 14.0, "ps": 1.0, "Ts": 300.0},
+            {"Nome": "T2", "flow_m": 16.0, "ps": 1.0, "Ts": 300.0},
+        ],
+        "results": [
+            {"Ponto": "T1", "Eficiencia": 0.82, "Head": 50.0},
+            {"Ponto": "T2", "Eficiencia": 0.80, "Head": 48.5},
+        ],
+        "plots": {"head": b"PNGFAKE", "eff": b"PNGFAKE2"},
+    }
+
+
+def test_session_to_excel_returns_bytes(sample_state):
+    payload = session_to_excel(sample_state)
+    assert isinstance(payload, bytes)
+    assert payload.startswith(b"PK")  # ZIP magic — xlsx is a zip container.
+
+
+def test_session_to_excel_sheets_present(sample_state):
+    payload = session_to_excel(sample_state)
+    wb = openpyxl.load_workbook(io.BytesIO(payload))
+    names = set(wb.sheetnames)
+    assert {
+        SHEET_PARAMETROS,
+        SHEET_GARANTIA,
+        SHEET_TESTE,
+        SHEET_RESULTADOS,
+        SHEET_GRAFICOS,
+    } <= names
+
+
+def test_session_to_excel_preserves_portuguese_columns(sample_state):
+    payload = session_to_excel(sample_state)
+    wb = openpyxl.load_workbook(io.BytesIO(payload))
+    params = wb[SHEET_PARAMETROS]
+    header_row = [cell.value for cell in next(params.iter_rows(min_row=1, max_row=1))]
+    assert "Parametro" in header_row
+    assert "Valor" in header_row
+    assert "Unidade" in header_row
+
+    plots = wb[SHEET_GRAFICOS]
+    plot_header = [cell.value for cell in next(plots.iter_rows(min_row=1, max_row=1))]
+    assert "Grafico" in plot_header
+
+
+def test_session_to_excel_empty_state():
+    payload = session_to_excel({})
+    wb = openpyxl.load_workbook(io.BytesIO(payload))
+    assert SHEET_PARAMETROS in wb.sheetnames
+    assert SHEET_RESULTADOS in wb.sheetnames

--- a/ccp/app/django-app/apps/core/urls.py
+++ b/ccp/app/django-app/apps/core/urls.py
@@ -1,0 +1,23 @@
+"""URL routes for ``apps.core`` (mounted under ``/core/`` by Unit 1)."""
+
+from django.urls import path
+
+from apps.core.views import file_download, file_upload
+
+app_name = "core"
+
+urlpatterns = [
+    path("upload/ccp/", file_upload.upload_ccp, name="upload-ccp"),
+    path("upload/csv/", file_upload.upload_csv, name="upload-csv"),
+    path("upload/curve-png/", file_upload.upload_curve_png, name="upload-curve-png"),
+    path(
+        "download/ccp/<str:session_id>/",
+        file_download.download_ccp,
+        name="download-ccp",
+    ),
+    path(
+        "download/excel/<str:session_id>/",
+        file_download.download_excel,
+        name="download-excel",
+    ),
+]

--- a/ccp/app/django-app/apps/core/views/__init__.py
+++ b/ccp/app/django-app/apps/core/views/__init__.py
@@ -1,0 +1,5 @@
+"""Core HTTP views for uploads, downloads and exports."""
+
+from apps.core.views import file_download, file_upload
+
+__all__ = ["file_download", "file_upload"]

--- a/ccp/app/django-app/apps/core/views/file_download.py
+++ b/ccp/app/django-app/apps/core/views/file_download.py
@@ -1,0 +1,56 @@
+"""File download endpoints."""
+
+from __future__ import annotations
+
+from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.views.decorators.http import require_GET
+
+from apps.core.exports.to_excel import session_to_excel
+
+try:  # pragma: no cover - real module provided by Unit 3 at merge time
+    from apps.core.storage.ccp_file_exporter import export_ccp_file
+except ImportError:  # pragma: no cover
+    from apps.core._stubs.ccp_file_exporter import export_ccp_file
+
+try:  # pragma: no cover
+    from apps.core.session_store import get_session
+except ImportError:  # pragma: no cover
+    from apps.core._stubs.session_store import get_session
+
+
+def _load_state(session_id: str) -> dict | None:
+    state = get_session(session_id)
+    return state or None
+
+
+@require_GET
+def download_ccp(request: HttpRequest, session_id: str) -> HttpResponse:
+    """Return the session state packaged as a ``.ccp`` archive."""
+    state = _load_state(session_id)
+    if state is None:
+        return JsonResponse({"error": "unknown session"}, status=404)
+    payload = export_ccp_file(state)
+    response = HttpResponse(payload, content_type="application/zip")
+    name = state.get("name") or f"{session_id}.ccp"
+    if not name.endswith(".ccp"):
+        name = f"{name}.ccp"
+    response["Content-Disposition"] = f'attachment; filename="{name}"'
+    return response
+
+
+@require_GET
+def download_excel(request: HttpRequest, session_id: str) -> HttpResponse:
+    """Return the session state as an ``.xlsx`` workbook."""
+    state = _load_state(session_id)
+    if state is None:
+        return JsonResponse({"error": "unknown session"}, status=404)
+    payload = session_to_excel(state)
+    response = HttpResponse(
+        payload,
+        content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )
+    base = state.get("name") or session_id
+    if base.endswith(".ccp"):
+        base = base[:-4]
+    response["Content-Disposition"] = f'attachment; filename="{base}.xlsx"'
+    return response

--- a/ccp/app/django-app/apps/core/views/file_upload.py
+++ b/ccp/app/django-app/apps/core/views/file_upload.py
@@ -1,0 +1,173 @@
+"""File upload endpoints.
+
+Replaces the Streamlit ``st.file_uploader`` calls scattered across the
+original app with Django views that accept multipart POSTs, push payloads
+through the shared ``apps.core.storage`` / ``apps.core.session_store``
+layer, and return JSON so HTMX/Alpine front-ends can react.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+from django.conf import settings
+from django.http import HttpRequest, JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+
+try:  # pragma: no cover - real module provided by Unit 3 at merge time
+    from apps.core.storage.ccp_file_importer import load_ccp_file
+except ImportError:  # pragma: no cover
+    from apps.core._stubs.ccp_file_importer import load_ccp_file
+
+try:  # pragma: no cover
+    from apps.core.session_store import (
+        get_session,
+        new_session_id,
+        set_session,
+    )
+except ImportError:  # pragma: no cover
+    from apps.core._stubs.session_store import (
+        get_session,
+        new_session_id,
+        set_session,
+    )
+
+
+_DEFAULT_MAX_UPLOAD_SIZE = 200 * 1024 * 1024  # 200 MB, matching Streamlit.
+
+
+def _max_upload_size() -> int:
+    return int(getattr(settings, "CCP_MAX_UPLOAD_SIZE", _DEFAULT_MAX_UPLOAD_SIZE))
+
+
+def _too_large(request: HttpRequest) -> JsonResponse | None:
+    limit = _max_upload_size()
+    length = request.META.get("CONTENT_LENGTH")
+    if length:
+        try:
+            if int(length) > limit:
+                return JsonResponse(
+                    {"error": "file too large", "limit": limit},
+                    status=413,
+                )
+        except ValueError:
+            pass
+    return None
+
+
+def _require_file(
+    request: HttpRequest, field: str = "file"
+) -> tuple[Any | None, JsonResponse | None]:
+    too_big = _too_large(request)
+    if too_big is not None:
+        return None, too_big
+    upload = request.FILES.get(field)
+    if upload is None:
+        return None, JsonResponse(
+            {"error": f"missing file field '{field}'"}, status=400
+        )
+    if upload.size > _max_upload_size():
+        return None, JsonResponse(
+            {"error": "file too large", "limit": _max_upload_size()},
+            status=413,
+        )
+    return upload, None
+
+
+@csrf_exempt
+@require_POST
+def upload_ccp(request: HttpRequest) -> JsonResponse:
+    """Accept a ``.ccp`` archive and persist it as a new session.
+
+    Returns
+    -------
+    JsonResponse
+        ``{"session_id": str, "keys": [..]}`` on success.
+    """
+    upload, err = _require_file(request)
+    if err is not None:
+        return err
+    try:
+        state = load_ccp_file(upload)
+    except Exception as exc:  # pragma: no cover - defensive
+        return JsonResponse({"error": f"invalid .ccp file: {exc}"}, status=400)
+
+    session_id = new_session_id()
+    state.setdefault("name", upload.name)
+    set_session(session_id, state)
+    return JsonResponse(
+        {
+            "session_id": session_id,
+            "name": upload.name,
+            "keys": sorted(k for k in state.keys() if isinstance(k, str)),
+        }
+    )
+
+
+@csrf_exempt
+@require_POST
+def upload_csv(request: HttpRequest) -> JsonResponse:
+    """Accept an engauge CSV export and return its parsed text.
+
+    The real parsing lives in Unit 7's curves-conversion services; this
+    endpoint simply decodes the upload, stashes it on an optional
+    session, and echoes it back so the caller can display a preview.
+    """
+    upload, err = _require_file(request)
+    if err is not None:
+        return err
+    try:
+        text = upload.read().decode("utf-8-sig")
+    except UnicodeDecodeError:
+        return JsonResponse({"error": "csv must be utf-8"}, status=400)
+
+    session_id = request.POST.get("session_id")
+    if session_id:
+        state = get_session(session_id)
+        state.setdefault("engauge_csvs", {})[upload.name] = text
+        set_session(session_id, state)
+
+    return JsonResponse(
+        {
+            "name": upload.name,
+            "bytes": upload.size,
+            "content": text,
+            "session_id": session_id,
+        }
+    )
+
+
+@csrf_exempt
+@require_POST
+def upload_curve_png(request: HttpRequest) -> JsonResponse:
+    """Accept a PNG image of a curve and store it on the session state.
+
+    Parameters
+    ----------
+    request : HttpRequest
+        The POST must carry a ``file`` field (the PNG) and a
+        ``session_id`` form field identifying the target session. An
+        optional ``key`` field selects the session-state slot;
+        otherwise the file name is used.
+    """
+    upload, err = _require_file(request)
+    if err is not None:
+        return err
+    session_id = request.POST.get("session_id") or new_session_id()
+    key = request.POST.get("key") or upload.name
+    payload = upload.read()
+
+    state = get_session(session_id)
+    state.setdefault("curve_pngs", {})[key] = base64.b64encode(payload).decode("ascii")
+    set_session(session_id, state)
+
+    return JsonResponse(
+        {
+            "session_id": session_id,
+            "key": key,
+            "bytes": len(payload),
+            "url": f"/core/download/curve-png/{session_id}/{key}/",
+        }
+    )

--- a/ccp/app/django-app/ccp_web/__init__.py
+++ b/ccp/app/django-app/ccp_web/__init__.py
@@ -1,0 +1,1 @@
+# STUB: replaced by Unit 1 at merge time.

--- a/ccp/app/django-app/ccp_web/settings.py
+++ b/ccp/app/django-app/ccp_web/settings.py
@@ -1,0 +1,48 @@
+"""Minimal Django settings for Unit 12 local verification.
+
+# STUB: replaced by Unit 1 at merge time with full MongoEngine + Redis config.
+"""
+
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = "unit12-dev-secret-not-for-production"
+DEBUG = True
+ALLOWED_HOSTS = ["*"]
+
+INSTALLED_APPS = [
+    "django.contrib.contenttypes",
+    "django.contrib.auth",
+    "apps.core",
+]
+
+MIDDLEWARE = [
+    "django.middleware.common.CommonMiddleware",
+]
+
+ROOT_URLCONF = "ccp_web.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {"context_processors": []},
+    },
+]
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+USE_TZ = True
+
+# Max upload size (bytes) mirroring Streamlit's default of 200 MB.
+CCP_MAX_UPLOAD_SIZE = 200 * 1024 * 1024
+DATA_UPLOAD_MAX_MEMORY_SIZE = CCP_MAX_UPLOAD_SIZE
+FILE_UPLOAD_MAX_MEMORY_SIZE = CCP_MAX_UPLOAD_SIZE

--- a/ccp/app/django-app/ccp_web/urls.py
+++ b/ccp/app/django-app/ccp_web/urls.py
@@ -1,0 +1,10 @@
+"""Root URLconf for Unit 12 local scaffold.
+
+# STUB: replaced by Unit 1 at merge time.
+"""
+
+from django.urls import include, path
+
+urlpatterns = [
+    path("core/", include("apps.core.urls")),
+]

--- a/ccp/app/django-app/manage.py
+++ b/ccp/app/django-app/manage.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+"""Django management entry point (Unit 12 local scaffold).
+
+# STUB: replaced by Unit 1 at merge time.
+"""
+
+import os
+import sys
+
+
+def main():
+    """Run administrative tasks."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ccp_web.settings")
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Bootstraps `ccp/app/django-app/` with the Unit 12 deliverables from the Streamlit → Django migration plan.
- Adds `apps/core/exports/to_excel.session_to_excel(state)` producing a multi-sheet xlsx with Portuguese sheet names (Parametros, Ponto de Garantia, Pontos de Teste, Resultados, Graficos). Prefers `xlsxwriter`, falls back to `openpyxl`.
- Adds `apps/core/views/file_upload.py` (`.ccp`, engauge CSV, curve PNG) and `apps/core/views/file_download.py` (`.ccp`, `.xlsx`), wired through `apps/core/urls.py` under `/core/`.
- Enforces `CCP_MAX_UPLOAD_SIZE` (default 200 MB to match the Streamlit upload limit) via `Content-Length` and per-file checks.
- Cross-unit dependencies (`apps.core.storage`, `apps.core.session_store`, `apps.core.models`) are stubbed locally under `apps/core/_stubs/` and loaded via `try/except ImportError` so Units 1 and 3 can replace them cleanly at merge time.
- Ships a minimal `ccp_web/` scaffold (settings, urls, manage.py) so `manage.py check` and pytest can run in isolation — these files are marked `# STUB` and will be overwritten by Unit 1.

## Test plan
- [x] `uv run python manage.py check` — passes with no issues.
- [x] `uv run pytest apps/core/tests/` — 13 tests pass (Excel round-trip + upload/download views using `example_straight.ccp`).
- [x] End-to-end: `curl -F "file=@ccp/app/example_straight.ccp" http://127.0.0.1:8000/core/upload/ccp/` returns HTTP 200 with a JSON body containing `session_id` and the decoded state keys.