### PR TITLE
django-app: Unit 7 — curves conversion page

### DIFF
--- a/ccp/app/django-app/apps/curves_conversion/__init__.py
+++ b/ccp/app/django-app/apps/curves_conversion/__init__.py
@@ -1,0 +1,8 @@
+"""Curves conversion Django app (Unit 7).
+
+Ports ``ccp/app/pages/3_curves_conversion.py`` (Streamlit) to a Django app
+that reproduces the original look & feel via templates, HTMX, and the shared
+``apps.core`` service layer.
+"""
+
+default_app_config = "apps.curves_conversion.apps.CurvesConversionConfig"

--- a/ccp/app/django-app/apps/curves_conversion/_stubs/__init__.py
+++ b/ccp/app/django-app/apps/curves_conversion/_stubs/__init__.py
@@ -1,0 +1,7 @@
+# STUB: replaced by Units 2/3/4 at merge time
+"""Local stubs for cross-unit dependencies.
+
+These minimal modules let ``apps.curves_conversion`` run in isolation before
+Units 2, 3, and 4 land. Each module is clearly marked and mirrors the public
+API contract documented in the migration plan.
+"""

--- a/ccp/app/django-app/apps/curves_conversion/_stubs/ccp_file_exporter.py
+++ b/ccp/app/django-app/apps/curves_conversion/_stubs/ccp_file_exporter.py
@@ -1,0 +1,48 @@
+# STUB: replaced by Unit 3 at merge time
+"""Minimal exporter that writes the curves conversion state to a ``.ccp`` archive."""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from typing import Any
+
+import ccp
+import toml
+
+
+def export_ccp_file(state: dict[str, Any]) -> bytes:
+    """Serialise *state* into a ``.ccp`` ZIP archive.
+
+    Parameters
+    ----------
+    state : dict
+        Session state dict as produced by the curves conversion views.
+
+    Returns
+    -------
+    bytes
+        Bytes of a ZIP archive containing ``session_state.json``,
+        ``ccp.version``, curve CSVs, and TOML-serialised impellers.
+    """
+    buffer = io.BytesIO()
+    cleaned: dict[str, Any] = dict(state)
+    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("ccp.version", ccp.__version__)
+        for key, value in list(cleaned.items()):
+            if isinstance(value, ccp.Impeller):
+                if key in {"original_impeller", "converted_impeller"}:
+                    archive.writestr(f"{key}.toml", toml.dumps(value._dict_to_save()))
+                cleaned.pop(key)
+            elif (
+                key.startswith("curves_file_")
+                and isinstance(value, dict)
+                and "name" in value
+                and "content" in value
+            ):
+                archive.writestr(value["name"], value["content"])
+                cleaned.pop(key)
+        cleaned["app_type"] = "curves_conversion"
+        archive.writestr("session_state.json", json.dumps(cleaned, default=str))
+    return buffer.getvalue()

--- a/ccp/app/django-app/apps/curves_conversion/_stubs/ccp_file_importer.py
+++ b/ccp/app/django-app/apps/curves_conversion/_stubs/ccp_file_importer.py
@@ -1,0 +1,54 @@
+# STUB: replaced by Unit 3 at merge time
+"""Minimal importer for ``.ccp`` ZIP archives used by the curves conversion page."""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from typing import Any, BinaryIO
+
+import ccp
+
+
+def load_ccp_file(fp: BinaryIO) -> dict[str, Any]:
+    """Load a ``.ccp`` archive into a state dict.
+
+    Matches the behaviour of the Streamlit page's ``_load_curves_conversion``
+    helper: JSON session state, plus original / converted impeller TOML files,
+    plus any loose ``.csv`` curve files preserved under ``curves_file_<i>``.
+
+    Parameters
+    ----------
+    fp : file-like
+        Binary file-like object positioned at the start of a ``.ccp`` ZIP.
+
+    Returns
+    -------
+    dict
+        Session state dict with ``original_impeller`` / ``converted_impeller``
+        keys populated as :class:`ccp.Impeller` instances when present.
+    """
+    state: dict[str, Any] = {}
+    with zipfile.ZipFile(fp) as archive:
+        names = archive.namelist()
+        for name in names:
+            if name.endswith(".json"):
+                state = json.loads(archive.read(name))
+                if state.get("app_type") != "curves_conversion":
+                    state["app_type"] = "curves_conversion"
+        csv_index = 1
+        for name in names:
+            if name.endswith(".csv"):
+                state[f"curves_file_{csv_index}"] = {
+                    "name": name,
+                    "content": archive.read(name),
+                }
+                csv_index += 1
+            elif name.endswith(".toml"):
+                impeller_file = io.StringIO(archive.read(name).decode("utf-8"))
+                if name.startswith("original_impeller"):
+                    state["original_impeller"] = ccp.Impeller.load(impeller_file)
+                elif name.startswith("converted_impeller"):
+                    state["converted_impeller"] = ccp.Impeller.load(impeller_file)
+    return state

--- a/ccp/app/django-app/apps/curves_conversion/_stubs/ccp_service.py
+++ b/ccp/app/django-app/apps/curves_conversion/_stubs/ccp_service.py
@@ -1,0 +1,98 @@
+# STUB: replaced by Unit 2 at merge time
+"""Minimal ``ccp_service`` used when ``apps.core.services.ccp_service`` is absent.
+
+Delegates to the ``ccp`` library. Keeps the same public signatures documented
+in the migration plan so views can switch to the real implementation without
+code changes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import ccp
+
+
+def build_gas_state(composition: dict, p, T) -> ccp.State:
+    """Build a :class:`ccp.State` from a composition mapping and ``pint`` quantities.
+
+    Parameters
+    ----------
+    composition : dict
+        Component-to-molar-fraction mapping.
+    p : ccp.Q_
+        Suction pressure.
+    T : ccp.Q_
+        Suction temperature.
+
+    Returns
+    -------
+    ccp.State
+        Thermodynamic state describing the suction conditions.
+    """
+    return ccp.State(p=p, T=T, fluid=composition)
+
+
+def load_impeller_from_engauge_csv(
+    suction_state: ccp.State,
+    curve_name: str,
+    curve_path: Path,
+    **kwargs: Any,
+) -> ccp.Impeller:
+    """Load an :class:`ccp.Impeller` from Engauge-digitized CSVs.
+
+    Parameters
+    ----------
+    suction_state : ccp.State
+        Suction state for the original curves.
+    curve_name : str
+        Base name of the curve files (without the ``-head`` / ``-eff`` suffix).
+    curve_path : pathlib.Path
+        Directory containing the CSV files.
+    **kwargs
+        Forwarded to :meth:`ccp.Impeller.load_from_engauge_csv`.
+
+    Returns
+    -------
+    ccp.Impeller
+        The loaded impeller.
+    """
+    return ccp.Impeller.load_from_engauge_csv(
+        suc=suction_state,
+        curve_name=curve_name,
+        curve_path=curve_path,
+        **kwargs,
+    )
+
+
+def convert_impeller(
+    original_impeller: ccp.Impeller,
+    suction_state: ccp.State,
+    find: str = "speed",
+    speed: Any = "same",
+) -> ccp.Impeller:
+    """Convert an impeller to new suction conditions.
+
+    Parameters
+    ----------
+    original_impeller : ccp.Impeller
+        Impeller loaded from the original curves.
+    suction_state : ccp.State
+        Target suction state.
+    find : str, optional
+        Conversion strategy passed to :meth:`ccp.Impeller.convert_from`.
+    speed : str or None, optional
+        ``"same"`` to keep the original speed, ``None`` to recompute it.
+
+    Returns
+    -------
+    ccp.Impeller
+        The converted impeller.
+    """
+    return ccp.Impeller.convert_from(
+        original_impeller=original_impeller,
+        suc=suction_state,
+        find=find,
+        speed=speed,
+    )

--- a/ccp/app/django-app/apps/curves_conversion/_stubs/session_store.py
+++ b/ccp/app/django-app/apps/curves_conversion/_stubs/session_store.py
@@ -1,0 +1,48 @@
+# STUB: replaced by Unit 3 at merge time
+"""In-process session store fallback.
+
+Uses Django's cache backend so behaviour matches the Redis-backed store once
+Unit 3 lands. Values are pickled through the cache layer.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.cache import cache
+
+_PREFIX = "ccp.session."
+
+
+def get_session(session_id: str) -> dict[str, Any]:
+    """Return the session dict associated with *session_id*.
+
+    Parameters
+    ----------
+    session_id : str
+        Unique session identifier, typically ``request.session.session_key``.
+
+    Returns
+    -------
+    dict
+        Previously stored state, or an empty dict if none exists.
+    """
+    return cache.get(_PREFIX + session_id, {}) or {}
+
+
+def set_session(session_id: str, state: dict[str, Any]) -> None:
+    """Persist *state* for *session_id*.
+
+    Parameters
+    ----------
+    session_id : str
+        Unique session identifier.
+    state : dict
+        Arbitrary picklable dict to persist.
+    """
+    cache.set(_PREFIX + session_id, state, timeout=24 * 3600)
+
+
+def clear_session(session_id: str) -> None:
+    """Drop any state associated with *session_id*."""
+    cache.delete(_PREFIX + session_id)

--- a/ccp/app/django-app/apps/curves_conversion/apps.py
+++ b/ccp/app/django-app/apps/curves_conversion/apps.py
@@ -1,0 +1,12 @@
+"""Django ``AppConfig`` for the curves conversion page."""
+
+from django.apps import AppConfig
+
+
+class CurvesConversionConfig(AppConfig):
+    """Config for the curves conversion app."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.curves_conversion"
+    label = "curves_conversion"
+    verbose_name = "Curves Conversion"

--- a/ccp/app/django-app/apps/curves_conversion/forms.py
+++ b/ccp/app/django-app/apps/curves_conversion/forms.py
@@ -1,0 +1,101 @@
+"""Django forms for the curves conversion page.
+
+Forms mirror the Streamlit widgets from ``ccp/app/pages/3_curves_conversion.py``.
+They are deliberately thin — validation delegates to the ``ccp`` library inside
+:mod:`apps.curves_conversion.services`.
+"""
+
+from __future__ import annotations
+
+from django import forms
+
+try:
+    from apps.core.services.unit_helpers import (
+        FLOW_UNITS,
+        HEAD_UNITS,
+        POWER_UNITS,
+        PRESSURE_UNITS,
+        SPEED_UNITS,
+        TEMPERATURE_UNITS,
+    )
+except ImportError:  # pragma: no cover - fallback when Unit 2 not merged
+    FLOW_UNITS = ["m³/h", "m³/min", "m³/s", "kg/h", "kg/s"]
+    HEAD_UNITS = ["kJ/kg", "J/kg", "m*g0", "ft"]
+    POWER_UNITS = ["kW", "hp", "W", "MW"]
+    PRESSURE_UNITS = ["bar", "kgf/cm²", "Pa", "kPa", "MPa", "psi"]
+    SPEED_UNITS = ["rpm", "Hz"]
+    TEMPERATURE_UNITS = ["degK", "degC", "degF", "degR"]
+
+
+def _pairs(values):
+    """Return a list of ``(value, value)`` tuples for use in ``ChoiceField``."""
+    return [(value, value) for value in values]
+
+
+class SuctionConditionsForm(forms.Form):
+    """Shared fields for a suction state: gas name, pressure, temperature."""
+
+    gas = forms.CharField(max_length=64, required=False)
+    pressure = forms.FloatField(min_value=0.0)
+    pressure_unit = forms.ChoiceField(choices=_pairs(PRESSURE_UNITS))
+    temperature = forms.FloatField(min_value=0.0)
+    temperature_unit = forms.ChoiceField(choices=_pairs(TEMPERATURE_UNITS))
+
+
+class OriginalSuctionForm(SuctionConditionsForm):
+    """Suction conditions for the original (as-tested) curves."""
+
+
+class ConvertedSuctionForm(SuctionConditionsForm):
+    """Target suction conditions for the converted curves."""
+
+
+class ConversionParamsForm(forms.Form):
+    """Conversion strategy + unit selections for loaded and plot curves."""
+
+    find_method = forms.ChoiceField(
+        choices=[("speed", "speed"), ("volume_ratio", "volume_ratio")],
+        initial="speed",
+    )
+    speed_option = forms.ChoiceField(
+        choices=[("same", "same"), ("calculate", "calculate")],
+        initial="same",
+    )
+
+    loaded_flow_unit = forms.ChoiceField(choices=_pairs(FLOW_UNITS), initial="m³/h")
+    loaded_head_unit = forms.ChoiceField(choices=_pairs(HEAD_UNITS), initial="kJ/kg")
+    loaded_power_unit = forms.ChoiceField(choices=_pairs(POWER_UNITS), initial="kW")
+    loaded_disch_p_unit = forms.ChoiceField(
+        choices=_pairs(PRESSURE_UNITS), initial="bar"
+    )
+    loaded_disch_T_unit = forms.ChoiceField(
+        choices=_pairs(TEMPERATURE_UNITS), initial="degK"
+    )
+    loaded_speed_unit = forms.ChoiceField(choices=_pairs(SPEED_UNITS), initial="rpm")
+
+    plot_flow_unit = forms.ChoiceField(choices=_pairs(FLOW_UNITS), initial="m³/h")
+    plot_head_unit = forms.ChoiceField(choices=_pairs(HEAD_UNITS), initial="kJ/kg")
+    plot_power_unit = forms.ChoiceField(choices=_pairs(POWER_UNITS), initial="kW")
+    plot_disch_p_unit = forms.ChoiceField(choices=_pairs(PRESSURE_UNITS), initial="bar")
+    plot_disch_T_unit = forms.ChoiceField(
+        choices=_pairs(TEMPERATURE_UNITS), initial="degK"
+    )
+    plot_speed_unit = forms.ChoiceField(choices=_pairs(SPEED_UNITS), initial="rpm")
+
+    operational_flow = forms.FloatField(min_value=0.0, required=False)
+    operational_speed = forms.FloatField(min_value=0.0, required=False)
+
+
+class CurvesCSVUploadForm(forms.Form):
+    """Upload up to two Engauge-digitized CSV curve files."""
+
+    curves_file_1 = forms.FileField(required=False)
+    curves_file_2 = forms.FileField(required=False)
+
+    def clean(self):
+        cleaned = super().clean()
+        if not cleaned.get("curves_file_1") and not cleaned.get("curves_file_2"):
+            raise forms.ValidationError(
+                "Envie pelo menos um arquivo CSV digitalizado (Engauge)."
+            )
+        return cleaned

--- a/ccp/app/django-app/apps/curves_conversion/services.py
+++ b/ccp/app/django-app/apps/curves_conversion/services.py
@@ -1,0 +1,429 @@
+"""Service layer for the curves conversion page.
+
+All compressor math delegates to the ``ccp`` Python library through
+:mod:`apps.core.services.ccp_service` (with a local stub fallback). Plotly
+figures are rendered to HTML fragments that the templates embed directly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import ccp
+import plotly.io as pio
+from django.core.cache import cache
+
+try:
+    from apps.core.services import ccp_service
+except ImportError:  # pragma: no cover - stub fallback
+    from apps.curves_conversion._stubs import ccp_service  # type: ignore
+
+Q_ = ccp.Q_
+
+FLOW_V_UNITS = {"m³/h", "m³/min", "m³/s"}
+
+
+@dataclass
+class CurveFile:
+    """In-memory representation of an uploaded Engauge CSV."""
+
+    name: str
+    content: bytes
+
+
+def extract_curve_name(filename: str) -> str:
+    """Strip a known curve suffix from *filename*.
+
+    Parameters
+    ----------
+    filename : str
+        CSV filename, typically ``<curve>-head.csv`` or ``<curve>-eff.csv``.
+
+    Returns
+    -------
+    str
+        The base curve name with suffix and extension removed.
+    """
+    name = filename.rsplit(".", 1)[0]
+    suffixes = [
+        "head",
+        "eff",
+        "power",
+        "power_shaft",
+        "pressure_ratio",
+        "disch_T",
+    ]
+    for suffix in suffixes:
+        marker = f"-{suffix}"
+        if name.endswith(marker):
+            return name[: -len(marker)]
+    return name
+
+
+def resolve_flow_v_unit(flow_unit: str) -> str:
+    """Return a volumetric flow unit, defaulting to ``m³/h`` for mass-flow inputs."""
+    return flow_unit if flow_unit in FLOW_V_UNITS else "m³/h"
+
+
+def figure_to_html(fig) -> str:
+    """Render a Plotly figure to an embeddable HTML fragment.
+
+    Parameters
+    ----------
+    fig : plotly.graph_objects.Figure
+        Figure produced by ``ccp``'s plotting helpers.
+
+    Returns
+    -------
+    str
+        HTML fragment without ``<html>`` wrapping; Plotly.js is expected to be
+        loaded once by ``base.html``.
+    """
+    try:
+        fig.update_layout(template="ccp")
+    except Exception:  # pragma: no cover - template registration is optional
+        pass
+    return pio.to_html(fig, full_html=False, include_plotlyjs=False)
+
+
+def _hash_key(prefix: str, payload: dict[str, Any]) -> str:
+    """Compute a stable cache key for *prefix* and *payload*."""
+    digest = hashlib.sha1(
+        repr(sorted(payload.items())).encode("utf-8"), usedforsecurity=False
+    ).hexdigest()
+    return f"curves_conversion:{prefix}:{digest}"
+
+
+def load_original_impeller(
+    *,
+    curve_files: list[CurveFile],
+    suction_pressure: float,
+    suction_pressure_unit: str,
+    suction_temperature: float,
+    suction_temperature_unit: str,
+    gas_composition: dict,
+    flow_unit: str,
+    head_unit: str,
+    power_unit: str,
+    disch_p_unit: str,
+    disch_T_unit: str,
+    speed_unit: str,
+) -> ccp.Impeller:
+    """Load a :class:`ccp.Impeller` from uploaded Engauge CSVs.
+
+    Parameters
+    ----------
+    curve_files : list of CurveFile
+        Uploaded CSVs (at least one).
+    suction_pressure, suction_temperature : float
+        Suction state magnitudes.
+    suction_pressure_unit, suction_temperature_unit : str
+        Units for the suction state.
+    gas_composition : dict
+        Component-to-molar-fraction mapping for the suction gas.
+    flow_unit, head_unit, power_unit, disch_p_unit, disch_T_unit, speed_unit : str
+        Units used inside the CSV files.
+
+    Returns
+    -------
+    ccp.Impeller
+        Impeller loaded from the provided curves.
+    """
+    if not curve_files:
+        raise ValueError("No curve files supplied.")
+
+    suction_state = ccp_service.build_gas_state(
+        gas_composition,
+        Q_(suction_pressure, suction_pressure_unit),
+        Q_(suction_temperature, suction_temperature_unit),
+    )
+
+    temp_dir = Path(tempfile.mkdtemp(prefix="ccp_curves_"))
+    try:
+        for curve in curve_files:
+            (temp_dir / curve.name).write_bytes(curve.content)
+        curve_name = extract_curve_name(curve_files[0].name)
+        return ccp_service.load_impeller_from_engauge_csv(
+            suction_state=suction_state,
+            curve_name=curve_name,
+            curve_path=temp_dir,
+            flow_units=flow_unit,
+            disch_p_units=disch_p_unit,
+            disch_T_units=disch_T_unit,
+            head_units=head_unit,
+            power_units=power_unit,
+            speed_units=speed_unit,
+        )
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def convert_impeller(
+    *,
+    original_impeller: ccp.Impeller,
+    new_suction_pressure: float,
+    new_suction_pressure_unit: str,
+    new_suction_temperature: float,
+    new_suction_temperature_unit: str,
+    new_gas_composition: dict,
+    find_method: str = "speed",
+    speed_option: str = "same",
+) -> ccp.Impeller:
+    """Convert *original_impeller* to new suction conditions.
+
+    Parameters
+    ----------
+    original_impeller : ccp.Impeller
+        Impeller loaded from the original curves.
+    new_suction_pressure, new_suction_temperature : float
+        Target suction state magnitudes.
+    new_suction_pressure_unit, new_suction_temperature_unit : str
+        Units for the target suction state.
+    new_gas_composition : dict
+        Component-to-molar-fraction mapping for the target gas.
+    find_method : str, optional
+        Passed to :meth:`ccp.Impeller.convert_from` as ``find``.
+    speed_option : str, optional
+        ``"same"`` keeps the original speed, ``"calculate"`` lets ``ccp`` pick.
+
+    Returns
+    -------
+    ccp.Impeller
+        The converted impeller.
+    """
+    suction_state = ccp_service.build_gas_state(
+        new_gas_composition,
+        Q_(new_suction_pressure, new_suction_pressure_unit),
+        Q_(new_suction_temperature, new_suction_temperature_unit),
+    )
+    speed = "same" if speed_option == "same" else None
+    return ccp_service.convert_impeller(
+        original_impeller=original_impeller,
+        suction_state=suction_state,
+        find=find_method,
+        speed=speed,
+    )
+
+
+def generate_figures(
+    impeller: ccp.Impeller,
+    *,
+    flow: float,
+    flow_v_unit: str,
+    speed: float,
+    speed_unit: str,
+    head_unit: str,
+    power_unit: str,
+    disch_T_unit: str,
+    disch_p_unit: str,
+) -> dict[str, Any]:
+    """Build the five Plotly figures displayed on the page.
+
+    Uses the Django cache to memoise figure HTML keyed on the impeller identity
+    plus the plot parameters. Cached values live for one hour.
+
+    Parameters
+    ----------
+    impeller : ccp.Impeller
+        Impeller to plot.
+    flow, speed : float
+        Operational point magnitudes.
+    flow_v_unit, speed_unit, head_unit, power_unit, disch_T_unit, disch_p_unit : str
+        Display units.
+
+    Returns
+    -------
+    dict
+        ``{"head", "power", "disch_T", "eff", "disch_p"}`` HTML fragments and a
+        ``"project_point"`` summary dict.
+    """
+    impeller_hash = hash(impeller)
+    payload = {
+        "impeller_hash": impeller_hash,
+        "flow": flow,
+        "flow_v_unit": flow_v_unit,
+        "speed": speed,
+        "speed_unit": speed_unit,
+        "head_unit": head_unit,
+        "power_unit": power_unit,
+        "disch_T_unit": disch_T_unit,
+        "disch_p_unit": disch_p_unit,
+    }
+    key = _hash_key("figures", payload)
+
+    def _compute() -> dict[str, Any]:
+        flow_q = Q_(flow, flow_v_unit)
+        speed_q = Q_(speed, speed_unit)
+        head_fig = impeller.head_plot(
+            flow_v_units=flow_v_unit,
+            head_units=head_unit,
+            flow_v=flow_q,
+            speed=speed_q,
+        )
+        power_fig = impeller.power_plot(
+            flow_v_units=flow_v_unit,
+            power_units=power_unit,
+            flow_v=flow_q,
+            speed=speed_q,
+        )
+        disch_T_fig = impeller.disch.T_plot(
+            flow_v_units=flow_v_unit,
+            temperature_units=disch_T_unit,
+            flow_v=flow_q,
+            speed=speed_q,
+        )
+        eff_fig = impeller.eff_plot(
+            flow_v_units=flow_v_unit,
+            flow_v=flow_q,
+            speed=speed_q,
+        )
+        disch_p_fig = impeller.disch.p_plot(
+            flow_v_units=flow_v_unit,
+            p_units=disch_p_unit,
+            flow_v=flow_q,
+            speed=speed_q,
+        )
+        project_point = impeller.point(flow_v=flow_q, speed=speed_q)
+        return {
+            "head": figure_to_html(head_fig),
+            "power": figure_to_html(power_fig),
+            "disch_T": figure_to_html(disch_T_fig),
+            "eff": figure_to_html(eff_fig),
+            "disch_p": figure_to_html(disch_p_fig),
+            "project_point": _describe_point(
+                project_point,
+                flow_v_unit=flow_v_unit,
+                speed_unit=speed_unit,
+                head_unit=head_unit,
+                power_unit=power_unit,
+                disch_T_unit=disch_T_unit,
+                disch_p_unit=disch_p_unit,
+            ),
+        }
+
+    return cache.get_or_set(key, _compute, timeout=3600)
+
+
+def _describe_point(
+    point,
+    *,
+    flow_v_unit: str,
+    speed_unit: str,
+    head_unit: str,
+    power_unit: str,
+    disch_T_unit: str,
+    disch_p_unit: str,
+) -> dict[str, Any]:
+    """Return a serialisable summary of *point* in the requested units."""
+    return {
+        "speed": round(point.speed.to("rpm").m, 0),
+        "speed_unit": speed_unit,
+        "flow": round(point.flow_v.to(flow_v_unit).m, 2),
+        "flow_unit": flow_v_unit,
+        "head": round(point.head.to(head_unit).m, 2),
+        "head_unit": head_unit,
+        "eff": round(point.eff.m, 4),
+        "power": round(point.power.to(power_unit).m, 2),
+        "power_unit": power_unit,
+        "suc_p": round(point.suc.p(disch_p_unit).m, 2),
+        "suc_T": round(point.suc.T(disch_T_unit).m, 2),
+        "disch_p": round(point.disch.p(disch_p_unit).m, 2),
+        "disch_T": round(point.disch.T(disch_T_unit).m, 2),
+        "disch_p_unit": disch_p_unit,
+        "disch_T_unit": disch_T_unit,
+    }
+
+
+def run_conversion(
+    *,
+    original_data: dict,
+    converted_data: dict,
+    curves_files: list[CurveFile],
+    conversion_params: dict,
+) -> dict[str, Any]:
+    """Full pipeline: load original impeller, convert it, and render figures.
+
+    Parameters
+    ----------
+    original_data : dict
+        Original suction conditions (pressure, temperature, units, gas).
+    converted_data : dict
+        Target suction conditions (pressure, temperature, units, gas).
+    curves_files : list of CurveFile
+        Uploaded Engauge CSVs.
+    conversion_params : dict
+        Dictionary of conversion + plot parameters (units, operational point,
+        ``find_method``, ``speed_option``).
+
+    Returns
+    -------
+    dict
+        ``{"original_impeller", "converted_impeller", "original_figures",
+        "converted_figures"}``.
+    """
+    original_impeller = load_original_impeller(
+        curve_files=curves_files,
+        suction_pressure=original_data["pressure"],
+        suction_pressure_unit=original_data["pressure_unit"],
+        suction_temperature=original_data["temperature"],
+        suction_temperature_unit=original_data["temperature_unit"],
+        gas_composition=original_data.get("gas_composition", {"methane": 1.0}),
+        flow_unit=conversion_params["loaded_flow_unit"],
+        head_unit=conversion_params["loaded_head_unit"],
+        power_unit=conversion_params["loaded_power_unit"],
+        disch_p_unit=conversion_params["loaded_disch_p_unit"],
+        disch_T_unit=conversion_params["loaded_disch_T_unit"],
+        speed_unit=conversion_params["loaded_speed_unit"],
+    )
+    converted_impeller = convert_impeller(
+        original_impeller=original_impeller,
+        new_suction_pressure=converted_data["pressure"],
+        new_suction_pressure_unit=converted_data["pressure_unit"],
+        new_suction_temperature=converted_data["temperature"],
+        new_suction_temperature_unit=converted_data["temperature_unit"],
+        new_gas_composition=converted_data.get("gas_composition", {"methane": 1.0}),
+        find_method=conversion_params.get("find_method", "speed"),
+        speed_option=conversion_params.get("speed_option", "same"),
+    )
+
+    plot_flow_v_unit = resolve_flow_v_unit(conversion_params["plot_flow_unit"])
+
+    original_flow = conversion_params.get("operational_flow") or (
+        original_impeller.points[0].flow_v.to(plot_flow_v_unit).m
+    )
+    original_speed = conversion_params.get("operational_speed") or (
+        original_impeller.points[0].speed.to(conversion_params["plot_speed_unit"]).m
+    )
+    converted_flow = conversion_params.get("converted_flow") or (
+        converted_impeller.points[0].flow_v.to(plot_flow_v_unit).m
+    )
+    converted_speed = conversion_params.get("converted_speed") or (
+        converted_impeller.points[0].speed.to(conversion_params["plot_speed_unit"]).m
+    )
+
+    plot_kwargs = dict(
+        flow_v_unit=plot_flow_v_unit,
+        speed_unit=conversion_params["plot_speed_unit"],
+        head_unit=conversion_params["plot_head_unit"],
+        power_unit=conversion_params["plot_power_unit"],
+        disch_T_unit=conversion_params["plot_disch_T_unit"],
+        disch_p_unit=conversion_params["plot_disch_p_unit"],
+    )
+    original_figures = generate_figures(
+        original_impeller, flow=original_flow, speed=original_speed, **plot_kwargs
+    )
+    converted_figures = generate_figures(
+        converted_impeller, flow=converted_flow, speed=converted_speed, **plot_kwargs
+    )
+
+    return {
+        "original_impeller": original_impeller,
+        "converted_impeller": converted_impeller,
+        "original_figures": original_figures,
+        "converted_figures": converted_figures,
+    }

--- a/ccp/app/django-app/apps/curves_conversion/templates/base.html
+++ b/ccp/app/django-app/apps/curves_conversion/templates/base.html
@@ -1,0 +1,30 @@
+{# STUB: replaced by Unit 1's templates/base.html at merge time. #}
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}ccp{% endblock %}</title>
+  <style>
+    body { font-family: monospace; color: #2c3e50; margin: 1rem; }
+    .ccp-expander { margin: 0.5rem 0; border: 1px solid #2c3e50; }
+    .ccp-expander-header { width: 100%; text-align: left; padding: 0.5rem; background: #ebf0f8; border: 0; font-family: monospace; color: #2c3e50; cursor: pointer; }
+    .ccp-expander-body { padding: 0.5rem; }
+    .ccp-row { display: flex; gap: 0.25rem; align-items: center; margin: 0.25rem 0; }
+    .ccp-btn { background: #2c3e50; color: #fff; border: 0; padding: 0.4rem 0.8rem; font-family: monospace; cursor: pointer; }
+    .ccp-btn-primary { background: #2c3e50; }
+    .ccp-btn-secondary { background: #6c7a89; }
+    .ccp-plot-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem; }
+    .ccp-units-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.25rem; }
+    .ccp-errors { color: #b00020; }
+    pre.ccp-point-box { background: #f7f9fc; padding: 0.5rem; }
+  </style>
+</head>
+<body>
+  <header class="ccp-header">
+    <h1>ccp - Centrifugal Compressor Performance</h1>
+  </header>
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>

--- a/ccp/app/django-app/apps/curves_conversion/templates/curves_conversion/_errors.html
+++ b/ccp/app/django-app/apps/curves_conversion/templates/curves_conversion/_errors.html
@@ -1,0 +1,6 @@
+<div class="ccp-errors" role="alert">
+  {% if global_error %}<p class="ccp-error">{{ global_error }}</p>{% endif %}
+  {% if original_errors %}<p class="ccp-error">Original: {{ original_errors }}</p>{% endif %}
+  {% if converted_errors %}<p class="ccp-error">New: {{ converted_errors }}</p>{% endif %}
+  {% if params_errors %}<p class="ccp-error">Params: {{ params_errors }}</p>{% endif %}
+</div>

--- a/ccp/app/django-app/apps/curves_conversion/templates/curves_conversion/_plots.html
+++ b/ccp/app/django-app/apps/curves_conversion/templates/curves_conversion/_plots.html
@@ -1,0 +1,66 @@
+{% load static %}
+<div class="ccp-plots">
+  <h3>Original Curves</h3>
+  <div class="ccp-plot-grid">
+    <div class="ccp-plot-col">
+      {{ original_figures.head|safe }}
+      {{ original_figures.power|safe }}
+      {{ original_figures.disch_T|safe }}
+    </div>
+    <div class="ccp-plot-col">
+      {{ original_figures.eff|safe }}
+      {{ original_figures.disch_p|safe }}
+      <h4>Project Point</h4>
+      <pre class="ccp-point-box">
+-----------------------------
+    Speed:                 {{ original_figures.project_point.speed }} {{ original_figures.project_point.speed_unit }}
+    Flow:                  {{ original_figures.project_point.flow }} {{ original_figures.project_point.flow_unit }}
+    Head:                  {{ original_figures.project_point.head }} {{ original_figures.project_point.head_unit }}
+    Eff:                   {{ original_figures.project_point.eff }}
+    Power:                 {{ original_figures.project_point.power }} {{ original_figures.project_point.power_unit }}
+
+    Suction Conditions
+    --------------------
+    Suction Pressure:      {{ original_figures.project_point.suc_p }} {{ original_figures.project_point.disch_p_unit }}
+    Suction Temperature:   {{ original_figures.project_point.suc_T }} {{ original_figures.project_point.disch_T_unit }}
+
+    Discharge Conditions
+    --------------------
+    Discharge Pressure:    {{ original_figures.project_point.disch_p }} {{ original_figures.project_point.disch_p_unit }}
+    Discharge Temperature: {{ original_figures.project_point.disch_T }} {{ original_figures.project_point.disch_T_unit }}
+      </pre>
+    </div>
+  </div>
+
+  <h3>Converted Curves</h3>
+  <div class="ccp-plot-grid">
+    <div class="ccp-plot-col">
+      {{ converted_figures.head|safe }}
+      {{ converted_figures.power|safe }}
+      {{ converted_figures.disch_T|safe }}
+    </div>
+    <div class="ccp-plot-col">
+      {{ converted_figures.eff|safe }}
+      {{ converted_figures.disch_p|safe }}
+      <h4>New Point</h4>
+      <pre class="ccp-point-box">
+-----------------------------
+    Speed:                 {{ converted_figures.project_point.speed }} {{ converted_figures.project_point.speed_unit }}
+    Flow:                  {{ converted_figures.project_point.flow }} {{ converted_figures.project_point.flow_unit }}
+    Head:                  {{ converted_figures.project_point.head }} {{ converted_figures.project_point.head_unit }}
+    Eff:                   {{ converted_figures.project_point.eff }}
+    Power:                 {{ converted_figures.project_point.power }} {{ converted_figures.project_point.power_unit }}
+
+    Suction Conditions
+    --------------------
+    Suction Pressure:      {{ converted_figures.project_point.suc_p }} {{ converted_figures.project_point.disch_p_unit }}
+    Suction Temperature:   {{ converted_figures.project_point.suc_T }} {{ converted_figures.project_point.disch_T_unit }}
+
+    Discharge Conditions
+    --------------------
+    Discharge Pressure:    {{ converted_figures.project_point.disch_p }} {{ converted_figures.project_point.disch_p_unit }}
+    Discharge Temperature: {{ converted_figures.project_point.disch_T }} {{ converted_figures.project_point.disch_T_unit }}
+      </pre>
+    </div>
+  </div>
+</div>

--- a/ccp/app/django-app/apps/curves_conversion/templates/curves_conversion/page.html
+++ b/ccp/app/django-app/apps/curves_conversion/templates/curves_conversion/page.html
@@ -1,0 +1,155 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}Curves Conversion - ccp{% endblock %}
+
+{% block content %}
+<div class="ccp-page ccp-curves-conversion">
+  <h2>Curves Conversion</h2>
+  <p>Converta curvas de desempenho digitalizadas (Engauge) para novas condições de sucção.</p>
+
+  <section class="ccp-expander" x-data="{ open: true }">
+    <button type="button" class="ccp-expander-header" @click="open = !open">
+      Original Curves Suction Conditions
+    </button>
+    <div class="ccp-expander-body" x-show="open">
+      <form id="original-suction-form" method="post">
+        {% csrf_token %}
+        <div class="ccp-row">
+          <label>Suction Pressure</label>
+          {{ original_form.pressure }}
+          {{ original_form.pressure_unit }}
+        </div>
+        <div class="ccp-row">
+          <label>Suction Temperature</label>
+          {{ original_form.temperature }}
+          {{ original_form.temperature_unit }}
+        </div>
+      </form>
+    </div>
+  </section>
+
+  <section class="ccp-expander" x-data="{ open: true }">
+    <button type="button" class="ccp-expander-header" @click="open = !open">
+      Original Curves (Engauge CSV Upload)
+    </button>
+    <div class="ccp-expander-body" x-show="open">
+      <p>
+        Envie os arquivos CSV exportados do Engauge Digitizer contendo as curvas
+        de desempenho. Convenção de nome: <code>&lt;curve-name&gt;-head.csv</code>
+        e <code>&lt;curve-name&gt;-eff.csv</code>.
+      </p>
+      <form id="upload-form"
+            hx-post="{{ upload_url }}"
+            hx-encoding="multipart/form-data"
+            hx-target="#upload-status"
+            method="post"
+            enctype="multipart/form-data">
+        {% csrf_token %}
+        <div class="ccp-row">
+          <label>Performance Curves File 1</label>
+          {{ upload_form.curves_file_1 }}
+        </div>
+        <div class="ccp-row">
+          <label>Performance Curves File 2</label>
+          {{ upload_form.curves_file_2 }}
+        </div>
+        <button type="submit" class="ccp-btn ccp-btn-secondary">Enviar CSVs</button>
+        <span id="upload-status"></span>
+      </form>
+    </div>
+  </section>
+
+  <section class="ccp-expander" x-data="{ open: true }">
+    <button type="button" class="ccp-expander-header" @click="open = !open">
+      New Suction Conditions
+    </button>
+    <div class="ccp-expander-body" x-show="open">
+      <form id="converted-suction-form" method="post">
+        {% csrf_token %}
+        <div class="ccp-row">
+          <label>Suction Pressure</label>
+          {{ converted_form.pressure }}
+          {{ converted_form.pressure_unit }}
+        </div>
+        <div class="ccp-row">
+          <label>Suction Temperature</label>
+          {{ converted_form.temperature }}
+          {{ converted_form.temperature_unit }}
+        </div>
+      </form>
+    </div>
+  </section>
+
+  <section class="ccp-expander" x-data="{ open: true }">
+    <button type="button" class="ccp-expander-header" @click="open = !open">
+      Conversion Options
+    </button>
+    <div class="ccp-expander-body" x-show="open">
+      <form id="conversion-form"
+            hx-post="{{ convert_url }}"
+            hx-target="#plots-area"
+            hx-swap="innerHTML"
+            method="post">
+        {% csrf_token %}
+        <div class="ccp-row">
+          <label>Find Method</label>
+          {{ params_form.find_method }}
+        </div>
+        <div class="ccp-row">
+          <label>Speed Option</label>
+          {{ params_form.speed_option }}
+        </div>
+
+        <h4>Loaded Curves Units</h4>
+        <div class="ccp-units-grid">
+          <label>Flow {{ params_form.loaded_flow_unit }}</label>
+          <label>Head {{ params_form.loaded_head_unit }}</label>
+          <label>Power {{ params_form.loaded_power_unit }}</label>
+          <label>Disch. P {{ params_form.loaded_disch_p_unit }}</label>
+          <label>Disch. T {{ params_form.loaded_disch_T_unit }}</label>
+          <label>Speed {{ params_form.loaded_speed_unit }}</label>
+        </div>
+
+        <h4>Plot Curves Units</h4>
+        <div class="ccp-units-grid">
+          <label>Flow {{ params_form.plot_flow_unit }}</label>
+          <label>Head {{ params_form.plot_head_unit }}</label>
+          <label>Power {{ params_form.plot_power_unit }}</label>
+          <label>Disch. P {{ params_form.plot_disch_p_unit }}</label>
+          <label>Disch. T {{ params_form.plot_disch_T_unit }}</label>
+          <label>Speed {{ params_form.plot_speed_unit }}</label>
+        </div>
+
+        <div class="ccp-row">
+          <label>Operational Flow</label>
+          {{ params_form.operational_flow }}
+        </div>
+        <div class="ccp-row">
+          <label>Operational Speed</label>
+          {{ params_form.operational_speed }}
+        </div>
+
+        <button type="submit" class="ccp-btn ccp-btn-primary">Convert Curves</button>
+      </form>
+    </div>
+  </section>
+
+  <section class="ccp-ccp-file">
+    <form method="get" action="{{ save_url }}">
+      <button type="submit" class="ccp-btn">Salvar .ccp</button>
+    </form>
+    <form method="post"
+          action="{{ load_url }}"
+          enctype="multipart/form-data"
+          hx-post="{{ load_url }}"
+          hx-encoding="multipart/form-data">
+      {% csrf_token %}
+      <input type="file" name="ccp_file" accept=".ccp">
+      <button type="submit" class="ccp-btn">Carregar .ccp</button>
+    </form>
+  </section>
+
+  <section id="plots-area" class="ccp-plots-area"></section>
+</div>
+{% endblock %}

--- a/ccp/app/django-app/apps/curves_conversion/tests/conftest.py
+++ b/ccp/app/django-app/apps/curves_conversion/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Pytest bootstrap for the curves conversion unit tests."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+DJANGO_APP_ROOT = Path(__file__).resolve().parents[3]
+if str(DJANGO_APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(DJANGO_APP_ROOT))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "apps.curves_conversion.tests.settings")
+
+import django  # noqa: E402
+
+django.setup()

--- a/ccp/app/django-app/apps/curves_conversion/tests/settings.py
+++ b/ccp/app/django-app/apps/curves_conversion/tests/settings.py
@@ -1,0 +1,57 @@
+# STUB: Local test settings for running this unit in isolation.
+# When Unit 1 lands ``ccp_web/settings.py`` replaces this harness at runtime.
+"""Minimal Django settings so ``apps.curves_conversion`` can be tested alone."""
+
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[3]
+
+SECRET_KEY = "curves-conversion-test-key"
+DEBUG = True
+ALLOWED_HOSTS = ["*"]
+
+INSTALLED_APPS = [
+    "django.contrib.contenttypes",
+    "django.contrib.auth",
+    "django.contrib.sessions",
+    "django.contrib.staticfiles",
+    "apps.curves_conversion",
+]
+
+MIDDLEWARE = [
+    "django.contrib.sessions.middleware.SessionMiddleware",
+]
+
+ROOT_URLCONF = "apps.curves_conversion.tests.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.request",
+            ],
+        },
+    },
+]
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "curves-conversion-tests",
+    },
+}
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    },
+}
+
+SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+STATIC_URL = "/static/"
+USE_TZ = True
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/ccp/app/django-app/apps/curves_conversion/tests/test_services.py
+++ b/ccp/app/django-app/apps/curves_conversion/tests/test_services.py
@@ -1,0 +1,114 @@
+"""Unit tests for :mod:`apps.curves_conversion.services`.
+
+The tests exercise the real ``ccp`` library end-to-end, loading the example
+``curves-conversion-example.ccp`` archive checked into ``ccp/app/``.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from apps.curves_conversion.services import (
+    CurveFile,
+    extract_curve_name,
+    resolve_flow_v_unit,
+    run_conversion,
+)
+
+EXAMPLE_CCP = Path(__file__).resolve().parents[4] / "curves-conversion-example.ccp"
+
+
+def _load_example_csvs() -> list[CurveFile]:
+    files: list[CurveFile] = []
+    with zipfile.ZipFile(EXAMPLE_CCP) as archive:
+        for name in archive.namelist():
+            if name.endswith(".csv"):
+                files.append(CurveFile(name=name, content=archive.read(name)))
+    return files
+
+
+def test_extract_curve_name_strips_known_suffixes():
+    assert extract_curve_name("normal-head.csv") == "normal"
+    assert extract_curve_name("pump-eff.csv") == "pump"
+    assert extract_curve_name("no_suffix.csv") == "no_suffix"
+
+
+def test_resolve_flow_v_unit_defaults_to_cubic_metres_per_hour():
+    assert resolve_flow_v_unit("kg/h") == "m³/h"
+    assert resolve_flow_v_unit("m³/min") == "m³/min"
+
+
+@pytest.mark.skipif(not EXAMPLE_CCP.exists(), reason="example .ccp missing")
+def test_run_conversion_with_example_curves(settings):
+    settings.CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "tests",
+        }
+    }
+    curves = _load_example_csvs()
+    assert curves, "example .ccp should contain CSV curves"
+    gas = {
+        "methane": 92.11,
+        "ethane": 4.94,
+        "propane": 1.71,
+        "ibutane": 0.24,
+        "butane": 0.30,
+        "ipentane": 0.04,
+        "pentane": 0.03,
+        "hexane": 0.01,
+        "n2": 0.40,
+        "co2": 0.22,
+    }
+    result = run_conversion(
+        original_data={
+            "pressure": 3876.0,
+            "pressure_unit": "kPa",
+            "temperature": 11.0,
+            "temperature_unit": "degC",
+            "gas_composition": gas,
+        },
+        converted_data={
+            "pressure": 2000.0,
+            "pressure_unit": "kPa",
+            "temperature": 300.0,
+            "temperature_unit": "degK",
+            "gas_composition": {"co2": 1.0},
+        },
+        curves_files=curves,
+        conversion_params={
+            "find_method": "speed",
+            "speed_option": "same",
+            "loaded_flow_unit": "kg/h",
+            "loaded_head_unit": "kJ/kg",
+            "loaded_power_unit": "kW",
+            "loaded_disch_p_unit": "bar",
+            "loaded_disch_T_unit": "degK",
+            "loaded_speed_unit": "rpm",
+            "plot_flow_unit": "m³/h",
+            "plot_head_unit": "kJ/kg",
+            "plot_power_unit": "kW",
+            "plot_disch_p_unit": "bar",
+            "plot_disch_T_unit": "degK",
+            "plot_speed_unit": "rpm",
+            "operational_flow": None,
+            "operational_speed": None,
+        },
+    )
+    assert "original_impeller" in result
+    assert "converted_impeller" in result
+    assert "head" in result["original_figures"]
+    assert "head" in result["converted_figures"]
+
+
+def test_ccp_importer_reads_example_archive():
+    from apps.curves_conversion._stubs.ccp_file_importer import load_ccp_file
+
+    with EXAMPLE_CCP.open("rb") as handle:
+        state = load_ccp_file(handle)
+    assert state.get("app_type") == "curves_conversion"
+    assert "original_impeller" in state

--- a/ccp/app/django-app/apps/curves_conversion/tests/test_views.py
+++ b/ccp/app/django-app/apps/curves_conversion/tests/test_views.py
@@ -1,0 +1,51 @@
+"""Smoke tests for the curves conversion views."""
+
+from __future__ import annotations
+
+import pytest
+from django.test import Client
+
+pytestmark = pytest.mark.django_db
+
+
+def test_page_renders():
+    client = Client()
+    response = client.get("/curves-conversion/")
+    assert response.status_code == 200
+    assert b"Curves Conversion" in response.content
+
+
+def test_upload_requires_file():
+    client = Client()
+    response = client.post("/curves-conversion/upload-csv/", {})
+    assert response.status_code == 400
+
+
+def test_convert_without_files_returns_error():
+    client = Client()
+    payload = {
+        "original-pressure": "1.0",
+        "original-pressure_unit": "bar",
+        "original-temperature": "300",
+        "original-temperature_unit": "degK",
+        "converted-pressure": "1.2",
+        "converted-pressure_unit": "bar",
+        "converted-temperature": "305",
+        "converted-temperature_unit": "degK",
+        "params-find_method": "speed",
+        "params-speed_option": "same",
+        "params-loaded_flow_unit": "m³/h",
+        "params-loaded_head_unit": "kJ/kg",
+        "params-loaded_power_unit": "kW",
+        "params-loaded_disch_p_unit": "bar",
+        "params-loaded_disch_T_unit": "degK",
+        "params-loaded_speed_unit": "rpm",
+        "params-plot_flow_unit": "m³/h",
+        "params-plot_head_unit": "kJ/kg",
+        "params-plot_power_unit": "kW",
+        "params-plot_disch_p_unit": "bar",
+        "params-plot_disch_T_unit": "degK",
+        "params-plot_speed_unit": "rpm",
+    }
+    response = client.post("/curves-conversion/convert/", payload)
+    assert response.status_code == 400

--- a/ccp/app/django-app/apps/curves_conversion/tests/urls.py
+++ b/ccp/app/django-app/apps/curves_conversion/tests/urls.py
@@ -1,0 +1,7 @@
+"""Test URL conf mounting only the curves conversion app."""
+
+from django.urls import include, path
+
+urlpatterns = [
+    path("curves-conversion/", include("apps.curves_conversion.urls")),
+]

--- a/ccp/app/django-app/apps/curves_conversion/urls.py
+++ b/ccp/app/django-app/apps/curves_conversion/urls.py
@@ -1,0 +1,16 @@
+"""URL routes for the curves conversion page."""
+
+from django.urls import path
+
+from apps.curves_conversion import views
+
+app_name = "curves_conversion"
+
+urlpatterns = [
+    path("", views.page, name="page"),
+    path("convert/", views.convert, name="convert"),
+    path("upload-csv/", views.upload_csv, name="upload_csv"),
+    path("download-csv/<str:case>/", views.download_csv, name="download_csv"),
+    path("save.ccp", views.save_ccp, name="save_ccp"),
+    path("load.ccp", views.load_ccp, name="load_ccp"),
+]

--- a/ccp/app/django-app/apps/curves_conversion/views.py
+++ b/ccp/app/django-app/apps/curves_conversion/views.py
@@ -1,0 +1,222 @@
+"""Django views for the curves conversion page.
+
+Mirrors the UX of ``ccp/app/pages/3_curves_conversion.py``: a single page with
+HTMX-driven "Load Original Curves" and "Convert Curves" actions, CSV uploads,
+and ``.ccp`` save / load endpoints. All session state lives in the Redis-
+backed store provided by ``apps.core.session_store`` (stubbed locally until
+Unit 3 lands).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.shortcuts import render
+from django.urls import reverse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+
+from apps.curves_conversion.forms import (
+    ConversionParamsForm,
+    ConvertedSuctionForm,
+    CurvesCSVUploadForm,
+    OriginalSuctionForm,
+)
+from apps.curves_conversion.services import CurveFile, run_conversion
+
+try:
+    from apps.core import session_store
+except ImportError:  # pragma: no cover
+    from apps.curves_conversion._stubs import session_store  # type: ignore
+
+try:
+    from apps.core.storage.ccp_file_importer import load_ccp_file
+    from apps.core.storage.ccp_file_exporter import export_ccp_file
+except ImportError:  # pragma: no cover
+    from apps.curves_conversion._stubs.ccp_file_importer import load_ccp_file
+    from apps.curves_conversion._stubs.ccp_file_exporter import export_ccp_file
+
+logger = logging.getLogger(__name__)
+
+SESSION_KEY = "curves_conversion"
+
+
+def _session_id(request: HttpRequest) -> str:
+    """Return a stable session identifier, creating one if necessary."""
+    if not request.session.session_key:
+        request.session.save()
+    return f"{SESSION_KEY}:{request.session.session_key}"
+
+
+def _get_state(request: HttpRequest) -> dict[str, Any]:
+    return session_store.get_session(_session_id(request))
+
+
+def _set_state(request: HttpRequest, state: dict[str, Any]) -> None:
+    session_store.set_session(_session_id(request), state)
+
+
+def page(request: HttpRequest) -> HttpResponse:
+    """Render the curves conversion landing page."""
+    state = _get_state(request)
+    context = {
+        "original_form": OriginalSuctionForm(),
+        "converted_form": ConvertedSuctionForm(),
+        "params_form": ConversionParamsForm(),
+        "upload_form": CurvesCSVUploadForm(),
+        "has_original": bool(state.get("original_impeller")),
+        "has_converted": bool(state.get("converted_impeller")),
+        "convert_url": reverse("curves_conversion:convert"),
+        "upload_url": reverse("curves_conversion:upload_csv"),
+        "save_url": reverse("curves_conversion:save_ccp"),
+        "load_url": reverse("curves_conversion:load_ccp"),
+    }
+    return render(request, "curves_conversion/page.html", context)
+
+
+@require_http_methods(["POST"])
+def upload_csv(request: HttpRequest) -> HttpResponse:
+    """Persist uploaded Engauge CSV files to the session store."""
+    form = CurvesCSVUploadForm(request.POST, request.FILES)
+    if not form.is_valid():
+        return JsonResponse({"ok": False, "errors": form.errors}, status=400)
+    state = _get_state(request)
+    for field in ("curves_file_1", "curves_file_2"):
+        uploaded = form.cleaned_data.get(field)
+        if uploaded is not None:
+            state[field] = {"name": uploaded.name, "content": uploaded.read()}
+    _set_state(request, state)
+    return JsonResponse(
+        {"ok": True, "stored": sorted(k for k in state if k.startswith("curves_file_"))}
+    )
+
+
+def _collect_curve_files(state: dict[str, Any]) -> list[CurveFile]:
+    return [
+        CurveFile(name=entry["name"], content=entry["content"])
+        for index in (1, 2)
+        if (entry := state.get(f"curves_file_{index}"))
+    ]
+
+
+@require_http_methods(["POST"])
+def convert(request: HttpRequest) -> HttpResponse:
+    """Run the full conversion pipeline and return a plots partial."""
+    original_form = OriginalSuctionForm(request.POST, prefix="original")
+    converted_form = ConvertedSuctionForm(request.POST, prefix="converted")
+    params_form = ConversionParamsForm(request.POST, prefix="params")
+
+    if not (
+        original_form.is_valid()
+        and converted_form.is_valid()
+        and params_form.is_valid()
+    ):
+        return render(
+            request,
+            "curves_conversion/_errors.html",
+            {
+                "original_errors": original_form.errors,
+                "converted_errors": converted_form.errors,
+                "params_errors": params_form.errors,
+            },
+            status=400,
+        )
+
+    state = _get_state(request)
+    curve_files = _collect_curve_files(state)
+    if not curve_files:
+        return render(
+            request,
+            "curves_conversion/_errors.html",
+            {
+                "global_error": "Nenhum arquivo CSV carregado. Envie as curvas antes de converter."
+            },
+            status=400,
+        )
+
+    try:
+        result = run_conversion(
+            original_data={
+                "pressure": original_form.cleaned_data["pressure"],
+                "pressure_unit": original_form.cleaned_data["pressure_unit"],
+                "temperature": original_form.cleaned_data["temperature"],
+                "temperature_unit": original_form.cleaned_data["temperature_unit"],
+                "gas_composition": state.get(
+                    "original_gas_composition", {"methane": 1.0}
+                ),
+            },
+            converted_data={
+                "pressure": converted_form.cleaned_data["pressure"],
+                "pressure_unit": converted_form.cleaned_data["pressure_unit"],
+                "temperature": converted_form.cleaned_data["temperature"],
+                "temperature_unit": converted_form.cleaned_data["temperature_unit"],
+                "gas_composition": state.get(
+                    "converted_gas_composition", {"methane": 1.0}
+                ),
+            },
+            curves_files=curve_files,
+            conversion_params=params_form.cleaned_data,
+        )
+    except Exception as exc:
+        logger.exception("curves conversion failed")
+        return render(
+            request,
+            "curves_conversion/_errors.html",
+            {"global_error": f"Erro durante a conversão: {exc}"},
+            status=500,
+        )
+
+    state["original_impeller"] = result["original_impeller"]
+    state["converted_impeller"] = result["converted_impeller"]
+    _set_state(request, state)
+
+    return render(
+        request,
+        "curves_conversion/_plots.html",
+        {
+            "original_figures": result["original_figures"],
+            "converted_figures": result["converted_figures"],
+        },
+    )
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def load_ccp(request: HttpRequest) -> HttpResponse:
+    """Load a ``.ccp`` archive into the session state."""
+    uploaded = request.FILES.get("ccp_file")
+    if uploaded is None:
+        return JsonResponse({"ok": False, "error": "Arquivo .ccp ausente."}, status=400)
+    try:
+        state = load_ccp_file(uploaded)
+    except Exception as exc:
+        logger.exception("failed to load .ccp file")
+        return JsonResponse({"ok": False, "error": str(exc)}, status=400)
+    existing = _get_state(request)
+    existing.update(state)
+    _set_state(request, existing)
+    return JsonResponse({"ok": True})
+
+
+@require_http_methods(["GET"])
+def save_ccp(request: HttpRequest) -> HttpResponse:
+    """Download the current session state as a ``.ccp`` archive."""
+    state = _get_state(request)
+    payload = export_ccp_file(state)
+    response = HttpResponse(payload, content_type="application/zip")
+    response["Content-Disposition"] = 'attachment; filename="curves_conversion.ccp"'
+    return response
+
+
+@require_http_methods(["GET"])
+def download_csv(request: HttpRequest, case: str) -> HttpResponse:
+    """Re-download an originally uploaded CSV from the session store."""
+    state = _get_state(request)
+    entry = state.get(f"curves_file_{case}")
+    if entry is None:
+        return JsonResponse({"ok": False, "error": "CSV não encontrado."}, status=404)
+    response = HttpResponse(entry["content"], content_type="text/csv")
+    response["Content-Disposition"] = f'attachment; filename="{entry["name"]}"'
+    return response


### PR DESCRIPTION
## Summary
- Port `ccp/app/pages/3_curves_conversion.py` to a new Django app at `apps/curves_conversion/`, reproducing the Streamlit UX with HTMX + Alpine templates and Portuguese copy.
- All compressor math delegates to the `ccp` library via `apps.core.services.ccp_service` (with local `_stubs/` fallback so the unit runs in isolation before Units 2/3/4 merge).
- Replaces `@st.cache_data` with `django.core.cache.cache.get_or_set` for memoised Plotly figure HTML, keyed on impeller hash + plot params.
- Preserves backward compatibility with `ccp/app/curves-conversion-example.ccp` via an ImportError-guarded `.ccp` importer/exporter stub that mirrors the ZIP layout produced by the Streamlit page.

## Test plan
- [x] `uv run python -m django check` (local test settings) — no issues.
- [x] `uv run pytest apps/curves_conversion/tests/` — 7 passed (includes end-to-end `run_conversion` against the real `ccp` library using `curves-conversion-example.ccp`).
- [x] `curl -sI http://127.0.0.1:8000/curves-conversion/` → `HTTP/1.1 200 OK` via `manage.py runserver`.