### PR TITLE
django-app: Unit 9 — performance evaluation compute/plots

### DIFF
--- a/ccp/app/django-app/apps/performance_evaluation/_stubs/__init__.py
+++ b/ccp/app/django-app/apps/performance_evaluation/_stubs/__init__.py
@@ -1,0 +1,7 @@
+"""Local fallbacks for symbols owned by sister units.
+
+These stubs let the performance evaluation app load in isolation before
+Units 2, 3, 10 and 11 are merged into the worktree. Every stub is marked
+with ``# STUB: replaced by Unit N`` and imported via ``try/except`` in the
+real modules.
+"""

--- a/ccp/app/django-app/apps/performance_evaluation/_stubs/ccp_service.py
+++ b/ccp/app/django-app/apps/performance_evaluation/_stubs/ccp_service.py
@@ -1,0 +1,16 @@
+# STUB: replaced by Unit 2 at merge time
+"""Fallback :func:`build_evaluation` wrapper.
+
+Only used when :mod:`apps.core.services.ccp_service` is unavailable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import ccp
+
+
+def build_evaluation(**kwargs: Any) -> ccp.Evaluation:
+    """Construct a :class:`ccp.Evaluation` directly from kwargs."""
+    return ccp.Evaluation(**kwargs)

--- a/ccp/app/django-app/apps/performance_evaluation/_stubs/integrations.py
+++ b/ccp/app/django-app/apps/performance_evaluation/_stubs/integrations.py
@@ -1,0 +1,41 @@
+# STUB: replaced by Unit 11 at merge time
+"""Offline fallbacks for :mod:`apps.integrations.pi_client` and
+:mod:`apps.integrations.ai_analysis`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+
+def is_pi_available() -> bool:
+    """Return ``False`` when :mod:`pandaspi` is not installed."""
+    try:
+        import pandaspi  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def fetch_pi_data(
+    tag_map: dict[str, Any],
+    start: Any = None,
+    end: Any = None,
+    **opts: Any,
+) -> pd.DataFrame:
+    """Return an empty :class:`pandas.DataFrame` when PI is unreachable."""
+    return pd.DataFrame()
+
+
+def generate_ai_analysis(
+    evaluation: Any = None,
+    *,
+    provider: str = "gemini",
+    api_key: str | None = None,
+    **_: Any,
+) -> str:
+    """Return an empty string when no AI provider is configured."""
+    return ""

--- a/ccp/app/django-app/apps/performance_evaluation/_stubs/reports.py
+++ b/ccp/app/django-app/apps/performance_evaluation/_stubs/reports.py
@@ -1,0 +1,22 @@
+# STUB: replaced by Unit 10 at merge time
+"""Placeholder HTML report renderer used until Unit 10 lands."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def render_html_report(
+    evaluation: Any,
+    figures: dict[str, Any],
+    ai_summary: str = "",
+) -> str:
+    """Return a minimal HTML document describing ``evaluation``."""
+    title = "ccp Performance Report"
+    count = len(figures or {})
+    return (
+        "<!doctype html><html><head><meta charset='utf-8'>"
+        f"<title>{title}</title></head><body>"
+        f"<h1>{title}</h1><p>Figures: {count}</p>"
+        f"<pre>{ai_summary}</pre></body></html>"
+    )

--- a/ccp/app/django-app/apps/performance_evaluation/_stubs/session_store.py
+++ b/ccp/app/django-app/apps/performance_evaluation/_stubs/session_store.py
@@ -1,0 +1,23 @@
+# STUB: replaced by Unit 3 at merge time
+"""In-memory fallback for :mod:`apps.core.session_store`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_STORE: dict[str, dict[str, Any]] = {}
+
+
+def get_session(session_id: str) -> dict[str, Any]:
+    """Return the state dict for ``session_id`` (empty if missing)."""
+    return _STORE.setdefault(session_id, {})
+
+
+def set_session(session_id: str, state: dict[str, Any]) -> None:
+    """Persist ``state`` under ``session_id``."""
+    _STORE[session_id] = state
+
+
+def clear_session(session_id: str) -> None:
+    """Drop all state for ``session_id``."""
+    _STORE.pop(session_id, None)

--- a/ccp/app/django-app/apps/performance_evaluation/services/__init__.py
+++ b/ccp/app/django-app/apps/performance_evaluation/services/__init__.py
@@ -1,0 +1,13 @@
+"""Service layer for the performance evaluation Django app.
+
+Wraps the ``ccp.Evaluation`` pipeline, produces plotly figures and owns
+monitoring state serialisation. No Django request/response objects here.
+"""
+
+from apps.performance_evaluation.services import (
+    figures,
+    monitoring_state,
+    run_evaluation,
+)
+
+__all__ = ["figures", "monitoring_state", "run_evaluation"]

--- a/ccp/app/django-app/apps/performance_evaluation/services/additional_urls.py
+++ b/ccp/app/django-app/apps/performance_evaluation/services/additional_urls.py
@@ -1,0 +1,41 @@
+"""Wiring hints for Unit 8's ``urls.py``.
+
+Import and include these patterns from ``apps/performance_evaluation/urls.py``::
+
+    from apps.performance_evaluation.services.additional_urls import urlpatterns as extra
+    urlpatterns += extra
+"""
+
+from __future__ import annotations
+
+from django.urls import path
+
+from apps.performance_evaluation.views.compute import (
+    compute_view,
+    download_report_view,
+)
+from apps.performance_evaluation.views.monitoring import (
+    poll_view,
+    start_monitoring_view,
+    stop_monitoring_view,
+)
+
+urlpatterns = [
+    path("compute/", compute_view, name="performance_evaluation_compute"),
+    path("report/", download_report_view, name="performance_evaluation_report"),
+    path(
+        "monitoring/start/",
+        start_monitoring_view,
+        name="performance_evaluation_monitoring_start",
+    ),
+    path(
+        "monitoring/stop/",
+        stop_monitoring_view,
+        name="performance_evaluation_monitoring_stop",
+    ),
+    path(
+        "monitoring/poll/",
+        poll_view,
+        name="performance_evaluation_monitoring_poll",
+    ),
+]

--- a/ccp/app/django-app/apps/performance_evaluation/services/figures.py
+++ b/ccp/app/django-app/apps/performance_evaluation/services/figures.py
@@ -1,0 +1,385 @@
+"""Plotly figure builders for the performance evaluation results page.
+
+Two public entry points:
+
+* :func:`build_trend_figures` — time-series Delta-* scatter plots with
+  linear regression + 95% confidence band.
+* :func:`build_performance_figures` — head / power / efficiency /
+  discharge-pressure curves with historical point overlays coloured by
+  acquisition time.
+
+Every figure uses the ``ccp`` Plotly template registered by Unit 1.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+from scipy import stats
+
+import ccp
+
+Q_ = ccp.Q_
+
+_TREND_PLOTS: dict[str, str] = {
+    "Delta Efficiency (%)": "delta_eff",
+    "Delta Head (%)": "delta_head",
+    "Delta Power (%)": "delta_power",
+    "Delta Discharge Pressure (%)": "delta_p_disch",
+}
+
+# Internal ccp units for evaluation output.
+_FLOW_V_INTERNAL = "m³/s"
+_HEAD_INTERNAL = "J/kg"
+_POWER_INTERNAL = "W"
+_PRESSURE_INTERNAL = "bar"
+
+
+def _valid_points(df: pd.DataFrame) -> pd.DataFrame:
+    """Return the subset of rows flagged ``valid`` with a positive head."""
+    if df is None or df.empty:
+        return pd.DataFrame()
+    valid = df.get("valid", pd.Series(True, index=df.index)) == True  # noqa: E712
+    head_ok = df.get("head", pd.Series(0, index=df.index)) > 0
+    return df[valid & head_ok].copy()
+
+
+def _trend_plot(y_data: pd.Series, title: str) -> tuple[go.Figure, dict | None]:
+    """Build a single trend scatter + regression for ``y_data``."""
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scattergl(
+            x=y_data.index,
+            y=y_data,
+            mode="markers",
+            marker=dict(color="#1f77b4", size=6),
+            name=title,
+        )
+    )
+    fig.add_hline(y=0, line_dash="dash", line_color="red", line_width=1)
+
+    regression: dict | None = None
+    if len(y_data) >= 3:
+        x_num = y_data.index.astype("int64").values / 1e9
+        slope, intercept, r, p, _se = stats.linregress(x_num, y_data)
+        y_fit = slope * x_num + intercept
+
+        n = len(x_num)
+        x_mean = x_num.mean()
+        ss_x = ((x_num - x_mean) ** 2).sum()
+        residuals = y_data - y_fit
+        s_err = np.sqrt((residuals**2).sum() / max(n - 2, 1))
+        t_val = stats.t.ppf(0.975, max(n - 2, 1))
+        ci = t_val * s_err * np.sqrt(1 / n + (x_num - x_mean) ** 2 / max(ss_x, 1e-12))
+
+        order = np.argsort(x_num)
+        x_sorted = y_data.index[order]
+        y_sorted = y_fit[order]
+        ci_sorted = ci[order]
+
+        fig.add_trace(
+            go.Scatter(
+                x=x_sorted,
+                y=y_sorted,
+                mode="lines",
+                line=dict(color="orange", width=2),
+                name="Trend",
+            )
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=np.concatenate([x_sorted, x_sorted[::-1]]),
+                y=np.concatenate([y_sorted + ci_sorted, (y_sorted - ci_sorted)[::-1]]),
+                fill="toself",
+                fillcolor="rgba(255,165,0,0.15)",
+                line=dict(width=0),
+                name="95% CI",
+                hoverinfo="skip",
+            )
+        )
+
+        slope_per_month = slope * 30.44 * 24 * 3600
+        regression = {
+            "slope_per_month": float(slope_per_month),
+            "r_squared": float(r**2),
+            "p_value": float(p),
+            "n_points": int(n),
+        }
+        fig.add_annotation(
+            text=(f"slope: {slope_per_month:.3f} %/mo · R²={r**2:.3f} · p={p:.2e}"),
+            xref="paper",
+            yref="paper",
+            x=0.02,
+            y=0.98,
+            showarrow=False,
+            font=dict(size=11),
+            bgcolor="rgba(255,255,255,0.8)",
+            bordercolor="#ccc",
+            borderwidth=1,
+        )
+
+    fig.update_layout(
+        title=title,
+        xaxis_title="Time",
+        yaxis_title=title,
+        showlegend=False,
+        template="ccp",
+    )
+    return fig, regression
+
+
+def build_trend_figures(evaluation: Any) -> dict[str, Any]:
+    """Return the 4 trend figures plus the regression metadata.
+
+    Parameters
+    ----------
+    evaluation : ccp.Evaluation
+        Evaluation whose ``df`` attribute carries the historical points.
+
+    Returns
+    -------
+    dict
+        ``{"figures": {col: go.Figure}, "regression": {col: info},
+        "valid": df, "empty": bool}``.
+    """
+    df_results = getattr(evaluation, "df", None)
+    df_valid = _valid_points(df_results)
+    figures: dict[str, go.Figure] = {}
+    regression: dict[str, dict] = {}
+    if df_valid.empty:
+        return {
+            "figures": figures,
+            "regression": regression,
+            "valid": df_valid,
+            "empty": True,
+        }
+
+    for title, col in _TREND_PLOTS.items():
+        if col not in df_valid.columns:
+            continue
+        y_data = df_valid[col].dropna()
+        if y_data.empty:
+            continue
+        fig, info = _trend_plot(y_data, title)
+        figures[col] = fig
+        if info is not None:
+            regression[col] = info
+
+    return {
+        "figures": figures,
+        "regression": regression,
+        "valid": df_valid,
+        "empty": False,
+    }
+
+
+def _colorbar(df_cluster: pd.DataFrame) -> dict[str, Any]:
+    """Build the date-aware colorbar used on performance plots."""
+    n_ticks = min(5, max(len(df_cluster), 1))
+    tick_positions = [i / max(n_ticks - 1, 1) for i in range(n_ticks)]
+    tick_indices = [int(p * max(len(df_cluster) - 1, 0)) for p in tick_positions]
+    tick_labels = [df_cluster.index[i].strftime("%Y-%m-%d") for i in tick_indices]
+    return dict(
+        title=dict(text="Date", side="right"),
+        tickvals=tick_positions,
+        ticktext=tick_labels,
+        orientation="h",
+        yanchor="top",
+        y=-0.2,
+        xanchor="center",
+        x=0.5,
+        thickness=12,
+        len=0.8,
+    )
+
+
+def _base_curves(
+    impeller: Any,
+    speed: Any,
+    *,
+    flow_v_units: str,
+    head_units: str,
+    power_units: str,
+    p_units: str,
+    similarity: bool,
+) -> dict[str, go.Figure]:
+    """Build the 4 base plots from the converted impeller."""
+    head = impeller.head_plot(
+        speed=speed,
+        flow_v_units=flow_v_units,
+        head_units=head_units,
+        similarity=similarity,
+    )
+    power = impeller.power_plot(
+        speed=speed,
+        flow_v_units=flow_v_units,
+        power_units=power_units,
+        similarity=similarity,
+    )
+    eff = impeller.eff_plot(
+        speed=speed,
+        flow_v_units=flow_v_units,
+        similarity=similarity,
+    )
+    disch = impeller.disch.p_plot(
+        speed=speed,
+        flow_v_units=flow_v_units,
+        p_units=p_units,
+        similarity=similarity,
+    )
+    for fig in (head, power, eff, disch):
+        if fig is not None:
+            fig.update_layout(template="ccp")
+    return {"head": head, "power": power, "eff": eff, "p_disch": disch}
+
+
+def build_performance_figures(
+    evaluation: Any,
+    *,
+    cluster_idx: int = 0,
+    show_similarity: bool = False,
+    flow_units: str = "m³/s",
+    head_units: str = "kJ/kg",
+    power_units: str = "kW",
+    pressure_units: str = "bar",
+    speed_units: str = "rpm",
+) -> dict[str, Any]:
+    """Return the 4 performance curves with historical overlays.
+
+    Parameters
+    ----------
+    evaluation : ccp.Evaluation
+        Evaluation object providing ``impellers_new`` and ``df``.
+    cluster_idx : int, optional
+        Index into ``evaluation.impellers_new``.
+    show_similarity : bool, optional
+        Forwarded to the impeller plot methods.
+    flow_units, head_units, power_units, pressure_units, speed_units : str
+        Plot display units.
+
+    Returns
+    -------
+    dict
+        ``{"figures": {...}, "empty": bool, "cluster_idx": int,
+        "n_clusters": int}``.
+    """
+    impellers = list(getattr(evaluation, "impellers_new", []) or [])
+    n_clusters = len(impellers)
+    if n_clusters == 0:
+        return {"figures": {}, "empty": True, "cluster_idx": 0, "n_clusters": 0}
+
+    cluster_idx = max(0, min(cluster_idx, n_clusters - 1))
+    impeller = impellers[cluster_idx]
+
+    df_valid = _valid_points(getattr(evaluation, "df", None))
+    if "cluster" in df_valid.columns:
+        df_cluster = df_valid[df_valid["cluster"] == cluster_idx].copy()
+    else:
+        df_cluster = df_valid
+
+    if df_cluster.empty:
+        return {
+            "figures": {},
+            "empty": True,
+            "cluster_idx": cluster_idx,
+            "n_clusters": n_clusters,
+        }
+
+    if "timescale" not in df_cluster.columns:
+        idx_num = pd.to_numeric(df_cluster.index.astype("int64"))
+        span = max(idx_num.max() - idx_num.min(), 1)
+        df_cluster["timescale"] = (idx_num - idx_num.min()) / span
+
+    hist_flow = df_cluster["flow_v"].apply(
+        lambda v: Q_(v, _FLOW_V_INTERNAL).to(flow_units).m
+    )
+    hist_head = df_cluster["head"].apply(
+        lambda v: Q_(v, _HEAD_INTERNAL).to(head_units).m
+    )
+    hist_eff = df_cluster["eff"]
+    hist_power = df_cluster["power"].apply(
+        lambda v: Q_(v, _POWER_INTERNAL).to(power_units).m
+    )
+    hist_p_disch = None
+    if "p_disch" in df_cluster.columns:
+        hist_p_disch = df_cluster["p_disch"].apply(
+            lambda v: Q_(v, _PRESSURE_INTERNAL).to(pressure_units).m
+        )
+
+    median_speed = Q_(float(df_cluster["speed"].median()), speed_units)
+
+    figures = _base_curves(
+        impeller,
+        median_speed,
+        flow_v_units=flow_units,
+        head_units=head_units,
+        power_units=power_units,
+        p_units=pressure_units,
+        similarity=show_similarity,
+    )
+
+    colorbar_cfg = _colorbar(df_cluster)
+    timescale = df_cluster["timescale"]
+
+    overlays = {
+        "head": hist_head,
+        "power": hist_power,
+        "eff": hist_eff,
+        "p_disch": hist_p_disch,
+    }
+    for key, y_series in overlays.items():
+        fig = figures.get(key)
+        if fig is None or y_series is None:
+            continue
+        marker: dict[str, Any] = dict(
+            color=timescale,
+            colorscale="Viridis",
+            size=6,
+        )
+        if key == "head":
+            marker["colorbar"] = colorbar_cfg
+        fig.add_trace(
+            go.Scatter(
+                x=hist_flow,
+                y=y_series,
+                mode="markers",
+                marker=marker,
+                name="Historical Points",
+                showlegend=True,
+            )
+        )
+
+    return {
+        "figures": figures,
+        "empty": False,
+        "cluster_idx": cluster_idx,
+        "n_clusters": n_clusters,
+    }
+
+
+def build_summary_stats(evaluation: Any) -> pd.DataFrame | None:
+    """Return ``describe()`` of the delta columns for valid points."""
+    df_results = getattr(evaluation, "df", None)
+    if df_results is None or df_results.empty:
+        return None
+    delta_cols = [
+        c
+        for c in ("delta_eff", "delta_head", "delta_power", "delta_p_disch")
+        if c in df_results.columns
+    ]
+    if not delta_cols:
+        return None
+    df_valid = _valid_points(df_results)
+    if df_valid.empty:
+        return None
+    return df_valid[delta_cols].describe()
+
+
+__all__ = [
+    "build_performance_figures",
+    "build_summary_stats",
+    "build_trend_figures",
+]

--- a/ccp/app/django-app/apps/performance_evaluation/services/monitoring_state.py
+++ b/ccp/app/django-app/apps/performance_evaluation/services/monitoring_state.py
@@ -1,0 +1,137 @@
+"""Redis-backed monitoring state helpers.
+
+Serialises the small bookkeeping variables (``monitoring_active`` flag,
+accumulated results DataFrame, last fetch timestamp) used by the online
+monitoring view. When Redis is not configured the helpers fall back to a
+process-local dictionary so unit tests and ``manage.py check`` keep
+working in isolation.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import time
+from typing import Any
+
+import pandas as pd
+
+try:  # pragma: no cover - exercised only when Django is installed
+    from django.core.cache import cache as _django_cache
+except Exception:  # pragma: no cover
+    _django_cache = None
+
+
+_PREFIX = "perfeval:mon:"
+_LOCAL: dict[str, Any] = {}
+
+
+def _key(session_id: str, field: str) -> str:
+    """Return the namespaced cache key."""
+    return f"{_PREFIX}{session_id}:{field}"
+
+
+def _get(key: str) -> Any:
+    if _django_cache is not None:
+        return _django_cache.get(key)
+    return _LOCAL.get(key)
+
+
+def _set(key: str, value: Any, timeout: int | None = 3600) -> None:
+    if _django_cache is not None:
+        _django_cache.set(key, value, timeout=timeout)
+    else:
+        _LOCAL[key] = value
+
+
+def _delete(key: str) -> None:
+    if _django_cache is not None:
+        _django_cache.delete(key)
+    else:
+        _LOCAL.pop(key, None)
+
+
+def set_active(session_id: str, active: bool) -> None:
+    """Flag monitoring as active/inactive for ``session_id``."""
+    _set(_key(session_id, "active"), bool(active))
+
+
+def is_active(session_id: str) -> bool:
+    """Return ``True`` if monitoring is currently running."""
+    return bool(_get(_key(session_id, "active")))
+
+
+def set_last_fetch(session_id: str, ts: float | None = None) -> None:
+    """Store the UNIX timestamp of the last successful fetch."""
+    _set(_key(session_id, "last_fetch"), float(ts if ts is not None else time.time()))
+
+
+def get_last_fetch(session_id: str) -> float | None:
+    """Return the UNIX timestamp of the last successful fetch, if any."""
+    value = _get(_key(session_id, "last_fetch"))
+    return float(value) if value is not None else None
+
+
+def set_accumulated_results(session_id: str, df: pd.DataFrame | None) -> None:
+    """Serialise ``df`` (JSON orient=split) and store it in cache."""
+    if df is None or df.empty:
+        _delete(_key(session_id, "accumulated"))
+        return
+    buffer = io.StringIO()
+    df.to_json(buffer, orient="split", date_format="iso", default_handler=str)
+    _set(_key(session_id, "accumulated"), buffer.getvalue())
+
+
+def get_accumulated_results(session_id: str) -> pd.DataFrame:
+    """Return the accumulated monitoring DataFrame (empty if missing)."""
+    raw = _get(_key(session_id, "accumulated"))
+    if not raw:
+        return pd.DataFrame()
+    try:
+        return pd.read_json(io.StringIO(raw), orient="split")
+    except ValueError:
+        return pd.DataFrame()
+
+
+def append_accumulated_results(
+    session_id: str,
+    new_rows: pd.DataFrame,
+    *,
+    keep: int = 5,
+) -> pd.DataFrame:
+    """Append ``new_rows`` to the accumulated DataFrame (keeping ``keep`` tail)."""
+    existing = get_accumulated_results(session_id)
+    if new_rows is None or new_rows.empty:
+        return existing
+    combined = pd.concat([existing, new_rows]) if not existing.empty else new_rows
+    trimmed = combined.tail(keep)
+    set_accumulated_results(session_id, trimmed)
+    return trimmed
+
+
+def clear(session_id: str) -> None:
+    """Reset every monitoring key for ``session_id``."""
+    for field in ("active", "last_fetch", "accumulated"):
+        _delete(_key(session_id, field))
+
+
+def snapshot(session_id: str) -> dict[str, Any]:
+    """Return a JSON-serialisable snapshot of the current monitoring state."""
+    return {
+        "active": is_active(session_id),
+        "last_fetch": get_last_fetch(session_id),
+        "accumulated_rows": len(get_accumulated_results(session_id)),
+    }
+
+
+__all__ = [
+    "append_accumulated_results",
+    "clear",
+    "get_accumulated_results",
+    "get_last_fetch",
+    "is_active",
+    "set_accumulated_results",
+    "set_active",
+    "set_last_fetch",
+    "snapshot",
+]

--- a/ccp/app/django-app/apps/performance_evaluation/services/run_evaluation.py
+++ b/ccp/app/django-app/apps/performance_evaluation/services/run_evaluation.py
@@ -1,0 +1,252 @@
+"""High-level orchestration for running a performance evaluation.
+
+Ports the ``_trigger_evaluation`` branch of
+``ccp/app/pages/4_performance_evaluation.py`` to a pure, request-free
+callable that Django views can invoke synchronously.
+
+The function:
+
+1. Pulls impellers + tag mappings from the caller-provided ``form_data``
+   (already validated by Unit 8's ``PerformanceEvaluationForm``).
+2. Fetches measured data from PI via :mod:`apps.integrations.pi_client`
+   with a graceful fallback to a CSV file on disk.
+3. Builds a :class:`ccp.Evaluation` via
+   :func:`apps.core.services.ccp_service.build_evaluation`.
+4. Generates trend + performance figures.
+5. Optionally calls the AI analysis service to produce a textual summary.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+import pandas as pd
+
+import ccp
+
+from apps.performance_evaluation.services import figures as _figures
+from apps.performance_evaluation.services import monitoring_state
+
+try:  # pragma: no cover - exercised when Unit 2 is merged
+    from apps.core.services.ccp_service import build_evaluation
+except Exception:  # pragma: no cover
+    from apps.performance_evaluation._stubs.ccp_service import build_evaluation
+
+try:  # pragma: no cover
+    from apps.integrations.pi_client import fetch_pi_data, is_pi_available
+except Exception:  # pragma: no cover
+    from apps.performance_evaluation._stubs.integrations import (
+        fetch_pi_data,
+        is_pi_available,
+    )
+
+try:  # pragma: no cover
+    from apps.integrations.ai_analysis import generate_ai_analysis
+except Exception:  # pragma: no cover
+    from apps.performance_evaluation._stubs.integrations import generate_ai_analysis
+
+try:  # pragma: no cover
+    from apps.core.session_store import get_session, set_session
+except Exception:  # pragma: no cover
+    from apps.performance_evaluation._stubs.session_store import (
+        get_session,
+        set_session,
+    )
+
+
+logger = logging.getLogger(__name__)
+
+Q_ = ccp.Q_
+
+
+def _coerce_datetime(value: Any) -> datetime | None:
+    """Coerce ``value`` to a naive :class:`datetime` if possible."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value
+    return pd.Timestamp(value).to_pydatetime()
+
+
+def _load_measured_data(
+    form_data: dict[str, Any],
+    tag_mappings: dict[str, Any],
+    start: datetime | None,
+    end: datetime | None,
+) -> pd.DataFrame:
+    """Return the raw measured DataFrame.
+
+    Pre-supplied ``measured_data`` (already a DataFrame) wins, otherwise
+    the CSV path in ``measured_csv`` is read, otherwise the PI client is
+    used when available.
+    """
+    measured = form_data.get("measured_data")
+    if isinstance(measured, pd.DataFrame):
+        return measured.copy()
+
+    csv_path = form_data.get("measured_csv")
+    if csv_path:
+        return pd.read_csv(csv_path, index_col=0, parse_dates=True)
+
+    if is_pi_available():
+        return fetch_pi_data(
+            tag_mappings,
+            start=start,
+            end=end,
+            testing=bool(form_data.get("testing", False)),
+        )
+    return pd.DataFrame()
+
+
+def _build_evaluation_kwargs(
+    form_data: dict[str, Any],
+    impellers: list[Any],
+    df_raw: pd.DataFrame,
+) -> dict[str, Any]:
+    """Assemble the kwargs dict for ``ccp.Evaluation``."""
+    data_units = form_data.get("data_units", {}) or {}
+
+    kwargs: dict[str, Any] = {
+        "data": df_raw,
+        "operation_fluid": form_data.get("operation_fluid"),
+        "data_units": data_units,
+        "impellers": impellers,
+        "n_clusters": len(impellers) or 1,
+        "calculate_points": True,
+        "parallel": not bool(form_data.get("testing", False)),
+        "temperature_fluctuation": float(form_data.get("temperature_fluctuation", 0.5)),
+        "pressure_fluctuation": float(form_data.get("pressure_fluctuation", 2.0)),
+        "speed_fluctuation": float(form_data.get("speed_fluctuation", 0.5)),
+    }
+
+    flow_method = form_data.get("flow_method", "Direct")
+    if flow_method != "Direct":
+        kwargs["D"] = Q_(
+            form_data.get("orifice_D", 0.5905),
+            form_data.get("orifice_D_unit", "m"),
+        )
+        kwargs["d"] = Q_(
+            form_data.get("orifice_d", 0.3661),
+            form_data.get("orifice_d_unit", "m"),
+        )
+        kwargs["tappings"] = form_data.get("orifice_tappings", "flange")
+
+    kwargs.update(form_data.get("evaluation_kwargs", {}) or {})
+    return kwargs
+
+
+def run_evaluation(
+    form_data: dict[str, Any],
+    session_id: str,
+    *,
+    evaluation: Any | None = None,
+) -> dict[str, Any]:
+    """Run one performance evaluation cycle.
+
+    Parameters
+    ----------
+    form_data : dict
+        Validated form payload from Unit 8's form.
+    session_id : str
+        Redis-backed session identifier. Used for state lookups and
+        monitoring bookkeeping.
+    evaluation : ccp.Evaluation, optional
+        Pre-built evaluation object. When given the heavy
+        ``build_evaluation`` call is skipped (used by tests and by the
+        incremental refresh path).
+
+    Returns
+    -------
+    dict
+        ``{"evaluation", "figures", "summary_df", "ai_summary",
+        "error", "trend", "performance"}``.
+    """
+    impellers = list(form_data.get("impellers") or [])
+    tag_mappings = form_data.get("tag_mappings") or {}
+    start = _coerce_datetime(form_data.get("start_datetime"))
+    end = _coerce_datetime(form_data.get("end_datetime"))
+
+    error: str | None = None
+
+    if evaluation is None:
+        try:
+            df_raw = _load_measured_data(form_data, tag_mappings, start, end)
+            kwargs = _build_evaluation_kwargs(form_data, impellers, df_raw)
+            evaluation = build_evaluation(**kwargs)
+        except Exception as exc:  # pragma: no cover - surfaced to the UI
+            logger.exception("Failed to build ccp.Evaluation")
+            error = str(exc)
+            evaluation = None
+
+    trend_result = (
+        _figures.build_trend_figures(evaluation)
+        if evaluation is not None
+        else {"figures": {}, "regression": {}, "empty": True}
+    )
+    perf_result = (
+        _figures.build_performance_figures(
+            evaluation,
+            cluster_idx=int(form_data.get("cluster_idx", 0)),
+            show_similarity=bool(form_data.get("show_similarity", False)),
+            flow_units=form_data.get("flow_units", "m³/s"),
+            head_units=form_data.get("head_units", "kJ/kg"),
+            power_units=form_data.get("power_units", "kW"),
+            pressure_units=form_data.get("pressure_units", "bar"),
+            speed_units=form_data.get("speed_units", "rpm"),
+        )
+        if evaluation is not None
+        else {"figures": {}, "empty": True, "cluster_idx": 0, "n_clusters": 0}
+    )
+    summary_df = (
+        _figures.build_summary_stats(evaluation) if evaluation is not None else None
+    )
+
+    ai_summary = ""
+    if (
+        evaluation is not None
+        and form_data.get("ai_enabled")
+        and form_data.get("ai_api_key")
+    ):
+        try:
+            ai_summary = generate_ai_analysis(
+                evaluation,
+                provider=form_data.get("ai_provider", "gemini"),
+                api_key=form_data.get("ai_api_key"),
+                azure_endpoint=form_data.get("ai_azure_endpoint"),
+                azure_deployment=form_data.get("ai_azure_deployment"),
+            )
+        except Exception as exc:  # pragma: no cover
+            logger.warning("AI analysis failed: %s", exc)
+            ai_summary = ""
+
+    # Persist a lightweight pointer in the Redis session for subsequent
+    # HTMX polls. The heavy Evaluation object itself is stored by the view
+    # (either directly, or via GridFS when larger than 16 MB).
+    state = get_session(session_id) or {}
+    state["has_evaluation"] = evaluation is not None
+    state["last_run"] = pd.Timestamp.utcnow().isoformat()
+    set_session(session_id, state)
+
+    figures_bundle: dict[str, Any] = {}
+    figures_bundle.update(
+        {f"trend_{k}": v for k, v in trend_result.get("figures", {}).items()}
+    )
+    figures_bundle.update(
+        {f"perf_{k}": v for k, v in perf_result.get("figures", {}).items()}
+    )
+
+    return {
+        "evaluation": evaluation,
+        "figures": figures_bundle,
+        "trend": trend_result,
+        "performance": perf_result,
+        "summary_df": summary_df,
+        "ai_summary": ai_summary,
+        "monitoring": monitoring_state.snapshot(session_id),
+        "error": error,
+    }
+
+
+__all__ = ["run_evaluation"]

--- a/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_performance.html
+++ b/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_performance.html
@@ -1,0 +1,24 @@
+{% load ccp_tags %}
+<section class="ccp-performance">
+    <h3>Curvas de Desempenho com Pontos Históricos</h3>
+    {% if not perf_figures %}
+        <div class="ccp-alert ccp-alert-warning">
+            Nenhum ponto válido para a curva convertida selecionada.
+        </div>
+    {% else %}
+        <div class="ccp-grid ccp-grid-2">
+            {% if perf_figures.head %}
+                <div class="ccp-cell">{% plotly_figure perf_figures.head %}</div>
+            {% endif %}
+            {% if perf_figures.eff %}
+                <div class="ccp-cell">{% plotly_figure perf_figures.eff %}</div>
+            {% endif %}
+            {% if perf_figures.power %}
+                <div class="ccp-cell">{% plotly_figure perf_figures.power %}</div>
+            {% endif %}
+            {% if perf_figures.p_disch %}
+                <div class="ccp-cell">{% plotly_figure perf_figures.p_disch %}</div>
+            {% endif %}
+        </div>
+    {% endif %}
+</section>

--- a/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_summary.html
+++ b/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_summary.html
@@ -1,0 +1,21 @@
+{% load ccp_tags %}
+<section class="ccp-summary">
+    <h3>Tabela de Resultados</h3>
+    {% if summary_df is None %}
+        <div class="ccp-alert ccp-alert-info">
+            Nenhuma estatística-resumo disponível.
+        </div>
+    {% else %}
+        <div class="ccp-summary-table">
+            {{ summary_html|safe }}
+        </div>
+    {% endif %}
+    <p class="ccp-download">
+        <a class="ccp-btn ccp-btn-primary"
+           href="/performance-evaluation/report/"
+           hx-post="/performance-evaluation/report/"
+           hx-swap="none">
+            Baixar Relatório HTML
+        </a>
+    </p>
+</section>

--- a/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_trends.html
+++ b/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_trends.html
@@ -1,0 +1,25 @@
+{% load ccp_tags %}
+<section class="ccp-trends">
+    <h3>Tendências de Desempenho ao Longo do Tempo</h3>
+    {% if not trend_figures %}
+        <div class="ccp-alert ccp-alert-warning">
+            Sem pontos calculados válidos para exibir.
+        </div>
+    {% else %}
+        <div class="ccp-grid ccp-grid-2">
+            {% for col, fig in trend_figures.items %}
+                <div class="ccp-cell" id="trend-{{ col }}">
+                    {% plotly_figure fig %}
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+    {% if monitoring.active %}
+        <div class="ccp-monitoring-status"
+             hx-get="/performance-evaluation/monitoring/poll/"
+             hx-trigger="every 30s"
+             hx-target="#performance-evaluation-results">
+            <em>Monitoramento ativo — atualizando a cada 30s.</em>
+        </div>
+    {% endif %}
+</section>

--- a/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/results.html
+++ b/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/results.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+{% load ccp_tags %}
+
+{% block title %}Performance Evaluation Results{% endblock %}
+
+{% block content %}
+<section class="ccp-results" id="performance-evaluation-results">
+    <h2>Resultados da Avaliação de Desempenho</h2>
+
+    {% if error %}
+        <div class="ccp-alert ccp-alert-error">
+            <strong>Erro ao executar avaliação:</strong> {{ error }}
+        </div>
+    {% endif %}
+
+    {% if not result.evaluation %}
+        <div class="ccp-alert ccp-alert-info">
+            Nenhum dado de avaliação disponível. Clique em <em>Run Evaluation</em>
+            para iniciar o cálculo.
+        </div>
+    {% else %}
+        <div class="ccp-tabs" x-data="{ tab: 'trend' }">
+            <nav class="ccp-tabnav">
+                <button type="button" :class="tab === 'trend' && 'active'"
+                        @click="tab = 'trend'">Trend Analysis</button>
+                <button type="button" :class="tab === 'perf' && 'active'"
+                        @click="tab = 'perf'">Performance Plots</button>
+                <button type="button" :class="tab === 'data' && 'active'"
+                        @click="tab = 'data'">Data Table</button>
+            </nav>
+
+            <div class="ccp-tabpanel" x-show="tab === 'trend'">
+                {% include "performance_evaluation/_trends.html" %}
+            </div>
+            <div class="ccp-tabpanel" x-show="tab === 'perf'">
+                {% include "performance_evaluation/_performance.html" %}
+            </div>
+            <div class="ccp-tabpanel" x-show="tab === 'data'">
+                {% include "performance_evaluation/_summary.html" %}
+            </div>
+        </div>
+
+        {% if ai_summary %}
+            <section class="ccp-ai-summary">
+                <h3>Análise Técnica (IA)</h3>
+                <pre>{{ ai_summary }}</pre>
+            </section>
+        {% endif %}
+    {% endif %}
+</section>
+{% endblock %}

--- a/ccp/app/django-app/apps/performance_evaluation/tests/apps.py
+++ b/ccp/app/django-app/apps/performance_evaluation/tests/apps.py
@@ -1,0 +1,8 @@
+"""Minimal ``AppConfig`` so the tests package can host a ``templatetags`` lib."""
+
+from django.apps import AppConfig
+
+
+class PerformanceEvaluationTestsConfig(AppConfig):
+    name = "apps.performance_evaluation.tests"
+    label = "performance_evaluation_tests"

--- a/ccp/app/django-app/apps/performance_evaluation/tests/conftest.py
+++ b/ccp/app/django-app/apps/performance_evaluation/tests/conftest.py
@@ -1,0 +1,66 @@
+"""Isolated pytest bootstrap for the performance evaluation Django app.
+
+Mirrors ``apps/straight_through/tests/conftest.py`` so this worker can
+run its own tests without Unit 1's ``ccp_web`` project package.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import django
+from django.conf import settings
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+if not settings.configured:
+    settings.configure(
+        DEBUG=True,
+        SECRET_KEY="test-secret",
+        ALLOWED_HOSTS=["*"],
+        ROOT_URLCONF="apps.performance_evaluation.tests.urls",
+        INSTALLED_APPS=[
+            "django.contrib.contenttypes",
+            "django.contrib.auth",
+            "django.contrib.sessions",
+            "apps.performance_evaluation.tests",
+        ],
+        MIDDLEWARE=[
+            "django.contrib.sessions.middleware.SessionMiddleware",
+        ],
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": ":memory:",
+            }
+        },
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "APP_DIRS": True,
+                "DIRS": [
+                    Path(__file__).resolve().parent / "templates",
+                    Path(__file__).resolve().parents[1] / "templates",
+                ],
+                "OPTIONS": {
+                    "context_processors": [
+                        "django.template.context_processors.request",
+                    ],
+                },
+            }
+        ],
+        SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies",
+        USE_TZ=True,
+        DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+        CACHES={
+            "default": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            }
+        },
+    )
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "")
+    django.setup()

--- a/ccp/app/django-app/apps/performance_evaluation/tests/templates/base.html
+++ b/ccp/app/django-app/apps/performance_evaluation/tests/templates/base.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>{% block title %}ccp{% endblock %}</title></head>
+<body>{% block content %}{% endblock %}</body>
+</html>

--- a/ccp/app/django-app/apps/performance_evaluation/tests/templatetags/ccp_tags.py
+++ b/ccp/app/django-app/apps/performance_evaluation/tests/templatetags/ccp_tags.py
@@ -1,0 +1,22 @@
+"""Stub template tag library for offline tests.
+
+Provides a trivial :func:`plotly_figure` implementation so the templates
+render to plain HTML without loading the real Unit 4 partials.
+"""
+
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.simple_tag
+def plotly_figure(fig, div_id=None):
+    """Return a placeholder ``<div>`` for a plotly figure."""
+    name = div_id or getattr(fig, "layout", None)
+    title = ""
+    if fig is not None and hasattr(fig, "layout"):
+        title = getattr(fig.layout, "title", None)
+        if title is not None:
+            title = getattr(title, "text", "") or ""
+    return mark_safe(f'<div class="ccp-plotly">{title}</div>')

--- a/ccp/app/django-app/apps/performance_evaluation/tests/test_compute_view.py
+++ b/ccp/app/django-app/apps/performance_evaluation/tests/test_compute_view.py
@@ -1,0 +1,33 @@
+"""HTTP-level smoke tests for the compute and monitoring views."""
+
+from __future__ import annotations
+
+from django.test import Client
+
+
+def test_compute_view_get_returns_results_partial():
+    client = Client()
+    response = client.get("/performance-evaluation/compute/")
+    assert response.status_code == 200
+    body = response.content.decode("utf-8")
+    assert "Avaliação de Desempenho" in body
+    assert "Run Evaluation" in body or "Nenhum dado" in body
+
+
+def test_monitoring_start_and_stop_endpoints():
+    client = Client()
+    start = client.post("/performance-evaluation/monitoring/start/")
+    assert start.status_code == 200
+
+    stop = client.post("/performance-evaluation/monitoring/stop/")
+    assert stop.status_code == 200
+    payload = stop.json()
+    assert payload["active"] is False
+
+
+def test_monitoring_poll_returns_trends_partial():
+    client = Client()
+    response = client.get("/performance-evaluation/monitoring/poll/")
+    assert response.status_code == 200
+    body = response.content.decode("utf-8")
+    assert "ccp-trends" in body or "Tendências" in body

--- a/ccp/app/django-app/apps/performance_evaluation/tests/test_services.py
+++ b/ccp/app/django-app/apps/performance_evaluation/tests/test_services.py
@@ -1,0 +1,149 @@
+"""Unit tests for the performance evaluation service layer."""
+
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+import pytest
+
+from apps.performance_evaluation.services import figures, monitoring_state
+from apps.performance_evaluation.services.run_evaluation import run_evaluation
+
+
+class _FakeImpeller:
+    """Minimal impeller stand-in exposing the plot methods used by figures."""
+
+    def __init__(self) -> None:
+        self.disch = self
+
+    def _fig(self, title: str) -> go.Figure:
+        return go.Figure(layout={"title": {"text": title}})
+
+    def head_plot(self, **_: object) -> go.Figure:
+        return self._fig("head")
+
+    def power_plot(self, **_: object) -> go.Figure:
+        return self._fig("power")
+
+    def eff_plot(self, **_: object) -> go.Figure:
+        return self._fig("eff")
+
+    def p_plot(self, **_: object) -> go.Figure:
+        return self._fig("p_disch")
+
+
+class _FakeEvaluation:
+    """Stand-in for ``ccp.Evaluation`` used by the service tests."""
+
+    def __init__(self, df: pd.DataFrame) -> None:
+        self.df = df
+        self.impellers_new = [_FakeImpeller()]
+
+
+def _sample_df() -> pd.DataFrame:
+    idx = pd.date_range("2024-01-01", periods=6, freq="D")
+    return pd.DataFrame(
+        {
+            "flow_v": [1.0, 1.1, 1.2, 1.3, 1.4, 1.5],
+            "head": [1000.0, 1010.0, 1020.0, 1030.0, 1040.0, 1050.0],
+            "eff": [0.75, 0.76, 0.77, 0.78, 0.77, 0.76],
+            "power": [100_000.0, 101_000.0, 102_000.0, 103_000.0, 104_000.0, 105_000.0],
+            "p_disch": [10.0, 10.1, 10.2, 10.3, 10.4, 10.5],
+            "speed": [9000.0, 9000.0, 9000.0, 9000.0, 9000.0, 9000.0],
+            "delta_eff": [0.1, 0.2, -0.1, 0.0, 0.1, 0.2],
+            "delta_head": [0.0, 0.1, 0.2, 0.0, 0.1, 0.2],
+            "delta_power": [0.0, 0.1, 0.0, -0.1, 0.1, 0.0],
+            "delta_p_disch": [0.0, 0.1, 0.0, 0.1, 0.0, 0.1],
+            "cluster": [0, 0, 0, 0, 0, 0],
+            "valid": [True, True, True, True, True, True],
+        },
+        index=idx,
+    )
+
+
+def test_build_trend_figures_returns_four_plots():
+    evaluation = _FakeEvaluation(_sample_df())
+    result = figures.build_trend_figures(evaluation)
+    assert result["empty"] is False
+    assert set(result["figures"]).issuperset(
+        {"delta_eff", "delta_head", "delta_power", "delta_p_disch"}
+    )
+    for fig in result["figures"].values():
+        assert isinstance(fig, go.Figure)
+    assert "delta_eff" in result["regression"]
+
+
+def test_build_trend_figures_empty_dataframe():
+    result = figures.build_trend_figures(_FakeEvaluation(pd.DataFrame()))
+    assert result["empty"] is True
+    assert result["figures"] == {}
+
+
+def test_build_performance_figures_produces_overlaid_curves():
+    evaluation = _FakeEvaluation(_sample_df())
+    result = figures.build_performance_figures(evaluation)
+    assert result["empty"] is False
+    assert set(result["figures"]) == {"head", "power", "eff", "p_disch"}
+    head_fig = result["figures"]["head"]
+    assert any("Historical" in (t.name or "") for t in head_fig.data)
+
+
+def test_build_performance_figures_no_impellers():
+    class _Empty:
+        df = _sample_df()
+        impellers_new: list[object] = []
+
+    result = figures.build_performance_figures(_Empty())
+    assert result["empty"] is True
+    assert result["n_clusters"] == 0
+
+
+def test_build_summary_stats_describes_delta_columns():
+    df = figures.build_summary_stats(_FakeEvaluation(_sample_df()))
+    assert df is not None
+    assert {"delta_eff", "delta_head", "delta_power", "delta_p_disch"}.issubset(
+        df.columns
+    )
+
+
+def test_monitoring_state_roundtrip():
+    session = "unit-test"
+    monitoring_state.clear(session)
+    assert monitoring_state.is_active(session) is False
+
+    monitoring_state.set_active(session, True)
+    assert monitoring_state.is_active(session) is True
+
+    df = _sample_df().head(3)
+    monitoring_state.set_accumulated_results(session, df)
+    restored = monitoring_state.get_accumulated_results(session)
+    assert len(restored) == 3
+
+    appended = monitoring_state.append_accumulated_results(
+        session, _sample_df().tail(3), keep=5
+    )
+    assert len(appended) == 5
+
+    snap = monitoring_state.snapshot(session)
+    assert snap["active"] is True
+    assert snap["accumulated_rows"] == 5
+
+    monitoring_state.clear(session)
+    assert monitoring_state.is_active(session) is False
+
+
+def test_run_evaluation_with_prebuilt_evaluation():
+    evaluation = _FakeEvaluation(_sample_df())
+    result = run_evaluation(
+        {"impellers": [_FakeImpeller()]},
+        session_id="run-eval",
+        evaluation=evaluation,
+    )
+    assert result["evaluation"] is evaluation
+    assert result["error"] is None
+    assert result["trend"]["empty"] is False
+    assert result["performance"]["empty"] is False
+    assert any(key.startswith("trend_") for key in result["figures"])
+    assert any(key.startswith("perf_") for key in result["figures"])
+    assert result["summary_df"] is not None
+    assert result["ai_summary"] == ""

--- a/ccp/app/django-app/apps/performance_evaluation/tests/urls.py
+++ b/ccp/app/django-app/apps/performance_evaluation/tests/urls.py
@@ -1,0 +1,29 @@
+"""Dedicated URLconf used by the performance evaluation test suite."""
+
+from django.urls import path
+
+from apps.performance_evaluation.views.compute import compute_view
+from apps.performance_evaluation.views.monitoring import (
+    poll_view,
+    start_monitoring_view,
+    stop_monitoring_view,
+)
+
+urlpatterns = [
+    path("performance-evaluation/compute/", compute_view, name="compute"),
+    path(
+        "performance-evaluation/monitoring/start/",
+        start_monitoring_view,
+        name="mon_start",
+    ),
+    path(
+        "performance-evaluation/monitoring/stop/",
+        stop_monitoring_view,
+        name="mon_stop",
+    ),
+    path(
+        "performance-evaluation/monitoring/poll/",
+        poll_view,
+        name="mon_poll",
+    ),
+]

--- a/ccp/app/django-app/apps/performance_evaluation/views/compute.py
+++ b/ccp/app/django-app/apps/performance_evaluation/views/compute.py
@@ -1,0 +1,118 @@
+"""HTMX endpoint that runs an evaluation and returns the results partial.
+
+Unit 8 owns the URL wiring; this module only exposes the callables.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+from django.views.decorators.http import require_http_methods
+
+from apps.performance_evaluation.services.run_evaluation import run_evaluation
+
+try:  # pragma: no cover
+    from apps.reports.views import render_html_report
+except Exception:  # pragma: no cover
+    from apps.performance_evaluation._stubs.reports import render_html_report
+
+try:  # pragma: no cover
+    from apps.core.session_store import get_session
+except Exception:  # pragma: no cover
+    from apps.performance_evaluation._stubs.session_store import get_session
+
+
+logger = logging.getLogger(__name__)
+
+
+def _form_data_from_request(request: HttpRequest) -> dict[str, Any]:
+    """Build a minimal ``form_data`` dict for the run_evaluation service.
+
+    Unit 8's ``PerformanceEvaluationForm`` is expected to populate most
+    of these fields via ``request.session`` / hidden inputs; this
+    fallback lets the endpoint still function when called directly from
+    a test or curl.
+    """
+    session_state = {}
+    try:
+        session_state = get_session(request.session.session_key or "anonymous") or {}
+    except Exception:
+        session_state = {}
+
+    form_data: dict[str, Any] = dict(session_state)
+    for key, value in request.POST.items():
+        form_data[key] = value
+    return form_data
+
+
+@require_http_methods(["GET", "POST"])
+def compute_view(request: HttpRequest) -> HttpResponse:
+    """Run an evaluation and return the ``results.html`` partial.
+
+    GET is accepted so operators can sanity-check the endpoint without
+    going through HTMX.
+    """
+    session_id = request.session.session_key or request.GET.get("sid", "anonymous")
+
+    if request.method == "GET":
+        result: dict[str, Any] = {
+            "evaluation": None,
+            "figures": {},
+            "trend": {"figures": {}, "regression": {}, "empty": True},
+            "performance": {
+                "figures": {},
+                "empty": True,
+                "cluster_idx": 0,
+                "n_clusters": 0,
+            },
+            "summary_df": None,
+            "ai_summary": "",
+            "error": None,
+        }
+    else:
+        form_data = _form_data_from_request(request)
+        result = run_evaluation(form_data, session_id)
+
+    context = {
+        "result": result,
+        "trend_figures": result.get("trend", {}).get("figures", {}),
+        "perf_figures": result.get("performance", {}).get("figures", {}),
+        "summary_df": result.get("summary_df"),
+        "summary_html": (
+            result["summary_df"].to_html(classes="ccp-summary", border=0)
+            if result.get("summary_df") is not None
+            else ""
+        ),
+        "ai_summary": result.get("ai_summary", ""),
+        "error": result.get("error"),
+        "n_clusters": result.get("performance", {}).get("n_clusters", 0),
+    }
+    return render(
+        request,
+        "performance_evaluation/results.html",
+        context,
+    )
+
+
+@require_http_methods(["POST"])
+def download_report_view(request: HttpRequest) -> HttpResponse:
+    """Regenerate the HTML report and stream it as an attachment."""
+    session_id = request.session.session_key or "anonymous"
+    form_data = _form_data_from_request(request)
+    result = run_evaluation(form_data, session_id)
+    html = render_html_report(
+        result.get("evaluation"),
+        result.get("figures", {}),
+        result.get("ai_summary", ""),
+    )
+    response = HttpResponse(html, content_type="text/html")
+    response["Content-Disposition"] = (
+        'attachment; filename="ccp_performance_report.html"'
+    )
+    return response
+
+
+__all__ = ["compute_view", "download_report_view"]

--- a/ccp/app/django-app/apps/performance_evaluation/views/monitoring.py
+++ b/ccp/app/django-app/apps/performance_evaluation/views/monitoring.py
@@ -1,0 +1,104 @@
+"""HTMX poll endpoints for the online monitoring panel.
+
+Unit 8 is responsible for exposing these under concrete URL patterns;
+this module ships the callables and an ``additional_urls.py`` hint in
+the ``services`` package.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pandas as pd
+from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.shortcuts import render
+from django.views.decorators.http import require_http_methods
+
+from apps.performance_evaluation.services import figures as _figures
+from apps.performance_evaluation.services import monitoring_state
+
+try:  # pragma: no cover
+    from apps.integrations.pi_client import fetch_pi_data
+except Exception:  # pragma: no cover
+    from apps.performance_evaluation._stubs.integrations import fetch_pi_data
+
+try:  # pragma: no cover
+    from apps.core.session_store import get_session
+except Exception:  # pragma: no cover
+    from apps.performance_evaluation._stubs.session_store import get_session
+
+
+logger = logging.getLogger(__name__)
+
+
+def _session_id(request: HttpRequest) -> str:
+    return request.session.session_key or request.GET.get("sid", "anonymous")
+
+
+@require_http_methods(["POST"])
+def start_monitoring_view(request: HttpRequest) -> HttpResponse:
+    """Flip the monitoring flag on and return the trends partial."""
+    session_id = _session_id(request)
+    monitoring_state.set_active(session_id, True)
+    monitoring_state.set_last_fetch(session_id)
+    return render(
+        request,
+        "performance_evaluation/_trends.html",
+        {"trend_figures": {}, "monitoring": monitoring_state.snapshot(session_id)},
+    )
+
+
+@require_http_methods(["POST"])
+def stop_monitoring_view(request: HttpRequest) -> HttpResponse:
+    """Flip the monitoring flag off."""
+    session_id = _session_id(request)
+    monitoring_state.set_active(session_id, False)
+    return JsonResponse(monitoring_state.snapshot(session_id))
+
+
+@require_http_methods(["GET", "POST"])
+def poll_view(request: HttpRequest) -> HttpResponse:
+    """Poll endpoint returning the freshly rebuilt trends partial.
+
+    Fetches new data from PI, appends to the Redis-backed accumulator,
+    rebuilds the trend figures from the accumulated history and returns
+    the ``_trends.html`` partial.
+    """
+    session_id = _session_id(request)
+
+    session_state = get_session(session_id) or {}
+    tag_mappings: dict[str, Any] = session_state.get("tag_mappings", {})
+
+    new_rows: pd.DataFrame
+    try:
+        new_rows = fetch_pi_data(tag_mappings, testing=True)
+    except Exception as exc:  # pragma: no cover
+        logger.warning("fetch_pi_data failed: %s", exc)
+        new_rows = pd.DataFrame()
+
+    accumulated = monitoring_state.append_accumulated_results(
+        session_id, new_rows, keep=5
+    )
+    monitoring_state.set_last_fetch(session_id)
+
+    class _Snapshot:
+        """Lightweight Evaluation-shaped object for figure builders."""
+
+        def __init__(self, df: pd.DataFrame) -> None:
+            self.df = df
+            self.impellers_new: list[Any] = []
+
+    trend_result = _figures.build_trend_figures(_Snapshot(accumulated))
+
+    return render(
+        request,
+        "performance_evaluation/_trends.html",
+        {
+            "trend_figures": trend_result.get("figures", {}),
+            "monitoring": monitoring_state.snapshot(session_id),
+        },
+    )
+
+
+__all__ = ["poll_view", "start_monitoring_view", "stop_monitoring_view"]


### PR DESCRIPTION
## Summary

Unit 9 of the Streamlit→Django migration. Ports the compute/results
half of ``ccp/app/pages/4_performance_evaluation.py`` (~1890 LOC) into
the new Django architecture.

- ``services/run_evaluation.py`` orchestrates PI data fetch and
  ``ccp.Evaluation`` construction via
  ``apps.core.services.ccp_service.build_evaluation`` (with offline
  stubs for sister units).
- ``services/figures.py`` produces the 4 trend plots (Delta Eff / Head
  / Power / P_disch with linear regression + 95% CI) and the 4
  performance curves (head, power, eff, discharge pressure) with
  historical overlays coloured by acquisition date. Every unit
  conversion goes through ``ccp.Q_``.
- ``services/monitoring_state.py`` keeps the monitoring flag, the
  accumulated results DataFrame and the last-fetch timestamp in Redis
  (falling back to ``django.core.cache.backends.locmem.LocMemCache``
  when Redis is unavailable).
- ``views/compute.py`` and ``views/monitoring.py`` expose HTMX
  endpoints. URL patterns are provided in
  ``services/additional_urls.py`` for Unit 8 to wire at merge time.
- Partial templates (``_trends.html``, ``_performance.html``,
  ``_summary.html``) extend ``base.html``, preserve Portuguese copy
  and render figures via ``{% plotly_figure %}``.

Cross-unit dependencies are imported with ``try/except`` from
``apps.core.services``, ``apps.core.session_store``,
``apps.integrations.*`` and ``apps.reports``; local stubs under
``_stubs/`` keep the app runnable in isolation.

## Notes for Unit 8

- Include ``apps.performance_evaluation.services.additional_urls``
  from the unit's ``urls.py``; the compute / monitoring endpoints are
  defined there.
- I did not write ``forms.py``, ``views/config.py``, ``apps.py``,
  ``__init__.py`` or ``urls.py`` — those remain Unit 8's scope.

## Test plan

- [x] ``uv run pytest ccp/app/django-app/apps/performance_evaluation/tests/``
      — 10 passing (figures, monitoring_state, run_evaluation, compute
      view, monitoring endpoints).
- [ ] ``manage.py check`` + full e2e runserver — deferred to the
      coordinator after Unit 1 (``manage.py``, ``ccp_web``) merges.