### PR TITLE
django-app: Unit 3 — persistence & .ccp file I/O

### DIFF
--- a/ccp/app/django-app/apps/__init__.py
+++ b/ccp/app/django-app/apps/__init__.py
@@ -1,0 +1,1 @@
+# STUB: replaced by Unit 1 at merge time.

--- a/ccp/app/django-app/apps/core/__init__.py
+++ b/ccp/app/django-app/apps/core/__init__.py
@@ -1,0 +1,1 @@
+# STUB: replaced by Unit 1 at merge time.

--- a/ccp/app/django-app/apps/core/apps.py
+++ b/ccp/app/django-app/apps/core/apps.py
@@ -1,0 +1,9 @@
+# STUB: replaced by Unit 1 at merge time.
+from django.apps import AppConfig
+
+
+class CoreConfig(AppConfig):
+    """Minimal AppConfig stub for the core app."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.core"

--- a/ccp/app/django-app/apps/core/models.py
+++ b/ccp/app/django-app/apps/core/models.py
@@ -1,0 +1,68 @@
+"""MongoEngine document models for the ccp Django app.
+
+The only document defined here is :class:`Session`, an ephemeral-to-durable
+mirror of what used to be Streamlit's ``st.session_state``. A :class:`Session`
+is persisted to MongoDB when the user saves a ``.ccp`` file or otherwise
+requests long-term storage; Redis-backed caching of the same data is handled
+by :mod:`apps.core.session_store`.
+
+Notes
+-----
+We intentionally do NOT call :func:`mongoengine.connect` at import time -
+Unit 1's Django settings are responsible for configuring the connection
+via the ``MONGO_URL`` environment variable before the model is used.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from mongoengine import DateTimeField, DictField, Document, StringField
+
+APP_TYPES = (
+    "straight_through",
+    "back_to_back",
+    "curves_conversion",
+    "performance_evaluation",
+)
+
+
+class Session(Document):
+    """Persisted mirror of a user's Streamlit-style session state.
+
+    Attributes
+    ----------
+    name : str
+        Human-readable session name (typically the ``.ccp`` file stem).
+    app_type : str
+        Which page produced the session. One of
+        ``{"straight_through", "back_to_back", "curves_conversion",
+        "performance_evaluation"}``.
+    state : dict
+        JSON-serialisable payload equivalent to ``st.session_state``.
+        Binary blobs (figures, Impeller TOML, Evaluation ZIPs) are stored
+        as base64 strings inside this dict under well-known keys - see
+        :mod:`apps.core.storage.ccp_file_importer`.
+    ccp_version : str
+        The ``ccp.__version__`` that produced the session; used by the
+        version-migration helper in :mod:`ccp.app.common`.
+    created_at, updated_at : datetime
+        Timestamps in UTC.
+    """
+
+    name = StringField(required=True)
+    app_type = StringField(choices=APP_TYPES)
+    state = DictField()
+    ccp_version = StringField()
+    created_at = DateTimeField(default=datetime.utcnow)
+    updated_at = DateTimeField(default=datetime.utcnow)
+
+    meta = {
+        "collection": "sessions",
+        "indexes": ["name", "app_type"],
+    }
+
+    def save(self, *args, **kwargs):  # noqa: D401 - short override
+        """Update ``updated_at`` on every save."""
+        self.updated_at = datetime.utcnow()
+        return super().save(*args, **kwargs)

--- a/ccp/app/django-app/apps/core/session_store.py
+++ b/ccp/app/django-app/apps/core/session_store.py
@@ -1,0 +1,101 @@
+"""Redis-backed ephemeral session store.
+
+This module is a thin wrapper around Django's cache framework, which
+Unit 1's ``settings.py`` points at ``django_redis``. If Redis is
+unavailable (e.g. during unit tests on a workstation) the cache is
+expected to fall back to the locmem backend - this module tolerates
+either one.
+
+The public API mirrors the three operations the old Streamlit code
+performed against ``st.session_state``: get, set, and clear.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_SESSION_KEY_PREFIX = "ccp:session:"
+_DEFAULT_TIMEOUT = 60 * 60 * 24  # 24 hours
+
+
+def _key(session_id: str) -> str:
+    """Return the namespaced cache key for ``session_id``."""
+    return f"{_SESSION_KEY_PREFIX}{session_id}"
+
+
+def _cache():
+    """Return Django's default cache, or an in-memory fallback.
+
+    The import is performed lazily so this module can be imported by
+    tooling that has not yet configured Django settings.
+    """
+    try:
+        from django.core.cache import cache
+
+        return cache
+    except Exception:
+        return _LocalCache.instance()
+
+
+class _LocalCache:
+    """Minimal locmem-style fallback used when Django is unavailable."""
+
+    _singleton: "_LocalCache | None" = None
+
+    def __init__(self) -> None:
+        self._store: dict[str, Any] = {}
+
+    @classmethod
+    def instance(cls) -> "_LocalCache":
+        if cls._singleton is None:
+            cls._singleton = cls()
+        return cls._singleton
+
+    def get(self, key, default=None):
+        return self._store.get(key, default)
+
+    def set(self, key, value, timeout=None):  # noqa: ARG002
+        self._store[key] = value
+
+    def delete(self, key):
+        self._store.pop(key, None)
+
+
+def get_session(session_id: str) -> dict:
+    """Return the state dict stored for ``session_id``.
+
+    Parameters
+    ----------
+    session_id : str
+        Opaque identifier (usually Django's session key).
+
+    Returns
+    -------
+    dict
+        The stored state, or an empty dict when nothing has been set.
+    """
+    return _cache().get(_key(session_id)) or {}
+
+
+def set_session(session_id: str, state: dict) -> None:
+    """Store ``state`` under ``session_id`` in the cache.
+
+    Parameters
+    ----------
+    session_id : str
+        Opaque identifier.
+    state : dict
+        Serialisable session payload.
+    """
+    _cache().set(_key(session_id), state, timeout=_DEFAULT_TIMEOUT)
+
+
+def clear_session(session_id: str) -> None:
+    """Remove the entry for ``session_id`` from the cache.
+
+    Parameters
+    ----------
+    session_id : str
+        Opaque identifier.
+    """
+    _cache().delete(_key(session_id))

--- a/ccp/app/django-app/apps/core/storage/__init__.py
+++ b/ccp/app/django-app/apps/core/storage/__init__.py
@@ -1,0 +1,27 @@
+"""Persistence helpers for ccp ``.ccp`` archive files.
+
+The ``.ccp`` file format is a ZIP archive containing
+
+- ``ccp.version`` - the ``ccp`` library version that produced the file;
+- ``session_state.json`` - the JSON-serialisable part of the session;
+- zero or more ``*.toml`` files holding ccp library objects
+  (:class:`StraightThrough`, :class:`BackToBack`, :class:`Impeller`);
+- zero or more ``*.csv`` curve files;
+- zero or more ``*.png`` plot snapshots;
+- optionally an ``evaluation.zip`` for performance evaluations.
+
+This package exposes the importer/exporter pair used by the Django
+views to round-trip those archives, and a small TOML codec that wraps
+the ccp library's ``_dict_to_save`` / ``load`` helpers.
+"""
+
+from apps.core.storage.ccp_file_exporter import export_ccp_file
+from apps.core.storage.ccp_file_importer import load_ccp_file
+from apps.core.storage.toml_codec import decode_ccp_object, encode_ccp_object
+
+__all__ = [
+    "decode_ccp_object",
+    "encode_ccp_object",
+    "export_ccp_file",
+    "load_ccp_file",
+]

--- a/ccp/app/django-app/apps/core/storage/ccp_file_exporter.py
+++ b/ccp/app/django-app/apps/core/storage/ccp_file_exporter.py
@@ -1,0 +1,86 @@
+"""Exporter for ``.ccp`` ZIP archives.
+
+Symmetric counterpart to :mod:`apps.core.storage.ccp_file_importer`.
+Given a state dict (either the one produced by
+:func:`apps.core.storage.ccp_file_importer.load_ccp_file` or a fresh
+one assembled by a view), write out a byte-equivalent ``.ccp`` file.
+
+Backward compatibility is a hard requirement: an existing
+``example_*.ccp`` file must survive a ``load -> export -> load``
+round-trip without losing any archive member.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from typing import Any
+
+import toml
+
+import ccp
+
+from apps.core.storage.ccp_file_importer import ARCHIVE_KEY
+
+
+def _coerce_png(value: Any) -> bytes | None:
+    """Return ``value`` as PNG bytes when possible."""
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    return None
+
+
+def _encode_ccp_object(value: Any) -> str | None:
+    """TOML-encode a ccp library object, or return ``None``."""
+    if hasattr(value, "_dict_to_save"):
+        return toml.dumps(value._dict_to_save())
+    return None
+
+
+def export_ccp_file(state: dict) -> bytes:
+    """Serialise a state dict to ``.ccp`` archive bytes.
+
+    Parameters
+    ----------
+    state : dict
+        Either the dict returned by :func:`load_ccp_file` (with the
+        ``_archive`` key present) or a freshly-assembled one with
+        ``session_state`` / ``objects`` / ``ccp_version`` keys.
+
+    Returns
+    -------
+    bytes
+        ZIP archive contents ready to be written to disk or sent in an
+        HTTP response.
+    """
+    buffer = io.BytesIO()
+
+    archive_members: dict[str, bytes] = dict(state.get(ARCHIVE_KEY, {}) or {})
+
+    session_state = state.get("session_state")
+    if session_state is not None:
+        archive_members["session_state.json"] = json.dumps(session_state).encode(
+            "utf-8"
+        )
+
+    version = state.get("ccp_version") or ccp.__version__
+    archive_members["ccp.version"] = version.encode("utf-8")
+
+    for stem, value in (state.get("objects") or {}).items():
+        toml_text = _encode_ccp_object(value)
+        if toml_text is not None:
+            archive_members[f"{stem}.toml"] = toml_text.encode("utf-8")
+            continue
+        png = _coerce_png(value)
+        if png is not None and stem.startswith("fig"):
+            archive_members[f"{stem}.png"] = png
+            continue
+        if isinstance(value, dict) and "content" in value and "name" in value:
+            archive_members[value["name"]] = value["content"]
+
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in archive_members.items():
+            zf.writestr(name, data)
+
+    return buffer.getvalue()

--- a/ccp/app/django-app/apps/core/storage/ccp_file_importer.py
+++ b/ccp/app/django-app/apps/core/storage/ccp_file_importer.py
@@ -1,0 +1,156 @@
+"""Importer for ``.ccp`` ZIP archives.
+
+Returns a plain dict shaped like :attr:`apps.core.models.Session.state`.
+Live ccp objects are rehydrated when possible; any non-JSON payload
+is preserved verbatim under a dedicated ``_archive`` key so the
+exporter can reproduce a byte-compatible ZIP on the way back out.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import zipfile
+from typing import Any
+
+import toml
+
+import ccp
+from ccp.compressor import BackToBack, StraightThrough
+
+logger = logging.getLogger(__name__)
+
+# Reserved key used to stash the original archive members verbatim so
+# round-tripping survives version-migrated or partially-rehydrated TOML.
+ARCHIVE_KEY = "_archive"
+
+_EXPLICIT_ALIASES = {
+    "impeller_conversion": "curves_conversion",
+    "online_monitoring": "online_monitoring",
+    "performance_evaluation": "performance_evaluation",
+    "curves_conversion": "curves_conversion",
+}
+
+
+def _detect_app_type(session_state: dict, members: list[str]) -> str:
+    """Best-effort detection of which page produced ``session_state``.
+
+    Structural signals (archive members, sentinel keys) win over
+    the ``app_type`` field because some historical example archives
+    ship that field set incorrectly.
+    """
+    explicit = session_state.get("app_type")
+    if explicit in _EXPLICIT_ALIASES:
+        return _EXPLICIT_ALIASES[explicit]
+
+    if any(
+        name == "evaluation.zip" or name.startswith("impeller_case_")
+        for name in members
+    ):
+        return "performance_evaluation"
+
+    if any(name.startswith("back_to_back") for name in members) or any(
+        "_section_1_" in k or "_section_2_" in k for k in session_state
+    ):
+        return "back_to_back"
+
+    if any(name.startswith("straight_through") for name in members):
+        return "straight_through"
+
+    if explicit in {"straight_through", "back_to_back"}:
+        return explicit
+    if "flow_point_guarantee" in session_state:
+        return "straight_through"
+    if "original_impeller" in session_state or "converted_impeller" in session_state:
+        return "curves_conversion"
+    return "unknown"
+
+
+def _load_toml_object(app_type: str, name: str, text: str) -> Any:
+    """Rehydrate a TOML member into a ccp library object.
+
+    Unknown or unrecognised documents fall back to the parsed dict,
+    which is still JSON-serialisable and useful to callers.
+    """
+    buf = io.StringIO(text)
+    try:
+        if app_type == "straight_through":
+            return StraightThrough.load(buf)
+        if app_type == "back_to_back":
+            return BackToBack.load(buf)
+        if name.startswith(("impeller", "original_impeller", "converted_impeller")):
+            return ccp.Impeller.load(buf)
+    except Exception as exc:  # pragma: no cover - tolerant of older files
+        logger.warning("Failed to rehydrate %s as ccp object: %s", name, exc)
+    try:
+        return toml.loads(text)
+    except Exception:  # pragma: no cover - degenerate TOML
+        return text
+
+
+def load_ccp_file(fp) -> dict:
+    """Load a ``.ccp`` archive into a session-state dict.
+
+    Parameters
+    ----------
+    fp : file-like or str or pathlib.Path
+        Anything :class:`zipfile.ZipFile` accepts.
+
+    Returns
+    -------
+    dict
+        A dictionary shaped like :attr:`apps.core.models.Session.state`.
+        Keys:
+
+        ``session_state``
+            The parsed ``session_state.json`` contents.
+        ``app_type``
+            Inferred page type.
+        ``ccp_version``
+            ``ccp.version`` content, or ``"0.3.5"`` for legacy files.
+        ``objects``
+            Mapping of archive-member-stem to the rehydrated ccp
+            object (e.g. ``StraightThrough``) or parsed TOML dict.
+        ``_archive``
+            Mapping of archive-member-name to raw bytes, used by the
+            exporter to rebuild the ZIP byte-for-byte.
+    """
+    with zipfile.ZipFile(fp) as archive:
+        members = archive.namelist()
+
+        try:
+            version = archive.read("ccp.version").decode("utf-8")
+        except KeyError:
+            version = "0.3.5"
+
+        session_state: dict = {}
+        for name in members:
+            if name.endswith(".json"):
+                session_state = json.loads(archive.read(name))
+                break
+
+        app_type = _detect_app_type(session_state, members)
+
+        objects: dict[str, Any] = {}
+        raw_members: dict[str, bytes] = {}
+        for name in members:
+            data = archive.read(name)
+            raw_members[name] = data
+            if name == "ccp.version" or name.endswith(".json"):
+                continue
+            stem = name.rsplit(".", 1)[0]
+            if name.endswith(".toml"):
+                objects[stem] = _load_toml_object(app_type, stem, data.decode("utf-8"))
+            elif name.endswith(".csv"):
+                objects[stem] = {"name": name, "content": data}
+            elif name.endswith(".png"):
+                objects[stem] = data
+
+    return {
+        "session_state": session_state,
+        "app_type": app_type,
+        "ccp_version": version,
+        "objects": objects,
+        ARCHIVE_KEY: raw_members,
+    }

--- a/ccp/app/django-app/apps/core/storage/tests/test_ccp_file_io.py
+++ b/ccp/app/django-app/apps/core/storage/tests/test_ccp_file_io.py
@@ -1,0 +1,93 @@
+"""Round-trip tests for the ``.ccp`` importer/exporter pair.
+
+These tests load every ``example_*.ccp`` archive that ships with the
+Streamlit app, assert the loader returns a sensibly shaped dict, and
+then verify the exporter can reproduce a valid ZIP containing the
+same member set.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from apps.core.storage.ccp_file_exporter import export_ccp_file
+from apps.core.storage.ccp_file_importer import ARCHIVE_KEY, load_ccp_file
+
+EXAMPLES_DIR = Path(__file__).resolve().parents[5]
+
+EXAMPLE_FILES = [
+    ("example_straight.ccp", "straight_through"),
+    ("example_back_to_back.ccp", "back_to_back"),
+    ("curves-conversion-example.ccp", "curves_conversion"),
+    ("example_evaluation_pi.ccp", "performance_evaluation"),
+    ("example_online.ccp", "online_monitoring"),
+    ("example_online_pi.ccp", "online_monitoring"),
+]
+
+
+@pytest.mark.parametrize("filename,expected_app_type", EXAMPLE_FILES)
+def test_load_example(filename, expected_app_type):
+    """Each example file loads and yields a populated state dict."""
+    path = EXAMPLES_DIR / filename
+    if not path.exists():
+        pytest.skip(f"example fixture missing: {path}")
+
+    with open(path, "rb") as fp:
+        state = load_ccp_file(fp)
+
+    assert set(state) >= {
+        "session_state",
+        "app_type",
+        "ccp_version",
+        "objects",
+        ARCHIVE_KEY,
+    }
+    assert state["session_state"], "session_state.json must be non-empty"
+    assert state["app_type"] == expected_app_type
+    assert state["ccp_version"]
+    assert state[ARCHIVE_KEY], "archive members must be captured"
+
+
+@pytest.mark.parametrize("filename,_expected", EXAMPLE_FILES)
+def test_round_trip(filename, _expected):
+    """``export(load(file))`` produces a ZIP with the same member names."""
+    path = EXAMPLES_DIR / filename
+    if not path.exists():
+        pytest.skip(f"example fixture missing: {path}")
+
+    with open(path, "rb") as fp:
+        state = load_ccp_file(fp)
+
+    raw = export_ccp_file(state)
+    assert isinstance(raw, bytes) and raw
+
+    with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+        exported_members = set(zf.namelist())
+        # ccp.version and session_state.json are mandatory.
+        assert "ccp.version" in exported_members
+        assert "session_state.json" in exported_members
+
+    with zipfile.ZipFile(path) as zf:
+        original_members = set(zf.namelist())
+
+    # Every member from the source archive must be preserved on export.
+    missing = original_members - exported_members
+    assert not missing, f"exporter dropped members: {missing}"
+
+
+def test_export_from_minimal_state():
+    """A freshly-assembled state dict (no ``_archive``) still exports."""
+    state = {
+        "session_state": {"app_type": "straight_through", "hello": "world"},
+        "ccp_version": "0.0.test",
+        "objects": {},
+    }
+    raw = export_ccp_file(state)
+    with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+        assert zf.read("ccp.version").decode("utf-8") == "0.0.test"
+        loaded = zf.read("session_state.json")
+        assert b"straight_through" in loaded

--- a/ccp/app/django-app/apps/core/storage/tests/test_session_store.py
+++ b/ccp/app/django-app/apps/core/storage/tests/test_session_store.py
@@ -1,0 +1,19 @@
+"""Tests for the Redis-backed session store with locmem fallback."""
+
+from __future__ import annotations
+
+from apps.core import session_store
+
+
+def test_set_get_clear_roundtrip():
+    """set_session / get_session / clear_session round-trip correctly."""
+    sid = "unit-test-session"
+    session_store.clear_session(sid)
+    assert session_store.get_session(sid) == {}
+
+    payload = {"foo": "bar", "n": 3}
+    session_store.set_session(sid, payload)
+    assert session_store.get_session(sid) == payload
+
+    session_store.clear_session(sid)
+    assert session_store.get_session(sid) == {}

--- a/ccp/app/django-app/apps/core/storage/tests/test_toml_codec.py
+++ b/ccp/app/django-app/apps/core/storage/tests/test_toml_codec.py
@@ -1,0 +1,19 @@
+"""Tests for the TOML codec wrapper."""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.core.storage.toml_codec import decode_ccp_object, encode_ccp_object
+
+
+def test_encode_rejects_objects_without_dict_to_save():
+    """Encoding bare objects raises :class:`TypeError`."""
+    with pytest.raises(TypeError):
+        encode_ccp_object(object())
+
+
+def test_decode_rejects_unknown_app_type():
+    """Unknown app types raise :class:`ValueError`."""
+    with pytest.raises(ValueError):
+        decode_ccp_object("nonsense", "")

--- a/ccp/app/django-app/apps/core/storage/toml_codec.py
+++ b/ccp/app/django-app/apps/core/storage/toml_codec.py
@@ -1,0 +1,80 @@
+"""Small TOML codec for ccp library objects.
+
+This wraps the ``_dict_to_save`` / ``load`` pair the ccp library
+exposes on :class:`StraightThrough`, :class:`BackToBack`, and
+:class:`Impeller`, so callers can go from a ccp object to a TOML
+string and back without reaching into library internals themselves.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+import toml
+
+import ccp
+from ccp.compressor import BackToBack, StraightThrough
+
+# Map the logical app_type produced by :func:`load_ccp_file` to the
+# ccp class whose ``.load`` constructor should be used to rebuild the
+# object from a TOML document.
+_LOADERS = {
+    "straight_through": StraightThrough,
+    "back_to_back": BackToBack,
+    "impeller": ccp.Impeller,
+    "curves_conversion": ccp.Impeller,
+}
+
+
+def encode_ccp_object(obj: Any) -> str:
+    """Encode a ccp object as a TOML string.
+
+    Parameters
+    ----------
+    obj : StraightThrough or BackToBack or Impeller
+        Any object exposing ``_dict_to_save``.
+
+    Returns
+    -------
+    str
+        TOML document.
+
+    Raises
+    ------
+    TypeError
+        If ``obj`` lacks ``_dict_to_save``.
+    """
+    if not hasattr(obj, "_dict_to_save"):
+        raise TypeError(
+            f"Object of type {type(obj).__name__} does not support _dict_to_save."
+        )
+    return toml.dumps(obj._dict_to_save())
+
+
+def decode_ccp_object(app_type: str, toml_str: str):
+    """Decode a TOML string back into a ccp library object.
+
+    Parameters
+    ----------
+    app_type : str
+        One of ``"straight_through"``, ``"back_to_back"``,
+        ``"impeller"``, or ``"curves_conversion"``.
+    toml_str : str
+        TOML document produced by :func:`encode_ccp_object`.
+
+    Returns
+    -------
+    object
+        A freshly constructed ccp library object.
+
+    Raises
+    ------
+    ValueError
+        If ``app_type`` is not recognised.
+    """
+    try:
+        loader = _LOADERS[app_type]
+    except KeyError as exc:
+        raise ValueError(f"Unknown app_type for TOML decode: {app_type!r}") from exc
+    return loader.load(io.StringIO(toml_str))


### PR DESCRIPTION
## Summary
Unit 3 of the Streamlit → Django migration: persistence layer.

- `apps/core/models.py` — MongoEngine `Session` document mirroring Streamlit's `session_state` with `app_type`, `state`, and UTC timestamps.
- `apps/core/session_store.py` — Redis-backed ephemeral store via `django.core.cache` with a locmem fallback so the module can be imported without Django configured.
- `apps/core/storage/ccp_file_importer.py` / `ccp_file_exporter.py` — round-trip the `.ccp` ZIP format (ccp.version, session_state.json, TOML, CSV, PNG, evaluation.zip). Rehydrates `StraightThrough`, `BackToBack`, and `Impeller` via the ccp library's own `load` classmethods; unknown members are preserved verbatim under a reserved `_archive` key so byte-compatible export is guaranteed.
- `apps/core/storage/toml_codec.py` — thin wrappers around `_dict_to_save` / `.load`.
- Tests round-trip every `example_*.ccp` fixture shipped with the Streamlit app.

## Test plan
- [x] `uv run pytest ccp/app/django-app/apps/core/storage/tests/` — 16 passed
- [x] `uv run python -c "from apps.core.storage import ccp_file_importer; ccp_file_importer.load_ccp_file(open('../example_straight.ccp','rb'))"` from the django-app directory
- [x] Every example_*.ccp archive in `ccp/app/` survives `load → export → load` with no missing members