### PR TITLE
django-app: Unit 5 — straight-through page

### DIFF
--- a/ccp/app/django-app/apps/straight_through/__init__.py
+++ b/ccp/app/django-app/apps/straight_through/__init__.py
@@ -1,0 +1,1 @@
+"""Django app that ports the Streamlit straight-through compressor page."""

--- a/ccp/app/django-app/apps/straight_through/_stubs/__init__.py
+++ b/ccp/app/django-app/apps/straight_through/_stubs/__init__.py
@@ -1,0 +1,6 @@
+"""Local stand-ins for cross-unit dependencies.
+
+These modules let :mod:`apps.straight_through` import and run in isolation
+while the other migration units are still under development. They are marked
+``# STUB: replaced by Unit N`` and will be superseded at merge time.
+"""

--- a/ccp/app/django-app/apps/straight_through/_stubs/ccp_service.py
+++ b/ccp/app/django-app/apps/straight_through/_stubs/ccp_service.py
@@ -1,0 +1,53 @@
+# STUB: replaced by Unit 2 at merge time
+"""Fallback wrapper around the ``ccp`` compressor helpers.
+
+Only used when :mod:`apps.core.services.ccp_service` is unavailable (i.e. the
+other units have not yet been merged into the worktree). It forwards every
+call directly to the ``ccp`` library.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import ccp
+from ccp.compressor import Point1Sec, StraightThrough
+
+
+Q_ = ccp.Q_
+
+
+def build_gas_state(composition: dict, p: Any, T: Any) -> ccp.State:
+    """Instantiate a :class:`ccp.State` from a composition dict."""
+    return ccp.State(p=p, T=T, fluid=composition)
+
+
+def build_point_1sec(**kwargs: Any) -> Point1Sec:
+    """Construct a :class:`ccp.compressor.Point1Sec` from raw kwargs."""
+    return Point1Sec(**kwargs)
+
+
+def build_guarantee_point(**kwargs: Any) -> ccp.Point:
+    """Construct the guarantee :class:`ccp.Point`."""
+    return ccp.Point(**kwargs)
+
+
+def build_straight_through(
+    guarantee_point: ccp.Point,
+    test_points: list[Point1Sec],
+    *,
+    reynolds_correction: bool = True,
+    bearing_mechanical_losses: bool = False,
+    calculate_speed: bool = False,
+    **_: Any,
+) -> StraightThrough:
+    """Assemble a :class:`ccp.compressor.StraightThrough` instance."""
+    straight = StraightThrough(
+        guarantee_point=guarantee_point,
+        test_points=test_points,
+        reynolds_correction=reynolds_correction,
+        bearing_mechanical_losses=bearing_mechanical_losses,
+    )
+    if calculate_speed:
+        straight = straight.calculate_speed_to_match_discharge_pressure()
+    return straight

--- a/ccp/app/django-app/apps/straight_through/_stubs/ccp_tags.py
+++ b/ccp/app/django-app/apps/straight_through/_stubs/ccp_tags.py
@@ -1,0 +1,39 @@
+# STUB: replaced by Unit 4 at merge time
+"""Local template tag library mirroring the Unit 4 public API."""
+
+from __future__ import annotations
+
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.simple_tag
+def plotly_figure(fig, div_id: str | None = None):
+    """Render a Plotly figure inline without re-embedding ``plotly.js``."""
+    if fig is None or fig == "":
+        return ""
+    try:
+        import plotly.io as pio
+    except ImportError:
+        return ""
+    html = pio.to_html(
+        fig,
+        full_html=False,
+        include_plotlyjs=False,
+        div_id=div_id,
+    )
+    return mark_safe(html)
+
+
+@register.inclusion_tag("straight_through/_expander.html")
+def expander(title: str, body_id: str, expanded: bool = False):
+    """Render a collapsible section header."""
+    return {"title": title, "body_id": body_id, "expanded": expanded}
+
+
+@register.inclusion_tag("straight_through/_parameter_row.html")
+def parameter_row(key: str, value: str, unit_choices: list[str]):
+    """Render a labelled input row with unit selector."""
+    return {"key": key, "value": value, "unit_choices": unit_choices}

--- a/ccp/app/django-app/apps/straight_through/_stubs/gas_composition.py
+++ b/ccp/app/django-app/apps/straight_through/_stubs/gas_composition.py
@@ -1,0 +1,24 @@
+# STUB: replaced by Unit 2 at merge time
+"""Fallback gas-composition helpers."""
+
+from __future__ import annotations
+
+FLUID_LIST: list[str] = [
+    "methane",
+    "ethane",
+    "propane",
+    "n-butane",
+    "i-butane",
+    "n-pentane",
+    "i-pentane",
+    "n-hexane",
+    "nitrogen",
+    "carbon dioxide",
+    "hydrogen sulfide",
+    "water",
+]
+
+
+def default_composition() -> dict[str, float]:
+    """Return a methane-dominant default composition."""
+    return {"methane": 1.0}

--- a/ccp/app/django-app/apps/straight_through/_stubs/runserver.py
+++ b/ccp/app/django-app/apps/straight_through/_stubs/runserver.py
@@ -1,0 +1,66 @@
+# STUB: replaced by Unit 1 at merge time
+"""Stand-alone ``runserver`` entry point used for in-isolation smoke testing.
+
+Usage
+-----
+``uv run python -m apps.straight_through._stubs.runserver 0.0.0.0:8000``
+
+Configures Django with a minimal in-process settings object and mounts
+:mod:`apps.straight_through.urls` under ``/straight-through/``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import django
+from django.conf import settings
+
+
+def main() -> None:
+    """Entry point that configures settings and delegates to ``runserver``."""
+    if not settings.configured:
+        settings.configure(
+            DEBUG=True,
+            SECRET_KEY="dev",
+            ALLOWED_HOSTS=["*"],
+            ROOT_URLCONF="apps.straight_through.tests.urls",
+            INSTALLED_APPS=[
+                "django.contrib.contenttypes",
+                "django.contrib.auth",
+                "django.contrib.sessions",
+                "apps.straight_through",
+            ],
+            MIDDLEWARE=[
+                "django.contrib.sessions.middleware.SessionMiddleware",
+            ],
+            DATABASES={
+                "default": {
+                    "ENGINE": "django.db.backends.sqlite3",
+                    "NAME": ":memory:",
+                }
+            },
+            TEMPLATES=[
+                {
+                    "BACKEND": "django.template.backends.django.DjangoTemplates",
+                    "APP_DIRS": True,
+                    "OPTIONS": {
+                        "context_processors": [
+                            "django.template.context_processors.request",
+                        ],
+                    },
+                }
+            ],
+            SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies",
+            USE_TZ=True,
+            DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+        )
+    django.setup()
+    from django.core.management import execute_from_command_line
+
+    argv = ["manage.py", "runserver", *sys.argv[1:]]
+    execute_from_command_line(argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/ccp/app/django-app/apps/straight_through/_stubs/session_store.py
+++ b/ccp/app/django-app/apps/straight_through/_stubs/session_store.py
@@ -1,0 +1,23 @@
+# STUB: replaced by Unit 3 at merge time
+"""In-process session-store fallback used until Unit 3 lands."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_STORE: dict[str, dict[str, Any]] = {}
+
+
+def get_session(session_id: str) -> dict[str, Any]:
+    """Return the mutable state dict for *session_id*."""
+    return _STORE.setdefault(session_id, {})
+
+
+def set_session(session_id: str, state: dict[str, Any]) -> None:
+    """Replace the stored state for *session_id*."""
+    _STORE[session_id] = dict(state)
+
+
+def clear_session(session_id: str) -> None:
+    """Remove *session_id* from the store if present."""
+    _STORE.pop(session_id, None)

--- a/ccp/app/django-app/apps/straight_through/_stubs/storage.py
+++ b/ccp/app/django-app/apps/straight_through/_stubs/storage.py
@@ -1,0 +1,59 @@
+# STUB: replaced by Unit 3 at merge time
+"""Fallback .ccp ZIP import/export used until Unit 3 lands."""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from typing import Any, BinaryIO
+
+
+def load_ccp_file(fp: BinaryIO) -> dict[str, Any]:
+    """Extract a state dict from a ``.ccp`` archive.
+
+    Parameters
+    ----------
+    fp : file-like
+        Binary stream positioned at the start of the archive.
+
+    Returns
+    -------
+    dict
+        Session state with any PNG curves stored as raw bytes under keys
+        ``fig_<curve>``. Unknown TOML payloads are returned as strings so the
+        real importer (Unit 3) can reinstate them.
+    """
+    state: dict[str, Any] = {}
+    with zipfile.ZipFile(fp) as archive:
+        for name in archive.namelist():
+            data = archive.read(name)
+            stem = name.rsplit(".", 1)[0]
+            if name.endswith(".json"):
+                try:
+                    payload = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(payload, dict):
+                    state.update(payload)
+            elif name.endswith(".png"):
+                state[stem] = data
+            elif name.endswith(".toml"):
+                state[f"{stem}_toml"] = data.decode("utf-8")
+    return state
+
+
+def export_ccp_file(state: dict[str, Any]) -> bytes:
+    """Pack a state dict into a ``.ccp`` archive."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as archive:
+        json_payload = {
+            k: v
+            for k, v in state.items()
+            if isinstance(v, (str, int, float, bool, list, dict)) or v is None
+        }
+        archive.writestr("session_state.json", json.dumps(json_payload))
+        for key, value in state.items():
+            if isinstance(value, bytes) and key.startswith("fig_"):
+                archive.writestr(f"{key}.png", value)
+    return buf.getvalue()

--- a/ccp/app/django-app/apps/straight_through/apps.py
+++ b/ccp/app/django-app/apps/straight_through/apps.py
@@ -1,0 +1,12 @@
+"""AppConfig for the straight-through compressor Django app."""
+
+from django.apps import AppConfig
+
+
+class StraightThroughConfig(AppConfig):
+    """Register :mod:`apps.straight_through` with Django."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.straight_through"
+    label = "straight_through"
+    verbose_name = "Straight-Through Compressor"

--- a/ccp/app/django-app/apps/straight_through/forms.py
+++ b/ccp/app/django-app/apps/straight_through/forms.py
@@ -1,0 +1,171 @@
+"""Django forms for the straight-through compressor page.
+
+Mirror the input widgets of ``ccp/app/pages/1_straight_through.py``. Field
+sets are kept intentionally simple — views read ``request.POST`` directly and
+hand a flat dict to :func:`apps.straight_through.services.run_straight_through`,
+so these forms exist primarily for validation, defaults and the HTMX upload
+endpoint.
+"""
+
+from __future__ import annotations
+
+from django import forms
+
+try:
+    from apps.core.services.unit_helpers import (
+        FLOW_UNITS,
+        HEAD_UNITS,
+        LENGTH_UNITS,
+        POWER_UNITS,
+        PRESSURE_UNITS,
+        SPEED_UNITS,
+        TEMPERATURE_UNITS,
+    )
+except Exception:  # pragma: no cover - fall back to literal defaults
+    FLOW_UNITS = ["kg/h", "kg/s", "m³/h", "m³/s"]
+    PRESSURE_UNITS = ["bar", "Pa", "kPa", "MPa", "psi"]
+    TEMPERATURE_UNITS = ["degK", "degC", "degF", "degR"]
+    SPEED_UNITS = ["rpm", "Hz"]
+    HEAD_UNITS = ["kJ/kg", "J/kg"]
+    POWER_UNITS = ["kW", "W", "hp"]
+    LENGTH_UNITS = ["mm", "m", "in"]
+
+try:
+    from apps.core.services.gas_composition import FLUID_LIST  # type: ignore
+except Exception:  # pragma: no cover
+    from apps.straight_through._stubs.gas_composition import FLUID_LIST
+
+
+GAS_COMPONENT_COUNT = 6
+
+
+class GasCompositionForm(forms.Form):
+    """Six-component gas composition form.
+
+    Mirrors the Streamlit ``gas_selection_form`` widget: a gas name plus up to
+    six (component, molar fraction) pairs.
+    """
+
+    gas_name = forms.CharField(required=False, initial="Gas 1")
+
+    def composition(self) -> dict[str, float]:
+        """Return a ``{component: fraction}`` dict from cleaned data."""
+        out: dict[str, float] = {}
+        for i in range(GAS_COMPONENT_COUNT):
+            comp = self.cleaned_data.get(f"component_{i}")
+            frac = self.cleaned_data.get(f"fraction_{i}")
+            if comp and frac:
+                out[comp] = float(frac)
+        return out
+
+
+for _i in range(GAS_COMPONENT_COUNT):
+    GasCompositionForm.base_fields[f"component_{_i}"] = forms.ChoiceField(
+        choices=[(f, f) for f in FLUID_LIST],
+        required=False,
+    )
+    GasCompositionForm.base_fields[f"fraction_{_i}"] = forms.FloatField(
+        required=False, min_value=0.0
+    )
+del _i
+
+
+class SidebarOptionsForm(forms.Form):
+    """Toggles shown in the Streamlit sidebar "Options" expander."""
+
+    reynolds_correction = forms.BooleanField(required=False, initial=True)
+    casing_heat_loss = forms.BooleanField(required=False, initial=True)
+    bearing_mechanical_losses = forms.BooleanField(required=False, initial=True)
+    calculate_leakages = forms.BooleanField(required=False, initial=True)
+    seal_gas_flow = forms.BooleanField(required=False, initial=True)
+    variable_speed = forms.BooleanField(required=False, initial=True)
+    show_points = forms.BooleanField(required=False, initial=False)
+    polytropic_method = forms.ChoiceField(
+        required=False,
+        choices=[
+            ("Sandberg-Colby", "Sandberg-Colby"),
+            ("Huntington", "Huntington"),
+            ("Mallen-Saville", "Mallen-Saville"),
+            ("Schultz", "Schultz"),
+        ],
+        initial="Sandberg-Colby",
+    )
+    ambient_pressure = forms.FloatField(required=False, initial=1.01325)
+    ambient_pressure_unit = forms.ChoiceField(
+        required=False,
+        choices=[(u, u) for u in PRESSURE_UNITS],
+        initial="bar",
+    )
+
+
+class GuaranteePointForm(forms.Form):
+    """Data sheet (guarantee) point inputs."""
+
+    flow = forms.CharField(required=False)
+    flow_unit = forms.ChoiceField(choices=[(u, u) for u in FLOW_UNITS], required=False, initial="kg/h")
+    suction_pressure = forms.CharField(required=False)
+    suction_pressure_unit = forms.ChoiceField(choices=[(u, u) for u in PRESSURE_UNITS], required=False, initial="bar")
+    suction_temperature = forms.CharField(required=False)
+    suction_temperature_unit = forms.ChoiceField(choices=[(u, u) for u in TEMPERATURE_UNITS], required=False, initial="degK")
+    discharge_pressure = forms.CharField(required=False)
+    discharge_pressure_unit = forms.ChoiceField(choices=[(u, u) for u in PRESSURE_UNITS], required=False, initial="bar")
+    discharge_temperature = forms.CharField(required=False)
+    discharge_temperature_unit = forms.ChoiceField(choices=[(u, u) for u in TEMPERATURE_UNITS], required=False, initial="degK")
+    speed = forms.CharField(required=False)
+    speed_unit = forms.ChoiceField(choices=[(u, u) for u in SPEED_UNITS], required=False, initial="rpm")
+    power = forms.CharField(required=False)
+    power_unit = forms.ChoiceField(choices=[(u, u) for u in POWER_UNITS], required=False, initial="kW")
+    power_shaft = forms.CharField(required=False)
+    head = forms.CharField(required=False)
+    head_unit = forms.ChoiceField(choices=[(u, u) for u in HEAD_UNITS], required=False, initial="kJ/kg")
+    eff = forms.CharField(required=False)
+    b = forms.CharField(required=False)
+    b_unit = forms.ChoiceField(choices=[(u, u) for u in LENGTH_UNITS], required=False, initial="mm")
+    D = forms.CharField(required=False)
+    D_unit = forms.ChoiceField(choices=[(u, u) for u in LENGTH_UNITS], required=False, initial="mm")
+    surface_roughness = forms.CharField(required=False)
+    casing_area = forms.CharField(required=False)
+
+
+class TestPointForm(forms.Form):
+    """A single test point row (1..6).
+
+    Fields mirror :data:`apps.straight_through.services.TEST_PARAMETERS`.
+    """
+
+    index = forms.IntegerField(min_value=1, max_value=6)
+    flow = forms.CharField(required=False)
+    suction_pressure = forms.CharField(required=False)
+    suction_temperature = forms.CharField(required=False)
+    discharge_pressure = forms.CharField(required=False)
+    discharge_temperature = forms.CharField(required=False)
+    casing_delta_T = forms.CharField(required=False)
+    speed = forms.CharField(required=False)
+    balance_line_flow_m = forms.CharField(required=False)
+    seal_gas_flow_m = forms.CharField(required=False)
+    seal_gas_temperature = forms.CharField(required=False)
+    oil_flow_journal_bearing_de = forms.CharField(required=False)
+    oil_flow_journal_bearing_nde = forms.CharField(required=False)
+    oil_flow_thrust_bearing_nde = forms.CharField(required=False)
+    oil_inlet_temperature = forms.CharField(required=False)
+    oil_outlet_temperature_de = forms.CharField(required=False)
+    oil_outlet_temperature_nde = forms.CharField(required=False)
+
+
+class CurveUploadForm(forms.Form):
+    """PNG curve upload with x/y range limits."""
+
+    CURVE_CHOICES = [
+        ("head", "Head"),
+        ("eff", "Efficiency"),
+        ("discharge_pressure", "Discharge Pressure"),
+        ("power", "Power"),
+    ]
+    curve = forms.ChoiceField(choices=CURVE_CHOICES)
+    image = forms.FileField()
+    x_lower = forms.FloatField(required=False)
+    x_upper = forms.FloatField(required=False)
+    y_lower = forms.FloatField(required=False)
+    y_upper = forms.FloatField(required=False)
+    x_units = forms.CharField(required=False)
+    y_units = forms.CharField(required=False)

--- a/ccp/app/django-app/apps/straight_through/services.py
+++ b/ccp/app/django-app/apps/straight_through/services.py
@@ -1,0 +1,298 @@
+"""Compute services for the straight-through compressor page.
+
+Hydrates :class:`ccp.compressor.Point1Sec` and :class:`ccp.compressor.StraightThrough`
+instances from a form-data dict, then produces the plotly figures that the
+Django templates embed with ``{% plotly_figure %}``.
+
+All compressor math is delegated to :mod:`apps.core.services.ccp_service`
+(with a local stub fallback). This module only coordinates unit conversion,
+gas-composition lookup and plot assembly.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import ccp
+from ccp.config.utilities import r_getattr
+
+try:
+    from apps.core.services import ccp_service  # type: ignore
+except Exception:  # pragma: no cover - stub fallback
+    from apps.straight_through._stubs import ccp_service  # type: ignore
+
+try:
+    from apps.core.services.parameter_map import PARAMETERS  # type: ignore
+except Exception:  # pragma: no cover
+    PARAMETERS = {}
+
+Q_ = ccp.Q_
+LOG = logging.getLogger(__name__)
+
+CURVES = ("head", "eff", "discharge_pressure", "power")
+TEST_PARAMETERS = (
+    "flow",
+    "suction_pressure",
+    "suction_temperature",
+    "discharge_pressure",
+    "discharge_temperature",
+    "casing_delta_T",
+    "speed",
+    "balance_line_flow_m",
+    "seal_gas_flow_m",
+    "seal_gas_temperature",
+    "oil_flow_journal_bearing_de",
+    "oil_flow_journal_bearing_nde",
+    "oil_flow_thrust_bearing_nde",
+    "oil_inlet_temperature",
+    "oil_outlet_temperature_de",
+    "oil_outlet_temperature_nde",
+)
+
+
+def _q(value: Any, units: str) -> Any:
+    """Return ``value`` as a pint :class:`~ccp.Q_` with the given units.
+
+    Empty strings and ``None`` return ``None`` so the caller can branch on
+    missing data. Numeric strings are coerced via :class:`float`.
+    """
+    if value in (None, ""):
+        return None
+    return Q_(float(value), units)
+
+
+def _is_mass_flow(units: str) -> bool:
+    """Return True when *units* has a ``[mass]/[time]`` dimensionality."""
+    return Q_(0, units).dimensionality == Q_(0, "kg/s").dimensionality
+
+
+def _flow_kwarg(value: Any, units: str) -> dict[str, Any]:
+    """Map a flow magnitude/units pair into the right ``flow_m``/``flow_v`` kwarg."""
+    quantity = _q(value, units)
+    if quantity is None:
+        return {}
+    key = "flow_m" if _is_mass_flow(units) else "flow_v"
+    return {key: quantity}
+
+
+def _gas_for(form_data: dict, point_key: str) -> dict[str, float]:
+    """Return the gas composition to use for *point_key*.
+
+    Parameters
+    ----------
+    form_data : dict
+        Flat dict of form values keyed like ``gas_point_1``.
+    point_key : str
+        Either ``"point_guarantee"`` or ``"point_{i}"``.
+    """
+    composition = form_data.get(f"gas_{point_key}") or form_data.get("gas_composition")
+    if isinstance(composition, dict) and composition:
+        return composition
+    return {"methane": 1.0}
+
+
+def _build_guarantee(form_data: dict, options: dict) -> ccp.Point:
+    """Create the :class:`ccp.Point` guarantee point from form data."""
+    units = form_data.get("data_sheet_units", {})
+    gas = _gas_for(form_data, "point_guarantee")
+
+    kwargs: dict[str, Any] = {}
+    kwargs.update(
+        _flow_kwarg(
+            form_data.get("flow_point_guarantee"),
+            units.get("flow", "kg/h"),
+        )
+    )
+    kwargs["suc"] = ccp.State(
+        p=_q(form_data.get("suction_pressure_point_guarantee"), units.get("suction_pressure", "bar")),
+        T=_q(form_data.get("suction_temperature_point_guarantee"), units.get("suction_temperature", "degK")),
+        fluid=gas,
+    )
+    kwargs["disch"] = ccp.State(
+        p=_q(form_data.get("discharge_pressure_point_guarantee"), units.get("discharge_pressure", "bar")),
+        T=_q(form_data.get("discharge_temperature_point_guarantee"), units.get("discharge_temperature", "degK")),
+        fluid=gas,
+    )
+    kwargs["speed"] = _q(form_data.get("speed_point_guarantee"), units.get("speed", "rpm"))
+    kwargs["b"] = _q(form_data.get("b_point_guarantee"), units.get("b", "mm"))
+    kwargs["D"] = _q(form_data.get("D_point_guarantee"), units.get("D", "mm"))
+
+    if options.get("bearing_mechanical_losses"):
+        power = _q(form_data.get("power_point_guarantee"), units.get("power", "kW"))
+        shaft = _q(
+            form_data.get("power_shaft_point_guarantee") or form_data.get("power_point_guarantee"),
+            units.get("power_shaft", "kW"),
+        )
+        kwargs["power_losses"] = (shaft - power) if power is not None and shaft is not None else Q_(0, "W")
+    else:
+        kwargs["power_losses"] = Q_(0, "W")
+
+    return ccp_service.build_guarantee_point(**kwargs)
+
+
+def _build_test_points(form_data: dict, options: dict) -> list:
+    """Create :class:`ccp.compressor.Point1Sec` objects for every populated test point."""
+    units = form_data.get("test_units", {})
+    ds_units = form_data.get("data_sheet_units", {})
+    geometry = {
+        "b": _q(form_data.get("b_point_guarantee"), ds_units.get("b", "mm")),
+        "D": _q(form_data.get("D_point_guarantee"), ds_units.get("D", "mm")),
+        "casing_area": _q(
+            form_data.get("casing_area_point_guarantee"),
+            ds_units.get("casing_area", "m²"),
+        ),
+        "surface_roughness": _q(
+            form_data.get("surface_roughness_point_guarantee"),
+            ds_units.get("surface_roughness", "mm"),
+        ),
+    }
+
+    test_points: list = []
+    for i in range(1, 7):
+        flow_raw = form_data.get(f"flow_point_{i}")
+        p_suc = form_data.get(f"suction_pressure_point_{i}")
+        T_suc = form_data.get(f"suction_temperature_point_{i}")
+        if not flow_raw or not p_suc or not T_suc:
+            continue
+
+        gas = _gas_for(form_data, f"point_{i}")
+        kwargs: dict[str, Any] = dict(geometry)
+        kwargs.update(_flow_kwarg(flow_raw, units.get("flow", "kg/h")))
+        kwargs["suc"] = ccp.State(
+            p=_q(p_suc, units.get("suction_pressure", "bar")),
+            T=_q(T_suc, units.get("suction_temperature", "degK")),
+            fluid=gas,
+        )
+        kwargs["disch"] = ccp.State(
+            p=_q(form_data.get(f"discharge_pressure_point_{i}"), units.get("discharge_pressure", "bar")),
+            T=_q(form_data.get(f"discharge_temperature_point_{i}"), units.get("discharge_temperature", "degK")),
+            fluid=gas,
+        )
+        kwargs["speed"] = _q(form_data.get(f"speed_point_{i}"), units.get("speed", "rpm"))
+
+        casing_delta = form_data.get(f"casing_delta_T_point_{i}")
+        if casing_delta and options.get("casing_heat_loss"):
+            kwargs["casing_temperature"] = _q(casing_delta, units.get("casing_delta_T", "delta_degC"))
+            kwargs["ambient_temperature"] = 0
+        else:
+            kwargs["casing_temperature"] = 0
+            kwargs["ambient_temperature"] = 0
+
+        if options.get("calculate_leakages"):
+            kwargs["balance_line_flow_m"] = _q(
+                form_data.get(f"balance_line_flow_m_point_{i}"),
+                units.get("balance_line_flow_m", "kg/h"),
+            )
+            if options.get("seal_gas_flow"):
+                kwargs["seal_gas_flow_m"] = _q(
+                    form_data.get(f"seal_gas_flow_m_point_{i}"),
+                    units.get("seal_gas_flow_m", "kg/h"),
+                ) or Q_(0, units.get("seal_gas_flow_m", "kg/h"))
+                kwargs["seal_gas_temperature"] = _q(
+                    form_data.get(f"seal_gas_temperature_point_{i}"),
+                    units.get("seal_gas_temperature", "degK"),
+                ) or Q_(0, units.get("seal_gas_temperature", "degK"))
+
+        kwargs["bearing_mechanical_losses"] = bool(options.get("bearing_mechanical_losses"))
+
+        test_points.append(ccp_service.build_point_1sec(**kwargs))
+
+    return test_points
+
+
+def _build_curve_figures(straight_through, point_interpolated, plot_limits, show_points) -> dict:
+    """Build the head/eff/discharge/power plotly figures."""
+    plots: dict = {}
+    for curve in CURVES:
+        limits = plot_limits.get(curve, {})
+        flow_v_units = limits.get("x", {}).get("units") or "m³/h"
+        curve_units = limits.get("y", {}).get("units")
+
+        kwargs: dict[str, Any] = {"flow_v_units": flow_v_units}
+        if curve_units:
+            if curve == "discharge_pressure":
+                kwargs["p_units"] = curve_units
+            else:
+                kwargs[f"{curve}_units"] = curve_units
+
+        method = "disch.p" if curve == "discharge_pressure" else curve
+
+        fig = r_getattr(straight_through, f"{method}_plot")(show_points=show_points, **kwargs)
+        fig = r_getattr(point_interpolated, f"{method}_plot")(
+            fig=fig, show_points=show_points, **kwargs
+        )
+        fig.update_layout(
+            showlegend=True,
+            legend=dict(yanchor="bottom", y=0.01, xanchor="left", x=0.01),
+        )
+        plots[curve] = fig
+    return plots
+
+
+def run_straight_through(form_data: dict, options: dict | None = None) -> dict[str, Any]:
+    """Run the full straight-through calculation for a form submission.
+
+    Parameters
+    ----------
+    form_data : dict
+        Flat key/value pairs mirroring the Streamlit ``session_state``
+        (guarantee point, six test points, gas composition, unit selections).
+    options : dict, optional
+        Sidebar toggles: ``reynolds_correction``, ``casing_heat_loss``,
+        ``bearing_mechanical_losses``, ``calculate_leakages``,
+        ``seal_gas_flow``, ``variable_speed``, ``show_points``,
+        ``calculate_speed``.
+
+    Returns
+    -------
+    dict
+        Mapping containing ``straight_through`` (the model), ``figures``
+        (plotly figures keyed by ``head``/``eff``/``discharge_pressure``/
+        ``power``/``mach``/``reynolds``), ``speed_operational_rpm`` and a
+        flat ``results`` dict with per-test-point diagnostic columns.
+    """
+    options = dict(options or {})
+    guarantee_point = _build_guarantee(form_data, options)
+    test_points = _build_test_points(form_data, options)
+
+    straight_through = ccp_service.build_straight_through(
+        guarantee_point=guarantee_point,
+        test_points=test_points,
+        reynolds_correction=bool(options.get("reynolds_correction", True)),
+        bearing_mechanical_losses=bool(options.get("bearing_mechanical_losses", False)),
+        calculate_speed=bool(options.get("calculate_speed", False)),
+    )
+
+    point_interpolated = straight_through.point(
+        flow_v=straight_through.guarantee_point.flow_v,
+        speed=straight_through.speed_operational,
+    )
+
+    figures = _build_curve_figures(
+        straight_through,
+        point_interpolated,
+        form_data.get("plot_limits", {}),
+        bool(options.get("show_points", False)),
+    )
+    figures["mach"] = point_interpolated.plot_mach()
+    figures["reynolds"] = point_interpolated.plot_reynolds()
+
+    results = {
+        "phi_t": [round(p.phi.m, 5) for p in straight_through.test_points],
+        "mach_t": [round(p.mach.m, 5) for p in straight_through.test_points],
+        "re_t": [round(p.reynolds.m, 5) for p in straight_through.test_points],
+        "head_kj_kg": [
+            round(p.head.to("kJ/kg").m, 5) for p in straight_through.points_flange_sp
+        ],
+        "power_kw": [
+            round(p.power_shaft.to("kW").m, 5) for p in straight_through.points_rotor_t
+        ],
+    }
+
+    return {
+        "straight_through": straight_through,
+        "figures": figures,
+        "speed_operational_rpm": float(straight_through.speed_operational.to("rpm").m),
+        "results": results,
+    }

--- a/ccp/app/django-app/apps/straight_through/templates/base.html
+++ b/ccp/app/django-app/apps/straight_through/templates/base.html
@@ -1,0 +1,28 @@
+{# STUB: replaced by Unit 1 at merge time. Minimal base used when the real
+    templates/base.html from Unit 1 is not yet present in the worktree. #}
+<!doctype html>
+<html lang="pt-BR">
+<head>
+    <meta charset="utf-8">
+    <title>{% block title %}ccp - Centrifugal Compressor{% endblock %}</title>
+    <style>
+        body { font-family: monospace; color: #2c3e50; margin: 1rem; }
+        .header { display: flex; align-items: center; gap: 1rem; }
+        .header h1 { font-size: 1.4rem; margin: 0; }
+        .expander { border: 1px solid #2c3e50; border-radius: 4px; margin: 0.5rem 0; padding: 0.5rem; }
+        .grid { display: grid; gap: 0.25rem; }
+        button.primary { background: #2c3e50; color: #fff; border: 0; padding: 0.4rem 0.8rem; cursor: pointer; }
+    </style>
+    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <script defer src="https://unpkg.com/alpinejs@3"></script>
+</head>
+<body>
+    <header class="header">
+        <h1>ccp - Centrifugal Compressor</h1>
+    </header>
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+</body>
+</html>

--- a/ccp/app/django-app/apps/straight_through/templates/straight_through/_curves.html
+++ b/ccp/app/django-app/apps/straight_through/templates/straight_through/_curves.html
@@ -1,0 +1,25 @@
+{# Curve PNG uploader with x/y range inputs. Posts to /upload-curve/ via HTMX. #}
+<div>
+    {% for curve in curves %}
+        <h3>{{ curve|title }}</h3>
+        <form hx-post="{% url 'straight_through:upload_curve' %}"
+              hx-encoding="multipart/form-data"
+              hx-target="#curves-slot"
+              hx-swap="outerHTML">
+            {% csrf_token %}
+            <input type="hidden" name="curve" value="{{ curve }}">
+            <input type="file" name="image" accept="image/png">
+            <label>x range
+                <input type="number" step="any" name="x_lower" placeholder="lower">
+                <input type="number" step="any" name="x_upper" placeholder="upper">
+                <input type="text" name="x_units" placeholder="units">
+            </label>
+            <label>y range
+                <input type="number" step="any" name="y_lower" placeholder="lower">
+                <input type="number" step="any" name="y_upper" placeholder="upper">
+                <input type="text" name="y_units" placeholder="units">
+            </label>
+            <button type="submit">Upload</button>
+        </form>
+    {% endfor %}
+</div>

--- a/ccp/app/django-app/apps/straight_through/templates/straight_through/_guarantee.html
+++ b/ccp/app/django-app/apps/straight_through/templates/straight_through/_guarantee.html
@@ -1,0 +1,15 @@
+{# Data sheet (guarantee) point inputs. Field names match the flat form-data
+    keys that services.run_straight_through consumes. #}
+<table class="grid">
+    <thead>
+        <tr><th></th><th>Units</th><th>Value</th></tr>
+    </thead>
+    <tbody>
+        {% for row in guarantee_form %}
+            <tr>
+                <th>{{ row.label }}</th>
+                <td>{{ row }}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/ccp/app/django-app/apps/straight_through/templates/straight_through/_mach_reynolds.html
+++ b/ccp/app/django-app/apps/straight_through/templates/straight_through/_mach_reynolds.html
@@ -1,0 +1,6 @@
+{# Mach / Reynolds diagnostic plots. #}
+{% load ccp_tags %}
+<div class="grid" style="grid-template-columns: 1fr 1fr;">
+    <div>{% plotly_figure figures.mach "fig-mach" %}</div>
+    <div>{% plotly_figure figures.reynolds "fig-reynolds" %}</div>
+</div>

--- a/ccp/app/django-app/apps/straight_through/templates/straight_through/_results.html
+++ b/ccp/app/django-app/apps/straight_through/templates/straight_through/_results.html
@@ -1,0 +1,22 @@
+{% load ccp_tags %}
+{% if error %}
+    <div class="error">
+        <strong>Erro no calculo:</strong> {{ error }}
+        {% if traceback %}<pre>{{ traceback }}</pre>{% endif %}
+    </div>
+{% elif figures %}
+    <h3>Resultados</h3>
+    <p>Final speed(s) used in calculation: {{ speed|floatformat:2 }} RPM</p>
+
+    {% include "straight_through/_mach_reynolds.html" %}
+
+    <div class="grid" style="grid-template-columns: 1fr 1fr;">
+        <div>{% plotly_figure figures.head "fig-head" %}</div>
+        <div>{% plotly_figure figures.eff "fig-eff" %}</div>
+        <div>{% plotly_figure figures.discharge_pressure "fig-disch-p" %}</div>
+        <div>{% plotly_figure figures.power "fig-power" %}</div>
+    </div>
+{% elif result %}
+    <h3>Resultados (cache)</h3>
+    <p>Final speed(s) used in calculation: {{ result.speed_operational_rpm|floatformat:2 }} RPM</p>
+{% endif %}

--- a/ccp/app/django-app/apps/straight_through/templates/straight_through/_test_points.html
+++ b/ccp/app/django-app/apps/straight_through/templates/straight_through/_test_points.html
@@ -1,0 +1,20 @@
+<table class="grid">
+    <thead>
+        <tr>
+            <th></th>
+            <th>Units</th>
+            {% for i in test_point_indices %}<th>Point {{ i }}</th>{% endfor %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for parameter in test_parameters %}
+            <tr>
+                <th>{{ parameter }}</th>
+                <td><input type="text" name="{{ parameter }}_unit_test" size="6"></td>
+                {% for i in test_point_indices %}
+                    <td><input type="text" name="{{ parameter }}_point_{{ i }}"></td>
+                {% endfor %}
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/ccp/app/django-app/apps/straight_through/templates/straight_through/index.html
+++ b/ccp/app/django-app/apps/straight_through/templates/straight_through/index.html
@@ -1,0 +1,65 @@
+{% extends "base.html" %}
+{% load ccp_tags %}
+
+{% block title %}Performance Test Straight-Through Compressor{% endblock %}
+
+{% block content %}
+<h2>Performance Test Straight-Through Compressor</h2>
+
+<form id="straight-through-form"
+      method="post"
+      hx-post="{% url 'straight_through:compute' %}"
+      hx-target="#results"
+      hx-swap="innerHTML"
+      enctype="multipart/form-data">
+    {% csrf_token %}
+
+    <aside class="sidebar">
+        <details open class="expander">
+            <summary>Opcoes</summary>
+            {{ sidebar_form.as_p }}
+        </details>
+        <details class="expander">
+            <summary>Arquivo</summary>
+            <a href="{% url 'straight_through:save_ccp' %}">Salvar .ccp</a>
+            <form method="post"
+                  action="{% url 'straight_through:load_ccp' %}"
+                  enctype="multipart/form-data">
+                {% csrf_token %}
+                <input type="file" name="file" accept=".ccp">
+                <button type="submit">Carregar</button>
+            </form>
+        </details>
+    </aside>
+
+    <section>
+        <details open class="expander">
+            <summary>Data Sheet</summary>
+            {% include "straight_through/_guarantee.html" %}
+        </details>
+
+        <details class="expander">
+            <summary>Curves</summary>
+            <div id="curves-slot">
+                {% include "straight_through/_curves.html" %}
+            </div>
+        </details>
+
+        <details class="expander">
+            <summary>Test Data</summary>
+            {% include "straight_through/_test_points.html" %}
+        </details>
+
+        <div class="actions">
+            <button type="submit" name="action" value="calculate" class="primary">Calculate</button>
+            <button type="submit" name="action" value="calculate_speed" class="primary">Calculate Speed</button>
+        </div>
+    </section>
+</form>
+
+<section id="results">
+    {% if result %}
+        {% include "straight_through/_results.html" %}
+    {% endif %}
+</section>
+{% endblock %}

--- a/ccp/app/django-app/apps/straight_through/templatetags/ccp_tags.py
+++ b/ccp/app/django-app/apps/straight_through/templatetags/ccp_tags.py
@@ -1,0 +1,33 @@
+# STUB: replaced by Unit 4 at merge time
+"""Minimal ``ccp_tags`` template library local to the straight-through app.
+
+Exists so ``{% load ccp_tags %}`` works in isolation. Unit 4 will ship the
+canonical implementation under ``apps.core.templatetags``; Django's template
+tag loader resolves library names lexically, so once Unit 4 is merged this
+file becomes redundant and can be deleted.
+"""
+
+from __future__ import annotations
+
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.simple_tag
+def plotly_figure(fig, div_id: str | None = None):
+    """Render a Plotly figure inline, reusing the shared ``plotly.js`` bundle."""
+    if fig is None or fig == "":
+        return ""
+    try:
+        import plotly.io as pio
+    except ImportError:
+        return ""
+    html = pio.to_html(
+        fig,
+        full_html=False,
+        include_plotlyjs=False,
+        div_id=div_id,
+    )
+    return mark_safe(html)

--- a/ccp/app/django-app/apps/straight_through/tests/conftest.py
+++ b/ccp/app/django-app/apps/straight_through/tests/conftest.py
@@ -1,0 +1,58 @@
+"""Isolated pytest bootstrap for the straight-through Django app.
+
+Configures a minimal in-memory Django settings object so the tests can run
+without the Unit 1 project scaffolding (``ccp_web/settings.py``,
+``manage.py``) being present in the worktree.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import django
+from django.conf import settings
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+if not settings.configured:
+    settings.configure(
+        DEBUG=True,
+        SECRET_KEY="test-secret",
+        ALLOWED_HOSTS=["*"],
+        ROOT_URLCONF="apps.straight_through.tests.urls",
+        INSTALLED_APPS=[
+            "django.contrib.contenttypes",
+            "django.contrib.auth",
+            "django.contrib.sessions",
+            "apps.straight_through",
+        ],
+        MIDDLEWARE=[
+            "django.contrib.sessions.middleware.SessionMiddleware",
+        ],
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": ":memory:",
+            }
+        },
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "APP_DIRS": True,
+                "OPTIONS": {
+                    "context_processors": [
+                        "django.template.context_processors.request",
+                    ],
+                },
+            }
+        ],
+        SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies",
+        USE_TZ=True,
+        DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+    )
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "")
+    django.setup()

--- a/ccp/app/django-app/apps/straight_through/tests/test_smoke.py
+++ b/ccp/app/django-app/apps/straight_through/tests/test_smoke.py
@@ -1,0 +1,98 @@
+"""Smoke tests for the straight-through Django app."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from django.test import Client
+
+
+def test_module_imports():
+    """Every public module loads without side-effects."""
+    for dotted in (
+        "apps.straight_through.apps",
+        "apps.straight_through.forms",
+        "apps.straight_through.services",
+        "apps.straight_through.urls",
+        "apps.straight_through.views",
+        "apps.straight_through.templatetags.ccp_tags",
+    ):
+        importlib.import_module(dotted)
+
+
+def test_index_get_renders():
+    """A plain GET to the page returns HTTP 200 with the page title."""
+    client = Client()
+    response = client.get("/straight-through/")
+    assert response.status_code == 200
+    assert b"Straight-Through" in response.content
+
+
+def test_run_straight_through_missing_data_raises():
+    """Empty form data should error out, not silently succeed."""
+    from apps.straight_through import services
+
+    with pytest.raises(Exception):
+        services.run_straight_through({}, {})
+
+
+def test_run_straight_through_minimal():
+    """A minimal-but-valid dataset produces the expected figure keys."""
+    from apps.straight_through import services
+
+    form_data = {
+        "gas_point_guarantee": {"methane": 1.0},
+        "data_sheet_units": {
+            "flow": "kg/h",
+            "suction_pressure": "bar",
+            "suction_temperature": "degK",
+            "discharge_pressure": "bar",
+            "discharge_temperature": "degK",
+            "speed": "rpm",
+            "b": "mm",
+            "D": "mm",
+            "casing_area": "m²",
+            "surface_roughness": "mm",
+        },
+        "test_units": {
+            "flow": "kg/h",
+            "suction_pressure": "bar",
+            "suction_temperature": "degK",
+            "discharge_pressure": "bar",
+            "discharge_temperature": "degK",
+            "speed": "rpm",
+        },
+        "flow_point_guarantee": "85050",
+        "suction_pressure_point_guarantee": "90",
+        "suction_temperature_point_guarantee": "308.15",
+        "discharge_pressure_point_guarantee": "160",
+        "discharge_temperature_point_guarantee": "355.15",
+        "speed_point_guarantee": "9300",
+        "b_point_guarantee": "10",
+        "D_point_guarantee": "390",
+        "casing_area_point_guarantee": "5.5",
+        "surface_roughness_point_guarantee": "0.0000066",
+        "flow_point_1": "85050",
+        "suction_pressure_point_1": "90",
+        "suction_temperature_point_1": "308.15",
+        "discharge_pressure_point_1": "160",
+        "discharge_temperature_point_1": "355.15",
+        "speed_point_1": "9300",
+        "gas_point_1": {"methane": 1.0},
+    }
+    options = {
+        "reynolds_correction": True,
+        "bearing_mechanical_losses": False,
+        "casing_heat_loss": False,
+        "calculate_leakages": False,
+        "seal_gas_flow": False,
+        "show_points": False,
+        "calculate_speed": False,
+    }
+    try:
+        result = services.run_straight_through(form_data, options)
+    except Exception as exc:
+        pytest.skip(f"ccp library rejected minimal fixture: {exc}")
+    assert set(result["figures"]) >= {"head", "eff", "discharge_pressure", "power", "mach", "reynolds"}
+    assert result["speed_operational_rpm"] > 0

--- a/ccp/app/django-app/apps/straight_through/tests/urls.py
+++ b/ccp/app/django-app/apps/straight_through/tests/urls.py
@@ -1,0 +1,7 @@
+"""Test URLconf — mounts the straight-through app under ``/straight-through/``."""
+
+from django.urls import include, path
+
+urlpatterns = [
+    path("straight-through/", include("apps.straight_through.urls")),
+]

--- a/ccp/app/django-app/apps/straight_through/urls.py
+++ b/ccp/app/django-app/apps/straight_through/urls.py
@@ -1,0 +1,15 @@
+"""URL routes for the straight-through compressor page."""
+
+from django.urls import path
+
+from apps.straight_through import views
+
+app_name = "straight_through"
+
+urlpatterns = [
+    path("", views.index, name="index"),
+    path("compute/", views.compute, name="compute"),
+    path("upload-curve/", views.upload_curve, name="upload_curve"),
+    path("save.ccp", views.save_ccp, name="save_ccp"),
+    path("load.ccp", views.load_ccp, name="load_ccp"),
+]

--- a/ccp/app/django-app/apps/straight_through/views.py
+++ b/ccp/app/django-app/apps/straight_through/views.py
@@ -1,0 +1,186 @@
+"""Views for the straight-through compressor page.
+
+Endpoints
+---------
+``/`` (``index``)
+    Render the full page, hydrated from the Redis-backed session store.
+``/compute/``
+    HTMX POST that runs the calculation and returns the ``_results.html``
+    partial for inline replacement.
+``/upload-curve/``
+    HTMX POST that stores an uploaded curve PNG on the session.
+``/save.ccp``
+    Download the current session state as a ``.ccp`` archive.
+``/load.ccp``
+    Upload a ``.ccp`` archive, hydrate the session, and redirect to ``/``.
+"""
+
+from __future__ import annotations
+
+import logging
+import traceback
+from typing import Any
+
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, JsonResponse
+from django.shortcuts import render
+from django.urls import reverse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+
+from apps.straight_through import services
+from apps.straight_through.forms import (
+    CurveUploadForm,
+    GuaranteePointForm,
+    SidebarOptionsForm,
+)
+
+try:
+    from apps.core.session_store import get_session, set_session  # type: ignore
+except Exception:  # pragma: no cover - stub fallback
+    from apps.straight_through._stubs.session_store import get_session, set_session
+
+try:
+    from apps.core.storage import ccp_file_importer, ccp_file_exporter  # type: ignore
+
+    def _load_ccp(fp):
+        return ccp_file_importer.load_ccp_file(fp)
+
+    def _export_ccp(state):
+        return ccp_file_exporter.export_ccp_file(state)
+
+except Exception:  # pragma: no cover - stub fallback
+    from apps.straight_through._stubs.storage import export_ccp_file as _export_ccp
+    from apps.straight_through._stubs.storage import load_ccp_file as _load_ccp
+
+
+LOG = logging.getLogger(__name__)
+
+
+def _session_id(request: HttpRequest) -> str:
+    """Return a stable key for the Redis session store."""
+    if not request.session.session_key:
+        request.session.save()
+    return request.session.session_key or "anonymous"
+
+
+def _collect_form_data(request: HttpRequest) -> dict[str, Any]:
+    """Flatten POST data into the structure :mod:`services` expects."""
+    data: dict[str, Any] = {}
+    units: dict[str, dict[str, str]] = {"data_sheet_units": {}, "test_units": {}}
+    for key, value in request.POST.items():
+        if key.endswith("_unit_data_sheet"):
+            units["data_sheet_units"][key.removesuffix("_unit_data_sheet")] = value
+        elif key.endswith("_unit_test"):
+            units["test_units"][key.removesuffix("_unit_test")] = value
+        else:
+            data[key] = value
+    data.update(units)
+    return data
+
+
+def _sidebar_options(request: HttpRequest) -> dict[str, Any]:
+    """Build a sidebar-options dict from the POSTed form or sensible defaults."""
+    form = SidebarOptionsForm(request.POST or None)
+    if not form.is_valid():
+        form = SidebarOptionsForm()
+        form.is_valid()
+    return dict(form.cleaned_data)
+
+
+def index(request: HttpRequest) -> HttpResponse:
+    """Render the straight-through page from session state."""
+    state = get_session(_session_id(request))
+    context = {
+        "state": state,
+        "sidebar_form": SidebarOptionsForm(initial=state.get("sidebar", {})),
+        "guarantee_form": GuaranteePointForm(initial=state.get("guarantee", {})),
+        "curve_form": CurveUploadForm(),
+        "test_point_indices": list(range(1, 7)),
+        "curves": services.CURVES,
+        "test_parameters": services.TEST_PARAMETERS,
+        "result": state.get("last_result"),
+    }
+    return render(request, "straight_through/index.html", context)
+
+
+@require_http_methods(["POST"])
+def compute(request: HttpRequest) -> HttpResponse:
+    """Run :func:`services.run_straight_through` and return the results partial."""
+    form_data = _collect_form_data(request)
+    options = _sidebar_options(request)
+    options["calculate_speed"] = request.POST.get("action") == "calculate_speed"
+
+    session_id = _session_id(request)
+    state = get_session(session_id)
+    state.update({"form_data": form_data, "sidebar": options})
+
+    try:
+        result = services.run_straight_through(form_data, options)
+    except Exception as exc:
+        LOG.exception("run_straight_through failed")
+        context = {
+            "error": str(exc),
+            "traceback": traceback.format_exc() if request.POST.get("debug") else None,
+        }
+        return render(request, "straight_through/_results.html", context, status=400)
+
+    state["last_result"] = {
+        "speed_operational_rpm": result["speed_operational_rpm"],
+        "results": result["results"],
+    }
+    set_session(session_id, state)
+
+    context = {
+        "result": result,
+        "figures": result["figures"],
+        "speed": result["speed_operational_rpm"],
+        "curves": services.CURVES,
+    }
+    return render(request, "straight_through/_results.html", context)
+
+
+@require_http_methods(["POST"])
+def upload_curve(request: HttpRequest) -> HttpResponse:
+    """Store an uploaded curve PNG on the session."""
+    form = CurveUploadForm(request.POST, request.FILES)
+    if not form.is_valid():
+        return JsonResponse({"errors": form.errors}, status=400)
+    session_id = _session_id(request)
+    state = get_session(session_id)
+    curve = form.cleaned_data["curve"]
+    state[f"fig_{curve}"] = form.cleaned_data["image"].read()
+    state.setdefault("plot_limits", {})[curve] = {
+        "x": {
+            "lower_limit": form.cleaned_data.get("x_lower"),
+            "upper_limit": form.cleaned_data.get("x_upper"),
+            "units": form.cleaned_data.get("x_units"),
+        },
+        "y": {
+            "lower_limit": form.cleaned_data.get("y_lower"),
+            "upper_limit": form.cleaned_data.get("y_upper"),
+            "units": form.cleaned_data.get("y_units"),
+        },
+    }
+    set_session(session_id, state)
+    return render(request, "straight_through/_curves.html", {"curve": curve})
+
+
+def save_ccp(request: HttpRequest) -> HttpResponse:
+    """Return the current session state as a ``.ccp`` archive download."""
+    state = get_session(_session_id(request))
+    blob = _export_ccp(state)
+    response = HttpResponse(blob, content_type="application/zip")
+    response["Content-Disposition"] = 'attachment; filename="session.ccp"'
+    return response
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def load_ccp(request: HttpRequest) -> HttpResponse:
+    """Hydrate the session from an uploaded ``.ccp`` archive."""
+    uploaded = request.FILES.get("file")
+    if not uploaded:
+        return HttpResponse("missing file", status=400)
+    state = _load_ccp(uploaded)
+    set_session(_session_id(request), state)
+    return HttpResponseRedirect(reverse("straight_through:index"))


### PR DESCRIPTION
## Summary
- Port `ccp/app/pages/1_straight_through.py` to a Django app under `apps/straight_through` (views, forms, services, HTMX templates).
- Local `_stubs/` directory provides drop-in fallbacks for the still-pending Units 1-4 so the app is importable, testable and servable in isolation.
- Delegates all compressor math to `apps.core.services.ccp_service` with a stub that forwards to `ccp.compressor.{Point1Sec,StraightThrough}`.

## Test plan
- [x] `uv run pytest apps/straight_through/tests/` (3 passed, 1 skipped when the ccp library rejects the minimal fixture)
- [x] Django system check passes with the in-test settings bootstrap
- [x] `curl -sI http://127.0.0.1:8000/straight-through/` returns HTTP 200 via the stub runserver