### PR TITLE
django-app: Unit 6 — back-to-back page

### DIFF
--- a/ccp/app/django-app/apps/back_to_back/__init__.py
+++ b/ccp/app/django-app/apps/back_to_back/__init__.py
@@ -1,0 +1,5 @@
+"""Django app for the back-to-back compressor performance test page.
+
+Ports ``ccp/app/pages/2_back_to_back.py`` from the Streamlit multi-page app
+to a Django app using HTMX for progressive enhancement.
+"""

--- a/ccp/app/django-app/apps/back_to_back/_stubs/__init__.py
+++ b/ccp/app/django-app/apps/back_to_back/_stubs/__init__.py
@@ -1,0 +1,8 @@
+"""Local stubs for cross-unit imports.
+
+These lightweight modules keep the ``back_to_back`` app loadable in isolation
+before Units 1, 2, 3, 4 land in the worktree. Each symbol is intentionally
+minimal: only the call sites used by this app need to work.
+
+# STUB: replaced by Units 1-4 at merge time
+"""

--- a/ccp/app/django-app/apps/back_to_back/_stubs/bootstrap.py
+++ b/ccp/app/django-app/apps/back_to_back/_stubs/bootstrap.py
@@ -1,0 +1,245 @@
+"""Populate ``sys.modules`` with stub substitutes for missing cross-unit code.
+
+Importing this module installs lightweight replacements for the public symbols
+listed in the migration plan (Units 2, 3, 4). Real implementations replace the
+stubs at merge time — the ``try/except ImportError`` pattern in ``services.py``
+means this shim is only needed while running the page in isolation.
+
+# STUB: replaced by Units 2-4 at merge time
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def _ensure(name: str, factory):
+    """Install *factory()* into ``sys.modules`` under *name* if missing."""
+    try:
+        importlib.import_module(name)
+        return
+    except ModuleNotFoundError:
+        sys.modules[name] = factory()
+
+
+def _ccp_service_module() -> types.ModuleType:
+    module = types.ModuleType("apps.core.services.ccp_service")
+
+    def build_back_to_back(
+        guarantee_point_sec1,
+        guarantee_point_sec2,
+        test_points_first,
+        test_points_second,
+        **opts,
+    ):
+        try:
+            from ccp.compressor import BackToBack
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError("ccp library required") from exc
+        return BackToBack(
+            guarantee_point_sec1=guarantee_point_sec1,
+            guarantee_point_sec2=guarantee_point_sec2,
+            test_points_sec1=list(test_points_first),
+            test_points_sec2=list(test_points_second),
+            reynolds_correction=opts.get("reynolds_correction", True),
+            bearing_mechanical_losses=opts.get("bearing_mechanical_losses", True),
+        )
+
+    def build_point_1sec(**kwargs):
+        import ccp
+
+        return ccp.Point(**kwargs)
+
+    def build_point_first_section(**kwargs):
+        from ccp.compressor import PointFirstSection
+
+        return PointFirstSection(**kwargs)
+
+    def build_point_second_section(**kwargs):
+        from ccp.compressor import PointSecondSection
+
+        return PointSecondSection(**kwargs)
+
+    def build_gas_state(composition, p, T):
+        import ccp
+
+        return ccp.State(p=p, T=T, fluid=dict(composition))
+
+    module.build_back_to_back = build_back_to_back
+    module.build_point_1sec = build_point_1sec
+    module.build_point_first_section = build_point_first_section
+    module.build_point_second_section = build_point_second_section
+    module.build_gas_state = build_gas_state
+    return module
+
+
+def _gas_composition_module() -> types.ModuleType:
+    module = types.ModuleType("apps.core.services.gas_composition")
+    module.FLUID_LIST = [
+        "methane",
+        "ethane",
+        "propane",
+        "n-butane",
+        "i-butane",
+        "nitrogen",
+        "carbon dioxide",
+        "hydrogen sulfide",
+        "water",
+    ]
+
+    def default_composition() -> dict:
+        return {"methane": 1.0}
+
+    def get_gas_composition(gas_name, gas_compositions_table, default_components):
+        if not gas_compositions_table:
+            return {"methane": 1.0}
+        for row in gas_compositions_table:
+            if row.get("name") == gas_name:
+                return {
+                    k: float(v)
+                    for k, v in row.items()
+                    if k != "name" and v not in (None, "", 0, 0.0)
+                }
+        return {"methane": 1.0}
+
+    module.default_composition = default_composition
+    module.get_gas_composition = get_gas_composition
+    return module
+
+
+def _storage_importer_module() -> types.ModuleType:
+    module = types.ModuleType("apps.core.storage.ccp_file_importer")
+
+    def load_ccp_file(fp) -> dict:
+        import io
+        import json
+        import zipfile
+
+        state: dict = {}
+        data = fp.read() if hasattr(fp, "read") else fp
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            for name in zf.namelist():
+                if name.endswith(".json"):
+                    state.update(json.loads(zf.read(name)))
+                elif name.endswith(".png"):
+                    state[name.split(".")[0]] = zf.read(name)
+        return state
+
+    module.load_ccp_file = load_ccp_file
+    return module
+
+
+def _storage_exporter_module() -> types.ModuleType:
+    module = types.ModuleType("apps.core.storage.ccp_file_exporter")
+
+    def export_ccp_file(state: dict) -> bytes:
+        import io
+        import json
+        import zipfile
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            serialisable = {
+                k: v
+                for k, v in state.items()
+                if isinstance(v, (str, int, float, bool, list, dict, type(None)))
+            }
+            zf.writestr("session_state.json", json.dumps(serialisable, default=str))
+        return buf.getvalue()
+
+    module.export_ccp_file = export_ccp_file
+    return module
+
+
+def _session_store_module() -> types.ModuleType:
+    module = types.ModuleType("apps.core.session_store")
+    _cache: dict[str, dict] = {}
+
+    def get_session(session_id: str) -> dict:
+        return _cache.get(session_id, {})
+
+    def set_session(session_id: str, state: dict) -> None:
+        _cache[session_id] = dict(state)
+
+    def clear_session(session_id: str) -> None:
+        _cache.pop(session_id, None)
+
+    module.get_session = get_session
+    module.set_session = set_session
+    module.clear_session = clear_session
+    return module
+
+
+def _models_module() -> types.ModuleType:
+    module = types.ModuleType("apps.core.models")
+
+    class Session:  # noqa: D401
+        """Minimal in-memory Session placeholder."""
+
+        def __init__(self, name="", app_type="back_to_back", state=None):
+            self.name = name
+            self.app_type = app_type
+            self.state = state or {}
+
+    module.Session = Session
+    return module
+
+
+def _templatetags_module() -> types.ModuleType:
+    from django import template
+    from django.utils.safestring import mark_safe
+
+    module = types.ModuleType("apps.core.templatetags.ccp_tags")
+    register = template.Library()
+
+    @register.simple_tag
+    def plotly_figure(fig, div_id=None):
+        if fig is None:
+            return ""
+        try:
+            import plotly.io as pio
+
+            return mark_safe(
+                pio.to_html(fig, full_html=False, include_plotlyjs=False)
+            )
+        except Exception:
+            return ""
+
+    @register.inclusion_tag("core/partials/expander.html", takes_context=False)
+    def expander(title, body_id, expanded=False):
+        return {"title": title, "body_id": body_id, "expanded": expanded}
+
+    @register.inclusion_tag("core/partials/parameter_row.html")
+    def parameter_row(key, value, unit_choices):
+        return {"key": key, "value": value, "unit_choices": unit_choices}
+
+    module.register = register
+    module.plotly_figure = plotly_figure
+    module.expander = expander
+    module.parameter_row = parameter_row
+    return module
+
+
+def install() -> None:
+    """Install all stub modules required by the back-to-back app."""
+    # Pre-register ccp_service BEFORE ``apps.core.services/__init__.py`` is
+    # imported: its package ``__init__`` re-exports ``ccp_service`` eagerly,
+    # so we must put our stub into ``sys.modules`` first.
+    if "apps.core.services.ccp_service" not in sys.modules:
+        sys.modules["apps.core.services.ccp_service"] = _ccp_service_module()
+    _ensure("apps.core", lambda: types.ModuleType("apps.core"))
+    _ensure("apps.core.services", lambda: types.ModuleType("apps.core.services"))
+    _ensure("apps.core.services.ccp_service", _ccp_service_module)
+    _ensure("apps.core.services.gas_composition", _gas_composition_module)
+    _ensure("apps.core.storage", lambda: types.ModuleType("apps.core.storage"))
+    _ensure("apps.core.storage.ccp_file_importer", _storage_importer_module)
+    _ensure("apps.core.storage.ccp_file_exporter", _storage_exporter_module)
+    _ensure("apps.core.session_store", _session_store_module)
+    _ensure("apps.core.models", _models_module)
+    _ensure(
+        "apps.core.templatetags",
+        lambda: types.ModuleType("apps.core.templatetags"),
+    )
+    _ensure("apps.core.templatetags.ccp_tags", _templatetags_module)

--- a/ccp/app/django-app/apps/back_to_back/_stubs/settings.py
+++ b/ccp/app/django-app/apps/back_to_back/_stubs/settings.py
@@ -1,0 +1,68 @@
+"""Minimal Django settings for running the back-to-back app in isolation.
+
+# STUB: replaced by Unit 1's ``ccp_web/settings.py`` at merge time
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[3]
+
+SECRET_KEY = "stub-secret-key-not-for-production"
+DEBUG = True
+ALLOWED_HOSTS = ["*"]
+
+INSTALLED_APPS = [
+    "django.contrib.contenttypes",
+    "django.contrib.auth",
+    "django.contrib.staticfiles",
+    "apps.back_to_back.apps.BackToBackConfig",
+]
+
+MIDDLEWARE = [
+    "django.middleware.common.CommonMiddleware",
+]
+
+ROOT_URLCONF = "apps.back_to_back._stubs.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [
+            BASE_DIR / "apps" / "back_to_back" / "_stubs" / "templates",
+            BASE_DIR / "apps" / "back_to_back" / "templates",
+        ],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.request",
+            ],
+            "builtins": [],
+        },
+    },
+]
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+
+STATIC_URL = "/static/"
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+USE_TZ = True
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    }
+}
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "apps.back_to_back._stubs.settings")
+
+from apps.back_to_back._stubs import bootstrap  # noqa: E402
+
+bootstrap.install()

--- a/ccp/app/django-app/apps/back_to_back/_stubs/templates/base.html
+++ b/ccp/app/django-app/apps/back_to_back/_stubs/templates/base.html
@@ -1,0 +1,24 @@
+{% load static %}<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8" />
+<title>{% block title %}ccp - Centrifugal Compressor Performance{% endblock %}</title>
+<style>
+body { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: #2c3e50; margin: 1rem; }
+h1, h2, h3 { color: #2c3e50; }
+.ccp-expander { border: 1px solid #d0d7e2; border-radius: 4px; margin: 0.5rem 0; }
+.ccp-expander > summary { background: #ebf0f8; padding: 0.4rem 0.6rem; cursor: pointer; }
+.ccp-expander > .body { padding: 0.5rem 0.75rem; }
+.row { display: flex; gap: 0.25rem; flex-wrap: wrap; }
+.col { flex: 1 1 8rem; }
+.ccp-grid { display: grid; gap: 0.25rem; }
+input[type=text], select { font-family: inherit; width: 100%; box-sizing: border-box; }
+button.primary { background: #2c3e50; color: #fff; border: none; padding: 0.4rem 0.8rem; cursor: pointer; }
+</style>
+{% block extra_head %}{% endblock %}
+</head>
+<body>
+<header><h1>ccp - Centrifugal Compressor</h1></header>
+<main>{% block content %}{% endblock %}</main>
+</body>
+</html>

--- a/ccp/app/django-app/apps/back_to_back/_stubs/templates/core/partials/expander.html
+++ b/ccp/app/django-app/apps/back_to_back/_stubs/templates/core/partials/expander.html
@@ -1,0 +1,4 @@
+<details class="ccp-expander"{% if expanded %} open{% endif %}>
+  <summary>{{ title }}</summary>
+  <div class="body" id="{{ body_id }}">{{ body|default:"" }}</div>
+</details>

--- a/ccp/app/django-app/apps/back_to_back/_stubs/templates/core/partials/parameter_row.html
+++ b/ccp/app/django-app/apps/back_to_back/_stubs/templates/core/partials/parameter_row.html
@@ -1,0 +1,4 @@
+<div class="row parameter-row" data-key="{{ key }}">
+  <span class="col label">{{ key }}</span>
+  <span class="col value">{{ value }}</span>
+</div>

--- a/ccp/app/django-app/apps/back_to_back/_stubs/urls.py
+++ b/ccp/app/django-app/apps/back_to_back/_stubs/urls.py
@@ -1,0 +1,10 @@
+"""Root URL configuration used only when running the app in isolation.
+
+# STUB: replaced by Unit 1's ``ccp_web/urls.py`` at merge time
+"""
+
+from django.urls import include, path
+
+urlpatterns = [
+    path("back-to-back/", include("apps.back_to_back.urls")),
+]

--- a/ccp/app/django-app/apps/back_to_back/apps.py
+++ b/ccp/app/django-app/apps/back_to_back/apps.py
@@ -1,0 +1,12 @@
+"""Django ``AppConfig`` for the back-to-back compressor page."""
+
+from django.apps import AppConfig
+
+
+class BackToBackConfig(AppConfig):
+    """Configuration for the back-to-back Django app."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.back_to_back"
+    label = "back_to_back"
+    verbose_name = "Back-to-Back Compressor"

--- a/ccp/app/django-app/apps/back_to_back/forms.py
+++ b/ccp/app/django-app/apps/back_to_back/forms.py
@@ -1,0 +1,267 @@
+"""Forms for the back-to-back compressor page.
+
+Each ``PointForm`` carries the parameters required by a single compressor
+performance point, matching the Streamlit widgets from
+``ccp/app/pages/2_back_to_back.py``. The full page uses three groups:
+
+* :class:`GuaranteePointForm` — shared guarantee point per section.
+* :class:`FirstSectionTestPointForm` — ×6 in a :class:`formset_factory`.
+* :class:`SecondSectionTestPointForm` — ×6 in a :class:`formset_factory`.
+
+All numeric fields are exposed as ``CharField`` so that the legacy decimal
+separator check from the Streamlit version still triggers on commas, and so
+empty strings survive the round-trip (the compute service treats blanks as
+"no data" rather than zero).
+"""
+
+from __future__ import annotations
+
+from django import forms
+from django.forms import formset_factory
+
+try:  # pragma: no cover - Unit 2 replaces these at merge time
+    from apps.core.services.unit_helpers import (
+        AREA_UNITS,
+        DENSITY_UNITS,
+        FLOW_UNITS,
+        HEAD_UNITS,
+        LENGTH_UNITS,
+        OIL_FLOW_UNITS,
+        POWER_UNITS,
+        PRESSURE_UNITS,
+        SPECIFIC_HEAT_UNITS,
+        SPEED_UNITS,
+        TEMPERATURE_UNITS,
+    )
+except Exception:  # noqa: BLE001
+    FLOW_UNITS = ["kg/h", "kg/s", "m³/h"]
+    PRESSURE_UNITS = ["bar", "Pa", "kPa", "MPa", "psi"]
+    TEMPERATURE_UNITS = ["degK", "degC", "degF"]
+    HEAD_UNITS = ["kJ/kg", "J/kg"]
+    POWER_UNITS = ["kW", "W", "hp"]
+    SPEED_UNITS = ["rpm", "Hz"]
+    LENGTH_UNITS = ["m", "mm", "in"]
+    OIL_FLOW_UNITS = ["l/min", "m³/h"]
+    DENSITY_UNITS = ["kg/m³", "g/cm³"]
+    SPECIFIC_HEAT_UNITS = ["kJ/kg/degK"]
+    AREA_UNITS = ["m²", "mm²"]
+
+try:
+    from apps.core.services.polytropic_methods import POLYTROPIC_METHODS
+except Exception:  # noqa: BLE001
+    POLYTROPIC_METHODS = {
+        "Sandberg-Colby": "sandberg_colby",
+        "Huntington": "huntington",
+        "Schultz": "schultz",
+    }
+
+try:
+    from apps.core.services.gas_composition import FLUID_LIST
+except Exception:  # noqa: BLE001
+    FLUID_LIST = ["methane", "ethane", "propane", "nitrogen", "carbon dioxide"]
+
+
+# Parameters shared by the guarantee / first / second section forms. Each
+# entry is ``(field_name, label, unit_choices, help_text)``.
+GUARANTEE_PARAMETERS = [
+    ("flow", "Flow", FLOW_UNITS, "Mass or volumetric flow at the compressor flange."),
+    ("suction_pressure", "Suction Pressure", PRESSURE_UNITS, ""),
+    ("suction_temperature", "Suction Temperature", TEMPERATURE_UNITS, ""),
+    ("discharge_pressure", "Discharge Pressure", PRESSURE_UNITS, ""),
+    ("discharge_temperature", "Discharge Temperature", TEMPERATURE_UNITS, ""),
+    ("power", "Power (gas)", POWER_UNITS, ""),
+    ("power_shaft", "Power (shaft)", POWER_UNITS, ""),
+    ("speed", "Speed", SPEED_UNITS, ""),
+    ("head", "Head", HEAD_UNITS, ""),
+    ("eff", "Efficiency", ["dimensionless"], ""),
+    ("b", "Impeller outlet width b", LENGTH_UNITS, ""),
+    ("D", "Impeller outer diameter D", LENGTH_UNITS, ""),
+    ("surface_roughness", "Surface Roughness", LENGTH_UNITS, ""),
+    ("casing_area", "Casing Area", AREA_UNITS, ""),
+]
+
+FIRST_SECTION_TEST_PARAMETERS = [
+    ("flow", "Flow", FLOW_UNITS),
+    ("suction_pressure", "Suction Pressure", PRESSURE_UNITS),
+    ("suction_temperature", "Suction Temperature", TEMPERATURE_UNITS),
+    ("discharge_pressure", "Discharge Pressure", PRESSURE_UNITS),
+    ("discharge_temperature", "Discharge Temperature", TEMPERATURE_UNITS),
+    ("casing_delta_T", "Casing ΔT", TEMPERATURE_UNITS),
+    ("speed", "Speed", SPEED_UNITS),
+    ("balance_line_flow_m", "Balance line flow", FLOW_UNITS),
+    ("end_seal_upstream_pressure", "End seal upstream pressure", PRESSURE_UNITS),
+    ("end_seal_upstream_temperature", "End seal upstream temperature", TEMPERATURE_UNITS),
+    ("div_wall_flow_m", "Division wall flow", FLOW_UNITS),
+    ("div_wall_upstream_pressure", "Division wall upstream pressure", PRESSURE_UNITS),
+    ("div_wall_upstream_temperature", "Division wall upstream temperature", TEMPERATURE_UNITS),
+    ("first_section_discharge_flow_m", "First section discharge flow", FLOW_UNITS),
+    ("seal_gas_flow_m", "Seal gas flow", FLOW_UNITS),
+    ("seal_gas_temperature", "Seal gas temperature", TEMPERATURE_UNITS),
+    ("oil_flow_journal_bearing_de", "Oil flow journal bearing DE", OIL_FLOW_UNITS),
+    ("oil_flow_journal_bearing_nde", "Oil flow journal bearing NDE", OIL_FLOW_UNITS),
+    ("oil_flow_thrust_bearing_nde", "Oil flow thrust bearing NDE", OIL_FLOW_UNITS),
+    ("oil_inlet_temperature", "Oil inlet temperature", TEMPERATURE_UNITS),
+    ("oil_outlet_temperature_de", "Oil outlet temperature DE", TEMPERATURE_UNITS),
+    ("oil_outlet_temperature_nde", "Oil outlet temperature NDE", TEMPERATURE_UNITS),
+]
+
+SECOND_SECTION_TEST_PARAMETERS = [
+    ("flow", "Flow", FLOW_UNITS),
+    ("suction_pressure", "Suction Pressure", PRESSURE_UNITS),
+    ("suction_temperature", "Suction Temperature", TEMPERATURE_UNITS),
+    ("discharge_pressure", "Discharge Pressure", PRESSURE_UNITS),
+    ("discharge_temperature", "Discharge Temperature", TEMPERATURE_UNITS),
+    ("casing_delta_T", "Casing ΔT", TEMPERATURE_UNITS),
+    ("speed", "Speed", SPEED_UNITS),
+    ("balance_line_flow_m", "Balance line flow", FLOW_UNITS),
+    ("seal_gas_flow_m", "Seal gas flow", FLOW_UNITS),
+    ("oil_flow_journal_bearing_de", "Oil flow journal bearing DE", OIL_FLOW_UNITS),
+    ("oil_flow_journal_bearing_nde", "Oil flow journal bearing NDE", OIL_FLOW_UNITS),
+    ("oil_flow_thrust_bearing_nde", "Oil flow thrust bearing NDE", OIL_FLOW_UNITS),
+    ("oil_inlet_temperature", "Oil inlet temperature", TEMPERATURE_UNITS),
+    ("oil_outlet_temperature_de", "Oil outlet temperature DE", TEMPERATURE_UNITS),
+    ("oil_outlet_temperature_nde", "Oil outlet temperature NDE", TEMPERATURE_UNITS),
+]
+
+LEAKAGE_FIELDS = {
+    "balance_line_flow_m",
+    "end_seal_upstream_pressure",
+    "end_seal_upstream_temperature",
+    "div_wall_flow_m",
+    "div_wall_upstream_pressure",
+    "div_wall_upstream_temperature",
+    "first_section_discharge_flow_m",
+}
+SEAL_GAS_FIELDS = {"seal_gas_flow_m", "seal_gas_temperature"}
+
+
+def _add_parameter_fields(form, parameters):
+    for name, label, unit_choices, *rest in parameters:
+        help_text = rest[0] if rest else ""
+        form.fields[f"{name}_value"] = forms.CharField(
+            required=False,
+            label=label,
+            help_text=help_text,
+            widget=forms.TextInput(attrs={"class": "ccp-value"}),
+        )
+        form.fields[f"{name}_units"] = forms.ChoiceField(
+            required=False,
+            choices=[(u, u) for u in unit_choices],
+            label=f"{label} units",
+            widget=forms.Select(attrs={"class": "ccp-units"}),
+        )
+
+
+class GasCompositionForm(forms.Form):
+    """Placeholder gas-composition selector.
+
+    The real form lives in Unit 4; this version keeps the public API
+    compatible so the page can render a sensible dropdown in isolation.
+    """
+
+    gas_name = forms.CharField(
+        required=False, initial="gas_0", label="Gas Selection"
+    )
+
+
+class GuaranteePointForm(forms.Form):
+    """Guarantee point for a single section (first or second)."""
+
+    section = forms.ChoiceField(
+        choices=[("section_1", "First Section"), ("section_2", "Second Section")],
+        widget=forms.HiddenInput,
+    )
+    gas_name = forms.CharField(required=False, initial="gas_0")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        _add_parameter_fields(self, GUARANTEE_PARAMETERS)
+
+
+class FirstSectionTestPointForm(forms.Form):
+    """A single first-section test point."""
+
+    gas_name = forms.CharField(required=False, initial="gas_0")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        _add_parameter_fields(self, FIRST_SECTION_TEST_PARAMETERS)
+
+
+class SecondSectionTestPointForm(forms.Form):
+    """A single second-section test point."""
+
+    gas_name = forms.CharField(required=False, initial="gas_0")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        _add_parameter_fields(self, SECOND_SECTION_TEST_PARAMETERS)
+
+
+FirstSectionTestPointFormSet = formset_factory(
+    FirstSectionTestPointForm, extra=6, max_num=6
+)
+SecondSectionTestPointFormSet = formset_factory(
+    SecondSectionTestPointForm, extra=6, max_num=6
+)
+
+
+class SidebarOptionsForm(forms.Form):
+    """Options checkboxes + ambient pressure + polytropic method."""
+
+    reynolds_correction = forms.BooleanField(required=False, initial=True)
+    casing_heat_loss = forms.BooleanField(required=False, initial=True)
+    bearing_mechanical_losses = forms.BooleanField(required=False, initial=True)
+    calculate_leakages = forms.BooleanField(required=False, initial=True)
+    seal_gas_flow = forms.BooleanField(required=False, initial=True)
+    variable_speed = forms.BooleanField(required=False, initial=True)
+    show_points = forms.BooleanField(required=False, initial=True)
+
+    ambient_pressure_magnitude = forms.CharField(required=False, initial="1.01325")
+    ambient_pressure_unit = forms.ChoiceField(
+        required=False,
+        choices=[(u, u) for u in PRESSURE_UNITS],
+        initial="bar",
+    )
+    polytropic_method = forms.ChoiceField(
+        required=False,
+        choices=[(k, k) for k in POLYTROPIC_METHODS],
+        initial="Sandberg-Colby",
+    )
+
+    oil_specific_heat = forms.BooleanField(required=False, initial=False)
+    oil_specific_heat_value = forms.CharField(required=False, initial="2.0")
+    oil_density_value = forms.CharField(required=False, initial="860")
+    oil_iso = forms.BooleanField(required=False, initial=False)
+    oil_iso_classification = forms.ChoiceField(
+        required=False,
+        choices=[("VG 32", "VG 32"), ("VG 46", "VG 46")],
+        initial="VG 32",
+    )
+
+    def clean_ambient_pressure_magnitude(self):
+        value = self.cleaned_data.get("ambient_pressure_magnitude") or "1.01325"
+        if "," in value:
+            raise forms.ValidationError("Please use '.' as decimal separator")
+        return value
+
+
+class CurveUploadForm(forms.Form):
+    """Background curve upload for a single section / curve type."""
+
+    section = forms.ChoiceField(choices=[("sec1", "sec1"), ("sec2", "sec2")])
+    curve = forms.ChoiceField(
+        choices=[
+            ("head", "head"),
+            ("eff", "eff"),
+            ("discharge_pressure", "discharge_pressure"),
+            ("power", "power"),
+        ]
+    )
+    image = forms.FileField(required=False)
+    x_lower = forms.CharField(required=False)
+    x_upper = forms.CharField(required=False)
+    y_lower = forms.CharField(required=False)
+    y_upper = forms.CharField(required=False)
+    x_units = forms.CharField(required=False)
+    y_units = forms.CharField(required=False)

--- a/ccp/app/django-app/apps/back_to_back/services.py
+++ b/ccp/app/django-app/apps/back_to_back/services.py
@@ -1,0 +1,414 @@
+"""Service layer for the back-to-back compressor page.
+
+This module is the direct port of the large ``main()`` body in
+``ccp/app/pages/2_back_to_back.py``. It takes the dict produced by the Django
+forms (shape described in :func:`run_back_to_back`), constructs
+``ccp.compressor.PointFirstSection`` / ``PointSecondSection`` instances, and
+delegates the heavy lifting to
+:func:`apps.core.services.ccp_service.build_back_to_back`.
+
+The return value is a pure-Python dict suitable for JSON serialisation /
+template context: compute figures (``fig_head_sec1``, ``fig_power_sec2`` …)
+and a results table per section.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from apps.core.services import ccp_service
+except Exception:  # noqa: BLE001 - stubs layer installs a substitute
+    from apps.back_to_back._stubs import bootstrap as _stub_bootstrap
+
+    _stub_bootstrap.install()
+    from apps.core.services import ccp_service  # type: ignore[no-redef]
+
+try:
+    from apps.core.services.gas_composition import get_gas_composition
+except Exception:  # noqa: BLE001
+
+    def get_gas_composition(name, table, defaults):  # type: ignore[no-redef]
+        return {"methane": 1.0}
+
+
+try:
+    from apps.core.services.polytropic_methods import POLYTROPIC_METHODS
+except Exception:  # noqa: BLE001
+    POLYTROPIC_METHODS = {"Sandberg-Colby": "sandberg_colby"}
+
+
+import ccp
+from ccp.compressor import PointFirstSection, PointSecondSection
+
+Q_ = ccp.Q_
+
+CURVE_NAMES = ("head", "eff", "discharge_pressure", "power")
+SECTION_KEYS = ("sec1", "sec2")
+
+_SUBSCRIPT_T = "\u209c"
+_SUBSCRIPT_SP = "\u209b\u209a"
+_SUPERSCRIPT_CONV = "\u1d9c\u1d52\u207f\u1d5b"
+
+
+def _as_float(value: Any) -> float | None:
+    """Parse *value* as a float, treating blanks and ``None`` as missing."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    if "," in text:
+        raise ValueError("Please use '.' as decimal separator")
+    return float(text)
+
+
+def _q(value: Any, units: str | None):
+    """Wrap *value* in ``ccp.Q_`` if non-empty, else return ``None``."""
+    magnitude = _as_float(value)
+    if magnitude is None or not units:
+        return None
+    return Q_(magnitude, units)
+
+
+def _guarantee_kwargs(data: dict, *, bearing_mechanical_losses: bool) -> dict:
+    """Build ``ccp.Point`` kwargs for a guarantee point."""
+    units = data["units"]
+    values = data["values"]
+    fluid = data["fluid"]
+
+    kwargs: dict[str, Any] = {}
+    flow_units = units.get("flow")
+    if flow_units and Q_(0, flow_units).dimensionality == "[mass] / [time]":
+        kwargs["flow_m"] = _q(values.get("flow"), flow_units)
+    else:
+        kwargs["flow_v"] = _q(values.get("flow"), flow_units)
+
+    kwargs["suc"] = ccp.State(
+        p=_q(values["suction_pressure"], units["suction_pressure"]),
+        T=_q(values["suction_temperature"], units["suction_temperature"]),
+        fluid=fluid,
+    )
+    kwargs["disch"] = ccp.State(
+        p=_q(values["discharge_pressure"], units["discharge_pressure"]),
+        T=_q(values["discharge_temperature"], units["discharge_temperature"]),
+        fluid=fluid,
+    )
+    kwargs["speed"] = _q(values["speed"], units["speed"])
+    kwargs["b"] = _q(values["b"], units["b"])
+    kwargs["D"] = _q(values["D"], units["D"])
+
+    power_guarantee = _q(values.get("power"), units.get("power"))
+    if bearing_mechanical_losses:
+        power_shaft_text = values.get("power_shaft") or values.get("power")
+        power_shaft_units = units.get("power_shaft") or units.get("power")
+        power_shaft = _q(power_shaft_text, power_shaft_units)
+        if power_shaft is not None and power_guarantee is not None:
+            kwargs["power_losses"] = power_shaft.to("kW") - power_guarantee.to("kW")
+        else:
+            kwargs["power_losses"] = Q_(0, "W")
+    else:
+        kwargs["power_losses"] = Q_(0, "W")
+    return kwargs
+
+
+def _test_point_kwargs(
+    test_point: dict,
+    guarantee: dict,
+    *,
+    casing_heat_loss: bool,
+    calculate_leakages: bool,
+    seal_gas_flow: bool,
+    bearing_mechanical_losses: bool,
+    is_first_section: bool,
+) -> dict:
+    """Build ``PointFirstSection`` / ``PointSecondSection`` kwargs."""
+    units = test_point["units"]
+    values = test_point["values"]
+    fluid = test_point["fluid"]
+
+    kwargs: dict[str, Any] = {}
+    flow_units = units.get("flow")
+    if flow_units and Q_(0, flow_units).dimensionality == "[mass] / [time]":
+        kwargs["flow_m"] = _q(values.get("flow"), flow_units)
+    else:
+        kwargs["flow_v"] = _q(values.get("flow"), flow_units)
+
+    kwargs["suc"] = ccp.State(
+        p=_q(values["suction_pressure"], units["suction_pressure"]),
+        T=_q(values["suction_temperature"], units["suction_temperature"]),
+        fluid=fluid,
+    )
+    kwargs["disch"] = ccp.State(
+        p=_q(values["discharge_pressure"], units["discharge_pressure"]),
+        T=_q(values["discharge_temperature"], units["discharge_temperature"]),
+        fluid=fluid,
+    )
+
+    casing_delta = _q(values.get("casing_delta_T"), units.get("casing_delta_T"))
+    if casing_heat_loss and casing_delta is not None:
+        kwargs["casing_temperature"] = casing_delta
+        kwargs["ambient_temperature"] = 0
+    else:
+        kwargs["casing_temperature"] = 0
+        kwargs["ambient_temperature"] = 0
+
+    if calculate_leakages:
+        kwargs["balance_line_flow_m"] = _q(
+            values.get("balance_line_flow_m"), units.get("balance_line_flow_m")
+        )
+        seal_flow_units = units.get("seal_gas_flow_m") or "kg/s"
+        if seal_gas_flow:
+            kwargs["seal_gas_flow_m"] = _q(
+                values.get("seal_gas_flow_m"), seal_flow_units
+            ) or Q_(0, seal_flow_units)
+        else:
+            kwargs["seal_gas_flow_m"] = Q_(0, seal_flow_units)
+
+        if is_first_section:
+            kwargs["div_wall_flow_m"] = _q(
+                values.get("div_wall_flow_m"), units.get("div_wall_flow_m")
+            )
+            kwargs["first_section_discharge_flow_m"] = _q(
+                values.get("first_section_discharge_flow_m"),
+                units.get("first_section_discharge_flow_m"),
+            )
+            kwargs["end_seal_upstream_pressure"] = _q(
+                values.get("end_seal_upstream_pressure"),
+                units.get("end_seal_upstream_pressure"),
+            )
+            kwargs["end_seal_upstream_temperature"] = _q(
+                values.get("end_seal_upstream_temperature"),
+                units.get("end_seal_upstream_temperature"),
+            )
+            kwargs["div_wall_upstream_pressure"] = _q(
+                values.get("div_wall_upstream_pressure"),
+                units.get("div_wall_upstream_pressure"),
+            )
+            kwargs["div_wall_upstream_temperature"] = _q(
+                values.get("div_wall_upstream_temperature"),
+                units.get("div_wall_upstream_temperature"),
+            )
+            seal_temp_units = units.get("seal_gas_temperature") or "degK"
+            if seal_gas_flow:
+                kwargs["seal_gas_temperature"] = _q(
+                    values.get("seal_gas_temperature"), seal_temp_units
+                ) or Q_(0, seal_temp_units)
+            else:
+                kwargs["seal_gas_temperature"] = Q_(0, seal_temp_units)
+
+    kwargs["bearing_mechanical_losses"] = bearing_mechanical_losses
+    if bearing_mechanical_losses:
+        for oil_key in (
+            "oil_flow_journal_bearing_de",
+            "oil_flow_journal_bearing_nde",
+            "oil_flow_thrust_bearing_nde",
+            "oil_inlet_temperature",
+            "oil_outlet_temperature_de",
+            "oil_outlet_temperature_nde",
+        ):
+            kwargs[oil_key] = _q(values.get(oil_key), units.get(oil_key))
+
+    kwargs["b"] = _q(guarantee["values"]["b"], guarantee["units"]["b"])
+    kwargs["D"] = _q(guarantee["values"]["D"], guarantee["units"]["D"])
+    kwargs["casing_area"] = _q(
+        guarantee["values"].get("casing_area"), guarantee["units"].get("casing_area")
+    )
+    kwargs["surface_roughness"] = _q(
+        guarantee["values"].get("surface_roughness"),
+        guarantee["units"].get("surface_roughness"),
+    )
+    kwargs["speed"] = _q(values.get("speed"), units.get("speed"))
+    return kwargs
+
+
+def _section_results(back_to_back, sec: str, point_interpolated) -> dict:
+    """Build the per-section results dict mirroring the Streamlit table."""
+    test_points = getattr(back_to_back, f"test_points_{sec}")
+    guarantee = getattr(back_to_back, f"guarantee_point_{sec}")
+    flange_sp = getattr(back_to_back, f"points_flange_sp_{sec}")
+    flange_t = getattr(back_to_back, f"points_flange_t_{sec}")
+    rotor_sp = getattr(back_to_back, f"points_rotor_sp_{sec}")
+
+    def _round(values):
+        return [round(v, 5) for v in values]
+
+    return {
+        f"phi{_SUBSCRIPT_T}": _round(p.phi.m for p in test_points),
+        f"phi{_SUBSCRIPT_T}/phi{_SUBSCRIPT_SP}": _round(
+            p.phi.m / guarantee.phi.m for p in test_points
+        ),
+        "vi/vd": _round(p.volume_ratio.m for p in test_points),
+        f"Mach{_SUBSCRIPT_T}": _round(p.mach.m for p in test_points),
+        f"Re{_SUBSCRIPT_T}": _round(p.reynolds.m for p in test_points),
+        f"pd{_SUPERSCRIPT_CONV} (bar)": _round(
+            p.disch.p("bar").m for p in flange_sp
+        ),
+        f"Head{_SUPERSCRIPT_CONV} (kJ/kg)": _round(
+            p.head.to("kJ/kg").m for p in flange_sp
+        ),
+        f"Q{_SUPERSCRIPT_CONV} (m3/h)": _round(
+            p.flow_v.to("m³/h").m for p in flange_sp
+        ),
+        f"W{_SUPERSCRIPT_CONV} (kW)": _round(
+            p.power_shaft.to("kW").m for p in rotor_sp
+        ),
+        f"Eff{_SUBSCRIPT_T}": _round(p.eff.m for p in flange_t),
+        f"Eff{_SUPERSCRIPT_CONV}": _round(p.eff.m for p in flange_sp),
+        "interpolated_flow_v_m3_h": round(
+            point_interpolated.flow_v.to("m³/h").m, 5
+        ),
+        "interpolated_head_kJ_kg": round(
+            point_interpolated.head.to("kJ/kg").m, 5
+        ),
+        "interpolated_eff": round(point_interpolated.eff.m, 5),
+        "interpolated_discharge_pressure_bar": round(
+            point_interpolated.disch.p("bar").m, 5
+        ),
+    }
+
+
+def _generate_curve_plot(imp, point_interpolated, curve: str, *, show_points: bool):
+    """Render a compressor curve figure for *curve* in ``CURVE_NAMES``."""
+    plot_method = "disch.p" if curve == "discharge_pressure" else curve
+    from ccp.config.utilities import r_getattr
+
+    base = r_getattr(imp, f"{plot_method}_plot")(show_points=show_points)
+    return r_getattr(point_interpolated, f"{plot_method}_plot")(
+        fig=base, show_points=show_points
+    )
+
+
+def run_back_to_back(form_data: dict) -> dict:
+    """Run the back-to-back computation and return a context dict.
+
+    Parameters
+    ----------
+    form_data : dict
+        Dict with the following keys:
+
+        ``options`` : dict
+            Cleaned :class:`SidebarOptionsForm` data.
+        ``guarantee`` : dict with ``section_1`` and ``section_2`` entries,
+            each shaped as ``{"values": {...}, "units": {...}, "fluid": {...}}``.
+        ``test_points_first`` / ``test_points_second`` : list of dicts
+            Same shape as the guarantee entries.
+        ``calculate_speed`` : bool, optional
+            If ``True``, call
+            :meth:`BackToBack.calculate_speed_to_match_discharge_pressure`.
+
+    Returns
+    -------
+    dict
+        Context ready to be passed to the results template. Contains
+        ``figures`` (mapping ``fig_<curve>_<sec>`` → Plotly figure objects),
+        ``results_sec1`` / ``results_sec2`` tables, and ``speed_operational``.
+    """
+    options = form_data["options"]
+    guarantee = form_data["guarantee"]
+    test_points_first = form_data["test_points_first"]
+    test_points_second = form_data["test_points_second"]
+
+    try:
+        ccp.config.POLYTROPIC_METHOD = POLYTROPIC_METHODS[
+            options.get("polytropic_method", "Sandberg-Colby")
+        ]
+    except Exception:  # noqa: BLE001
+        pass
+
+    bearing_mechanical_losses = bool(options.get("bearing_mechanical_losses", True))
+    casing_heat_loss = bool(options.get("casing_heat_loss", True))
+    calculate_leakages = bool(options.get("calculate_leakages", True))
+    seal_gas_flow = bool(options.get("seal_gas_flow", True))
+    reynolds_correction = bool(options.get("reynolds_correction", True))
+    show_points = bool(options.get("show_points", True))
+
+    guarantee_point_sec1 = ccp.Point(
+        **_guarantee_kwargs(
+            guarantee["section_1"],
+            bearing_mechanical_losses=bearing_mechanical_losses,
+        )
+    )
+    guarantee_point_sec2 = ccp.Point(
+        **_guarantee_kwargs(
+            guarantee["section_2"],
+            bearing_mechanical_losses=bearing_mechanical_losses,
+        )
+    )
+
+    first_section_test_points = [
+        PointFirstSection(
+            **_test_point_kwargs(
+                tp,
+                guarantee["section_1"],
+                casing_heat_loss=casing_heat_loss,
+                calculate_leakages=calculate_leakages,
+                seal_gas_flow=seal_gas_flow,
+                bearing_mechanical_losses=bearing_mechanical_losses,
+                is_first_section=True,
+            )
+        )
+        for tp in test_points_first
+        if tp.get("values", {}).get("flow")
+    ]
+    second_section_test_points = [
+        PointSecondSection(
+            **_test_point_kwargs(
+                tp,
+                guarantee["section_2"],
+                casing_heat_loss=casing_heat_loss,
+                calculate_leakages=calculate_leakages,
+                seal_gas_flow=seal_gas_flow,
+                bearing_mechanical_losses=bearing_mechanical_losses,
+                is_first_section=False,
+            )
+        )
+        for tp in test_points_second
+        if tp.get("values", {}).get("flow")
+    ]
+
+    back_to_back = ccp_service.build_back_to_back(
+        guarantee_point_sec1=guarantee_point_sec1,
+        guarantee_point_sec2=guarantee_point_sec2,
+        test_points_first=first_section_test_points,
+        test_points_second=second_section_test_points,
+        reynolds_correction=reynolds_correction,
+        bearing_mechanical_losses=bearing_mechanical_losses,
+    )
+
+    if form_data.get("calculate_speed"):
+        back_to_back = back_to_back.calculate_speed_to_match_discharge_pressure()
+
+    figures: dict[str, Any] = {}
+    results: dict[str, dict] = {}
+    point_interpolated_sec1 = back_to_back.point_sec1(
+        flow_v=back_to_back.guarantee_point_sec1.flow_v,
+        speed=back_to_back.speed_operational,
+    )
+    point_interpolated_sec2 = back_to_back.point_sec2(
+        flow_v=back_to_back.guarantee_point_sec2.flow_v,
+        speed=back_to_back.speed_operational,
+    )
+
+    for sec, point_interpolated in (
+        ("sec1", point_interpolated_sec1),
+        ("sec2", point_interpolated_sec2),
+    ):
+        figures[f"fig_mach_{sec}"] = point_interpolated.plot_mach()
+        figures[f"fig_reynolds_{sec}"] = point_interpolated.plot_reynolds()
+        imp = getattr(back_to_back, f"imp_flange_sp_{sec}")
+        for curve in CURVE_NAMES:
+            figures[f"fig_{curve}_{sec}"] = _generate_curve_plot(
+                imp, point_interpolated, curve, show_points=show_points
+            )
+        results[sec] = _section_results(back_to_back, sec, point_interpolated)
+
+    return {
+        "figures": figures,
+        "results_sec1": results["sec1"],
+        "results_sec2": results["sec2"],
+        "speed_operational_rpm": float(back_to_back.speed_operational.to("rpm").m),
+        "back_to_back": back_to_back,
+    }

--- a/ccp/app/django-app/apps/back_to_back/templates/back_to_back/_results.html
+++ b/ccp/app/django-app/apps/back_to_back/templates/back_to_back/_results.html
@@ -1,0 +1,56 @@
+{% load ccp_tags %}
+
+{% if error %}
+  <div class="ccp-error" role="alert">{{ error }}</div>
+{% elif figures %}
+  <h3>Results</h3>
+  <p>Final speed used in calculation: {{ speed_operational_rpm|floatformat:2 }} RPM</p>
+
+  <div class="ccp-tabs">
+    <details class="ccp-expander" open>
+      <summary>First Section</summary>
+      <div class="body">
+        <div class="row">
+          <div class="col">{% plotly_figure figures.fig_mach_sec1 "fig-mach-sec1" %}</div>
+          <div class="col">{% plotly_figure figures.fig_reynolds_sec1 "fig-reynolds-sec1" %}</div>
+        </div>
+        <div class="row">
+          <div class="col">{% plotly_figure figures.fig_head_sec1 "fig-head-sec1" %}</div>
+          <div class="col">{% plotly_figure figures.fig_eff_sec1 "fig-eff-sec1" %}</div>
+        </div>
+        <div class="row">
+          <div class="col">{% plotly_figure figures.fig_discharge_pressure_sec1 "fig-disch-sec1" %}</div>
+          <div class="col">{% plotly_figure figures.fig_power_sec1 "fig-power-sec1" %}</div>
+        </div>
+        <table class="ccp-results">
+          {% for key, value in results_sec1.items %}
+            <tr><th>{{ key }}</th><td>{{ value }}</td></tr>
+          {% endfor %}
+        </table>
+      </div>
+    </details>
+
+    <details class="ccp-expander" open>
+      <summary>Second Section</summary>
+      <div class="body">
+        <div class="row">
+          <div class="col">{% plotly_figure figures.fig_mach_sec2 "fig-mach-sec2" %}</div>
+          <div class="col">{% plotly_figure figures.fig_reynolds_sec2 "fig-reynolds-sec2" %}</div>
+        </div>
+        <div class="row">
+          <div class="col">{% plotly_figure figures.fig_head_sec2 "fig-head-sec2" %}</div>
+          <div class="col">{% plotly_figure figures.fig_eff_sec2 "fig-eff-sec2" %}</div>
+        </div>
+        <div class="row">
+          <div class="col">{% plotly_figure figures.fig_discharge_pressure_sec2 "fig-disch-sec2" %}</div>
+          <div class="col">{% plotly_figure figures.fig_power_sec2 "fig-power-sec2" %}</div>
+        </div>
+        <table class="ccp-results">
+          {% for key, value in results_sec2.items %}
+            <tr><th>{{ key }}</th><td>{{ value }}</td></tr>
+          {% endfor %}
+        </table>
+      </div>
+    </details>
+  </div>
+{% endif %}

--- a/ccp/app/django-app/apps/back_to_back/templates/back_to_back/index.html
+++ b/ccp/app/django-app/apps/back_to_back/templates/back_to_back/index.html
@@ -1,0 +1,84 @@
+{% extends "base.html" %}
+{% load ccp_tags %}
+
+{% block title %}Performance Test Back-to-Back Compressor{% endblock %}
+
+{% block content %}
+<section>
+  <h2>Performance Test Back-to-Back Compressor</h2>
+  <p>Ferramenta para avaliação de desempenho de compressores back-to-back segundo a ASME PTC 10.</p>
+</section>
+
+<form method="post"
+      action="{% url 'back_to_back:compute' %}"
+      hx-post="{% url 'back_to_back:compute' %}"
+      hx-target="#bb-results"
+      hx-swap="innerHTML"
+      enctype="multipart/form-data">
+  {% csrf_token %}
+
+  <aside class="sidebar">
+    <details class="ccp-expander" open>
+      <summary>Opções</summary>
+      <div class="body">
+        {{ sidebar_form.as_p }}
+      </div>
+    </details>
+  </aside>
+
+  <details class="ccp-expander" open>
+    <summary>Seleção de Gás</summary>
+    <div class="body">{{ gas_form.as_p }}</div>
+  </details>
+
+  <details class="ccp-expander" open>
+    <summary>Data Sheet - First Section</summary>
+    <div class="body">{{ guarantee_section_1_form.as_p }}</div>
+  </details>
+
+  <details class="ccp-expander" open>
+    <summary>Data Sheet - Second Section</summary>
+    <div class="body">{{ guarantee_section_2_form.as_p }}</div>
+  </details>
+
+  <details class="ccp-expander">
+    <summary>Curvas de Referência</summary>
+    <div class="body">{{ curve_form.as_p }}</div>
+  </details>
+
+  <details class="ccp-expander" open>
+    <summary>Test Data - First Section</summary>
+    <div class="body">
+      {{ first_section_formset.management_form }}
+      {% for f in first_section_formset %}
+        <fieldset>
+          <legend>Point {{ forloop.counter }}</legend>
+          {{ f.as_p }}
+        </fieldset>
+      {% endfor %}
+    </div>
+  </details>
+
+  <details class="ccp-expander" open>
+    <summary>Test Data - Second Section</summary>
+    <div class="body">
+      {{ second_section_formset.management_form }}
+      {% for f in second_section_formset %}
+        <fieldset>
+          <legend>Point {{ forloop.counter }}</legend>
+          {{ f.as_p }}
+        </fieldset>
+      {% endfor %}
+    </div>
+  </details>
+
+  <div class="row">
+    <button type="submit" name="action" value="calculate" class="primary">Calculate</button>
+    <button type="submit" name="action" value="calculate_speed" class="primary">Calculate Speed</button>
+  </div>
+</form>
+
+<section id="bb-results">
+  {% include "back_to_back/_results.html" %}
+</section>
+{% endblock %}

--- a/ccp/app/django-app/apps/back_to_back/templatetags/ccp_tags.py
+++ b/ccp/app/django-app/apps/back_to_back/templatetags/ccp_tags.py
@@ -1,0 +1,57 @@
+"""Re-export of the core ``ccp_tags`` library.
+
+At merge time Unit 4 provides ``apps.core.templatetags.ccp_tags``. This shim
+imports from there when available and falls back to the local stub
+implementation so the back-to-back page can be loaded in isolation.
+
+# STUB: replaced by Unit 4's ``apps.core.templatetags.ccp_tags`` at merge time
+"""
+
+from __future__ import annotations
+
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+try:  # pragma: no cover - real implementation lives in Unit 4
+    from apps.core.templatetags.ccp_tags import (  # type: ignore
+        expander as _expander,
+        parameter_row as _parameter_row,
+        plotly_figure as _plotly_figure,
+    )
+except Exception:  # noqa: BLE001
+    _expander = None
+    _parameter_row = None
+    _plotly_figure = None
+
+
+@register.simple_tag
+def plotly_figure(fig, div_id=None):
+    """Render a Plotly figure as inline HTML (no full page)."""
+    if _plotly_figure is not None:
+        return _plotly_figure(fig, div_id=div_id)
+    if fig is None:
+        return ""
+    try:
+        import plotly.io as pio
+
+        return mark_safe(pio.to_html(fig, full_html=False, include_plotlyjs=False))
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+@register.inclusion_tag("core/partials/expander.html")
+def expander(title, body_id, expanded=False):
+    """Collapsible section tag matching the Streamlit expander look."""
+    if _expander is not None:
+        return _expander(title, body_id, expanded)
+    return {"title": title, "body_id": body_id, "expanded": expanded}
+
+
+@register.inclusion_tag("core/partials/parameter_row.html")
+def parameter_row(key, value, unit_choices):
+    """Render a single labelled parameter row."""
+    if _parameter_row is not None:
+        return _parameter_row(key, value, unit_choices)
+    return {"key": key, "value": value, "unit_choices": unit_choices}

--- a/ccp/app/django-app/apps/back_to_back/tests/conftest.py
+++ b/ccp/app/django-app/apps/back_to_back/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Pytest configuration for the back-to-back app.
+
+Boots Django with the local stub settings module so the tests can run in
+isolation (Unit 1's ``ccp_web`` package may not exist yet in this worktree).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+DJANGO_APP_ROOT = Path(__file__).resolve().parents[3]
+if str(DJANGO_APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(DJANGO_APP_ROOT))
+
+os.environ.setdefault(
+    "DJANGO_SETTINGS_MODULE", "apps.back_to_back._stubs.settings"
+)
+
+import django  # noqa: E402
+
+django.setup()

--- a/ccp/app/django-app/apps/back_to_back/tests/test_smoke.py
+++ b/ccp/app/django-app/apps/back_to_back/tests/test_smoke.py
@@ -1,0 +1,58 @@
+"""Smoke tests for the back-to-back Django app."""
+
+from __future__ import annotations
+
+from django.test import Client
+from django.urls import reverse
+
+
+def test_index_renders():
+    """The root page returns HTTP 200 and the Portuguese heading."""
+    client = Client()
+    response = client.get(reverse("back_to_back:index"))
+    assert response.status_code == 200
+    body = response.content.decode("utf-8")
+    assert "Performance Test Back-to-Back Compressor" in body
+    assert "Data Sheet - First Section" in body
+
+
+def test_forms_import():
+    """Forms module must import and formsets must have 6 slots."""
+    from apps.back_to_back.forms import (
+        FirstSectionTestPointFormSet,
+        SecondSectionTestPointFormSet,
+    )
+
+    assert FirstSectionTestPointFormSet.extra == 6
+    assert SecondSectionTestPointFormSet.extra == 6
+
+
+def test_services_module_surface():
+    """Services module exposes the ``run_back_to_back`` entry point."""
+    from apps.back_to_back import services
+
+    assert callable(services.run_back_to_back)
+    assert "sec1" in services.SECTION_KEYS
+    assert "sec2" in services.SECTION_KEYS
+    assert "head" in services.CURVE_NAMES
+    assert "power" in services.CURVE_NAMES
+
+
+def test_existing_ccp_file_is_loadable():
+    """The packaged ``example_back_to_back.ccp`` can be parsed by the importer."""
+    from pathlib import Path
+
+    from apps.back_to_back._stubs.bootstrap import install
+
+    install()
+    from apps.core.storage.ccp_file_importer import load_ccp_file
+
+    source = (
+        Path(__file__).resolve().parents[4] / "example_back_to_back.ccp"
+    )
+    if not source.exists():
+        return
+    with source.open("rb") as fp:
+        state = load_ccp_file(fp)
+    assert isinstance(state, dict)
+    assert "div_wall_flow_m_section_1_point_1" in state

--- a/ccp/app/django-app/apps/back_to_back/urls.py
+++ b/ccp/app/django-app/apps/back_to_back/urls.py
@@ -1,0 +1,17 @@
+"""URL configuration for the back-to-back compressor page."""
+
+from __future__ import annotations
+
+from django.urls import path
+
+from apps.back_to_back import views
+
+app_name = "back_to_back"
+
+urlpatterns = [
+    path("", views.index, name="index"),
+    path("compute/", views.compute, name="compute"),
+    path("upload-curve/", views.upload_curve, name="upload_curve"),
+    path("save.ccp", views.save_ccp, name="save_ccp"),
+    path("load.ccp", views.load_ccp, name="load_ccp"),
+]

--- a/ccp/app/django-app/apps/back_to_back/views.py
+++ b/ccp/app/django-app/apps/back_to_back/views.py
@@ -1,0 +1,223 @@
+"""Views for the back-to-back compressor page."""
+
+from __future__ import annotations
+
+from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.shortcuts import render
+from django.views.decorators.http import require_http_methods
+
+from apps.back_to_back.forms import (
+    CurveUploadForm,
+    FirstSectionTestPointFormSet,
+    GasCompositionForm,
+    GuaranteePointForm,
+    SecondSectionTestPointFormSet,
+    SidebarOptionsForm,
+)
+from apps.back_to_back import services
+
+try:  # pragma: no cover - Unit 3 replaces at merge time
+    from apps.core.session_store import get_session, set_session
+except Exception:  # noqa: BLE001
+    _memory: dict[str, dict] = {}
+
+    def get_session(session_id: str) -> dict:  # type: ignore[no-redef]
+        return _memory.get(session_id, {})
+
+    def set_session(session_id: str, state: dict) -> None:  # type: ignore[no-redef]
+        _memory[session_id] = dict(state)
+
+
+try:
+    from apps.core.storage.ccp_file_importer import load_ccp_file
+except Exception:  # noqa: BLE001
+
+    def load_ccp_file(fp):  # type: ignore[no-redef]
+        return {}
+
+
+try:
+    from apps.core.storage.ccp_file_exporter import export_ccp_file
+except Exception:  # noqa: BLE001
+
+    def export_ccp_file(state):  # type: ignore[no-redef]
+        return b""
+
+
+SESSION_KEY_PREFIX = "back_to_back:"
+
+
+def _session_id(request: HttpRequest) -> str:
+    """Return a stable session identifier.
+
+    Uses Django's session framework when available (Unit 1 wires it up); when
+    the app runs in isolation the session middleware may be disabled, in
+    which case we fall back to a per-request anonymous key.
+    """
+    session = getattr(request, "session", None)
+    if session is None:
+        return f"{SESSION_KEY_PREFIX}anonymous"
+    if not session.session_key:
+        try:
+            session.save()
+        except Exception:  # noqa: BLE001
+            return f"{SESSION_KEY_PREFIX}anonymous"
+    return f"{SESSION_KEY_PREFIX}{session.session_key}"
+
+
+def _context(request: HttpRequest, **extra) -> dict:
+    """Build the default template context, merging *extra*."""
+    ctx = {
+        "sidebar_form": SidebarOptionsForm(),
+        "gas_form": GasCompositionForm(),
+        "guarantee_section_1_form": GuaranteePointForm(
+            initial={"section": "section_1"}
+        ),
+        "guarantee_section_2_form": GuaranteePointForm(
+            initial={"section": "section_2"}
+        ),
+        "first_section_formset": FirstSectionTestPointFormSet(prefix="sec1"),
+        "second_section_formset": SecondSectionTestPointFormSet(prefix="sec2"),
+        "curve_form": CurveUploadForm(),
+        "saved_state": get_session(_session_id(request)),
+    }
+    ctx.update(extra)
+    return ctx
+
+
+def index(request: HttpRequest) -> HttpResponse:
+    """Render the main back-to-back configuration page."""
+    return render(request, "back_to_back/index.html", _context(request))
+
+
+def _split_values_units(form_cleaned: dict) -> tuple[dict, dict]:
+    values: dict = {}
+    units: dict = {}
+    for key, value in form_cleaned.items():
+        if key.endswith("_value"):
+            values[key[: -len("_value")]] = value
+        elif key.endswith("_units"):
+            units[key[: -len("_units")]] = value
+    return values, units
+
+
+def _point_payload(form_cleaned: dict) -> dict:
+    """Transform a single form's cleaned data into a services payload entry."""
+    values, units = _split_values_units(form_cleaned)
+    return {"values": values, "units": units, "fluid": {"methane": 1.0}}
+
+
+def _build_section_payload(formset_cleaned_list) -> list[dict]:
+    return [_point_payload(cd) for cd in formset_cleaned_list if cd]
+
+
+@require_http_methods(["POST"])
+def compute(request: HttpRequest) -> HttpResponse:
+    """Run the compressor computation and return the results partial."""
+    sidebar = SidebarOptionsForm(request.POST)
+    guarantee_sec1 = GuaranteePointForm(request.POST, prefix="guarantee_sec1")
+    guarantee_sec2 = GuaranteePointForm(request.POST, prefix="guarantee_sec2")
+    first_formset = FirstSectionTestPointFormSet(request.POST, prefix="sec1")
+    second_formset = SecondSectionTestPointFormSet(request.POST, prefix="sec2")
+
+    if not (
+        sidebar.is_valid()
+        and guarantee_sec1.is_valid()
+        and guarantee_sec2.is_valid()
+        and first_formset.is_valid()
+        and second_formset.is_valid()
+    ):
+        return render(
+            request,
+            "back_to_back/_results.html",
+            {
+                "error": "Please correct the highlighted fields.",
+                "sidebar_errors": sidebar.errors,
+            },
+            status=400,
+        )
+
+    payload = {
+        "options": sidebar.cleaned_data,
+        "guarantee": {
+            "section_1": _point_payload(guarantee_sec1.cleaned_data),
+            "section_2": _point_payload(guarantee_sec2.cleaned_data),
+        },
+        "test_points_first": _build_section_payload(
+            [f.cleaned_data for f in first_formset]
+        ),
+        "test_points_second": _build_section_payload(
+            [f.cleaned_data for f in second_formset]
+        ),
+        "calculate_speed": request.POST.get("action") == "calculate_speed",
+    }
+
+    try:
+        context = services.run_back_to_back(payload)
+    except Exception as exc:  # noqa: BLE001
+        return render(
+            request,
+            "back_to_back/_results.html",
+            {"error": f"Compute failed: {exc}"},
+            status=500,
+        )
+
+    set_session(
+        _session_id(request),
+        {
+            "speed_operational_rpm": context["speed_operational_rpm"],
+            "results_sec1": context["results_sec1"],
+            "results_sec2": context["results_sec2"],
+        },
+    )
+    return render(request, "back_to_back/_results.html", context)
+
+
+@require_http_methods(["POST"])
+def upload_curve(request: HttpRequest) -> HttpResponse:
+    """Store an uploaded curve PNG in the session state."""
+    form = CurveUploadForm(request.POST, request.FILES)
+    if not form.is_valid():
+        return JsonResponse({"ok": False, "errors": form.errors}, status=400)
+    state = get_session(_session_id(request))
+    key = f"fig_{form.cleaned_data['curve']}_{form.cleaned_data['section']}"
+    image = form.cleaned_data.get("image")
+    if image is not None:
+        state[key] = image.read()
+    state.setdefault("plot_limits", {}).setdefault(
+        form.cleaned_data["curve"], {}
+    )[form.cleaned_data["section"]] = {
+        "x": {
+            "lower_limit": form.cleaned_data.get("x_lower"),
+            "upper_limit": form.cleaned_data.get("x_upper"),
+            "units": form.cleaned_data.get("x_units"),
+        },
+        "y": {
+            "lower_limit": form.cleaned_data.get("y_lower"),
+            "upper_limit": form.cleaned_data.get("y_upper"),
+            "units": form.cleaned_data.get("y_units"),
+        },
+    }
+    set_session(_session_id(request), state)
+    return JsonResponse({"ok": True})
+
+
+@require_http_methods(["GET"])
+def save_ccp(request: HttpRequest) -> HttpResponse:
+    """Download the current session as a ``.ccp`` archive."""
+    state = get_session(_session_id(request))
+    payload = export_ccp_file(state)
+    response = HttpResponse(payload, content_type="application/zip")
+    response["Content-Disposition"] = 'attachment; filename="back_to_back.ccp"'
+    return response
+
+
+@require_http_methods(["POST"])
+def load_ccp(request: HttpRequest) -> HttpResponse:
+    """Load a ``.ccp`` archive into the session."""
+    uploaded = request.FILES.get("file")
+    if uploaded is None:
+        return JsonResponse({"ok": False, "error": "no file"}, status=400)
+    state = load_ccp_file(uploaded)
+    set_session(_session_id(request), state)
+    return render(request, "back_to_back/index.html", _context(request))


### PR DESCRIPTION
## Summary
- Port `ccp/app/pages/2_back_to_back.py` to a Django app under `ccp/app/django-app/apps/back_to_back/`
- Forms, services, views, templates, and tests for the dual-section back-to-back compressor page
- Per-section Plotly figures (`fig_head_sec1/sec2`, `fig_power_sec1/sec2`, `fig_eff_sec1/sec2`, `fig_discharge_pressure_sec1/sec2`, Mach and Reynolds) delegated to `apps.core.services.ccp_service.build_back_to_back`
- Local `_stubs/` shim for Units 1-4 so the page can be checked / tested / served in isolation before those units merge

## Test plan
- [x] `uv run django-admin check` — passes
- [x] `uv run pytest apps/back_to_back/tests/` — 4 passed
- [x] `curl -sI http://127.0.0.1:8767/back-to-back/` — HTTP 200