### PR TITLE
django-app: Unit 8 — performance evaluation config/forms

### DIFF
--- a/ccp/app/django-app/apps/performance_evaluation/__init__.py
+++ b/ccp/app/django-app/apps/performance_evaluation/__init__.py
@@ -1,0 +1,4 @@
+"""Performance Evaluation Django app.
+
+Ports the config/input side of ``ccp/app/pages/4_performance_evaluation.py``.
+"""

--- a/ccp/app/django-app/apps/performance_evaluation/_compat.py
+++ b/ccp/app/django-app/apps/performance_evaluation/_compat.py
@@ -1,0 +1,52 @@
+"""Cross-unit import shim.
+
+Prefers the real ``apps.core.*`` and ``apps.integrations.*`` modules when they
+exist; falls back to local stubs otherwise so this app stays runnable in
+isolation while Units 2/3/4/11 are still in flight.
+"""
+
+from __future__ import annotations
+
+try:
+    from apps.core.services import unit_helpers
+except ImportError:  # pragma: no cover - exercised on merged tree
+    from ._stubs import unit_helpers  # type: ignore[no-redef]
+
+try:
+    from apps.core.services import gas_composition
+except ImportError:
+    from ._stubs import gas_composition  # type: ignore[no-redef]
+
+try:
+    from apps.core.services import parameter_map
+except ImportError:
+    from ._stubs import parameter_map  # type: ignore[no-redef]
+
+try:
+    from apps.core import session_store
+except ImportError:
+    from ._stubs import session_store  # type: ignore[no-redef]
+
+try:
+    from apps.integrations import pi_client
+except ImportError:
+    from ._stubs import pi_client  # type: ignore[no-redef]
+
+try:
+    from apps.core.storage import ccp_file_importer, ccp_file_exporter
+
+    load_ccp_file = ccp_file_importer.load_ccp_file
+    export_ccp_file = ccp_file_exporter.export_ccp_file
+except ImportError:
+    from ._stubs.ccp_file_io import load_ccp_file, export_ccp_file  # type: ignore[no-redef]
+
+
+__all__ = [
+    "unit_helpers",
+    "gas_composition",
+    "parameter_map",
+    "session_store",
+    "pi_client",
+    "load_ccp_file",
+    "export_ccp_file",
+]

--- a/ccp/app/django-app/apps/performance_evaluation/_stubs/__init__.py
+++ b/ccp/app/django-app/apps/performance_evaluation/_stubs/__init__.py
@@ -1,0 +1,1 @@
+# STUB: local fallbacks for cross-unit imports until Units 2/3/4/11 land.

--- a/ccp/app/django-app/apps/performance_evaluation/_stubs/ccp_file_io.py
+++ b/ccp/app/django-app/apps/performance_evaluation/_stubs/ccp_file_io.py
@@ -1,0 +1,25 @@
+# STUB: replaced by Unit 3 (apps.core.storage.{ccp_file_importer,ccp_file_exporter}).
+"""Minimal .ccp file importer/exporter used until Unit 3 lands."""
+
+import io
+import json
+import zipfile
+
+
+def load_ccp_file(fp) -> dict:
+    """Return a state dict read from a .ccp ZIP archive."""
+    state: dict = {}
+    with zipfile.ZipFile(fp) as zf:
+        for name in zf.namelist():
+            if name.endswith(".json"):
+                state.update(json.loads(zf.read(name)))
+    state.setdefault("app_type", "performance_evaluation")
+    return state
+
+
+def export_ccp_file(state: dict) -> bytes:
+    """Serialise ``state`` to a .ccp ZIP archive as bytes."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("session_state.json", json.dumps(state, default=str))
+    return buf.getvalue()

--- a/ccp/app/django-app/apps/performance_evaluation/_stubs/gas_composition.py
+++ b/ccp/app/django-app/apps/performance_evaluation/_stubs/gas_composition.py
@@ -1,0 +1,22 @@
+# STUB: replaced by Unit 2 (apps.core.services.gas_composition) at merge time.
+"""Minimal fluid list + default composition for offline tests."""
+
+FLUID_LIST = [
+    "methane",
+    "ethane",
+    "propane",
+    "n-butane",
+    "i-butane",
+    "n-pentane",
+    "i-pentane",
+    "n-hexane",
+    "nitrogen",
+    "carbon dioxide",
+    "hydrogen sulfide",
+    "water",
+]
+
+
+def default_composition():
+    """Return a default methane-dominant composition."""
+    return {"methane": 0.95, "ethane": 0.03, "nitrogen": 0.02}

--- a/ccp/app/django-app/apps/performance_evaluation/_stubs/parameter_map.py
+++ b/ccp/app/django-app/apps/performance_evaluation/_stubs/parameter_map.py
@@ -1,0 +1,11 @@
+# STUB: replaced by Unit 2 (apps.core.services.parameter_map) at merge time.
+"""Minimal parameter metadata used by templates."""
+
+PARAMETERS = {
+    "suc_p": {"label": "Suction Pressure", "units": "bar"},
+    "suc_T": {"label": "Suction Temperature", "units": "degC"},
+    "disch_p": {"label": "Discharge Pressure", "units": "bar"},
+    "disch_T": {"label": "Discharge Temperature", "units": "degC"},
+    "speed": {"label": "Speed", "units": "rpm"},
+    "flow": {"label": "Flow", "units": "m³/h"},
+}

--- a/ccp/app/django-app/apps/performance_evaluation/_stubs/pi_client.py
+++ b/ccp/app/django-app/apps/performance_evaluation/_stubs/pi_client.py
@@ -1,0 +1,19 @@
+# STUB: replaced by Unit 11 (apps.integrations.pi_client) at merge time.
+"""Offline PI client fallback - returns empty DataFrame."""
+
+import pandas as pd
+
+
+def is_pi_available() -> bool:
+    """Return True when pandaspi is importable."""
+    try:
+        import pandaspi  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def fetch_pi_data(tag_map: dict, start, end, **opts) -> pd.DataFrame:
+    """Offline fallback that returns an empty DataFrame."""
+    return pd.DataFrame()

--- a/ccp/app/django-app/apps/performance_evaluation/_stubs/session_store.py
+++ b/ccp/app/django-app/apps/performance_evaluation/_stubs/session_store.py
@@ -1,0 +1,19 @@
+# STUB: replaced by Unit 3 (apps.core.session_store) at merge time.
+"""In-memory session store used until the Redis-backed one lands."""
+
+_STORE: dict[str, dict] = {}
+
+
+def get_session(session_id: str) -> dict:
+    """Return session state dict for ``session_id`` (empty if unknown)."""
+    return _STORE.setdefault(session_id, {})
+
+
+def set_session(session_id: str, state: dict) -> None:
+    """Persist ``state`` for ``session_id``."""
+    _STORE[session_id] = state
+
+
+def clear_session(session_id: str) -> None:
+    """Drop ``session_id`` from the store."""
+    _STORE.pop(session_id, None)

--- a/ccp/app/django-app/apps/performance_evaluation/_stubs/unit_helpers.py
+++ b/ccp/app/django-app/apps/performance_evaluation/_stubs/unit_helpers.py
@@ -1,0 +1,33 @@
+# STUB: replaced by Unit 2 (apps.core.services.unit_helpers) at merge time.
+"""Minimal unit choice lists used by Unit 8 forms."""
+
+FLOW_UNITS = [
+    "kg/s",
+    "kg/h",
+    "lbm/h",
+    "lbm/min",
+    "m**3/s",
+    "m**3/h",
+    "m³/h",
+    "m³/s",
+    "ft**3/s",
+    "ft**3/min",
+    "MMSCFD",
+]
+
+PRESSURE_UNITS = ["Pa", "kPa", "bar", "bar_g", "psi", "kgf/cm**2", "atm"]
+TEMPERATURE_UNITS = ["K", "degC", "degF", "degR"]
+HEAD_UNITS = ["J/kg", "kJ/kg", "m", "ft"]
+POWER_UNITS = ["W", "kW", "MW", "hp"]
+SPEED_UNITS = ["rpm", "Hz", "rad/s"]
+LENGTH_UNITS = ["m", "mm", "cm", "in", "ft"]
+OIL_FLOW_UNITS = ["l/min", "m**3/h", "gpm"]
+DENSITY_UNITS = ["kg/m**3", "lbm/ft**3"]
+SPECIFIC_HEAT_UNITS = ["J/(kg*K)", "kJ/(kg*K)"]
+
+
+def convert(value, src, dst):
+    """Convert ``value`` from ``src`` to ``dst`` using ``ccp.Q_``."""
+    import ccp
+
+    return ccp.Q_(value, src).to(dst).m

--- a/ccp/app/django-app/apps/performance_evaluation/apps.py
+++ b/ccp/app/django-app/apps/performance_evaluation/apps.py
@@ -1,0 +1,12 @@
+"""AppConfig for the performance evaluation Django app."""
+
+from django.apps import AppConfig
+
+
+class PerformanceEvaluationConfig(AppConfig):
+    """Django AppConfig for performance_evaluation."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.performance_evaluation"
+    label = "performance_evaluation"
+    verbose_name = "Performance Evaluation"

--- a/ccp/app/django-app/apps/performance_evaluation/forms.py
+++ b/ccp/app/django-app/apps/performance_evaluation/forms.py
@@ -1,0 +1,269 @@
+"""Django forms for the Performance Evaluation config page.
+
+Ports the input widgets from ``ccp/app/pages/4_performance_evaluation.py``
+and ``ccp/app/common.py`` helpers (``design_cases_section``,
+``tags_config_section``) to plain Django ``Form`` classes. Unit conversions
+use ``pint`` via ``ccp.Q_`` - never manual arithmetic.
+"""
+
+from __future__ import annotations
+
+from django import forms
+from django.forms import formset_factory
+
+from ._compat import gas_composition, unit_helpers
+
+CASES = ["A", "B", "C", "D", "E"]
+AUTH_CHOICES = [("kerberos", "Kerberos"), ("basic", "Basic")]
+FLOW_METHOD_CHOICES = [("Direct", "Direct"), ("Orifice", "Orifice")]
+FLUID_SOURCE_CHOICES = [
+    ("Fixed Operation Fluid", "Fixed Operation Fluid"),
+    ("Inform Component Tags", "Inform Component Tags"),
+]
+AI_PROVIDER_CHOICES = [("gemini", "Google Gemini"), ("azure", "Azure OpenAI")]
+TAPPING_CHOICES = [("flange", "flange"), ("corner", "corner"), ("D D/2", "D D/2")]
+FLUID_UNIT_CHOICES = [("mol_frac", "mol_frac"), ("percent", "percent"), ("ppm", "ppm")]
+
+
+def _unit_choices(units: list[str]) -> list[tuple[str, str]]:
+    return [(u, u) for u in units]
+
+
+class DesignCaseForm(forms.Form):
+    """Design suction conditions for a single case (A-E).
+
+    Used inside a formset of length five. Validates that ``suc_p`` and
+    ``suc_T`` are positive when the case is populated, and converts them to
+    SI through ``pint`` in :meth:`clean`.
+    """
+
+    case = forms.ChoiceField(
+        choices=[(c, c) for c in CASES], widget=forms.HiddenInput, required=True
+    )
+    gas = forms.CharField(required=False, label="Gas")
+    suc_p = forms.FloatField(required=False, label="Suction Pressure", min_value=0)
+    suc_p_unit = forms.ChoiceField(
+        choices=_unit_choices(unit_helpers.PRESSURE_UNITS),
+        initial="bar",
+        required=False,
+    )
+    suc_T = forms.FloatField(required=False, label="Suction Temperature")
+    suc_T_unit = forms.ChoiceField(
+        choices=_unit_choices(unit_helpers.TEMPERATURE_UNITS),
+        initial="degC",
+        required=False,
+    )
+
+    def clean(self):
+        """Validate positivity and attach pint-converted SI values."""
+        cleaned = super().clean()
+        suc_p = cleaned.get("suc_p")
+        suc_T = cleaned.get("suc_T")
+        gas = cleaned.get("gas") or ""
+
+        has_any = any(v not in (None, "", 0, 0.0) for v in (suc_p, suc_T, gas))
+        if not has_any:
+            cleaned["_populated"] = False
+            return cleaned
+        cleaned["_populated"] = True
+
+        if suc_p is None or suc_p <= 0:
+            self.add_error("suc_p", "Suction pressure must be > 0.")
+        if suc_T in (None, 0, 0.0):
+            self.add_error("suc_T", "Suction temperature is required.")
+
+        if suc_p and suc_T:
+            try:
+                cleaned["suc_p_Pa"] = unit_helpers.convert(
+                    suc_p, cleaned["suc_p_unit"], "Pa"
+                )
+                cleaned["suc_T_K"] = unit_helpers.convert(
+                    suc_T, cleaned["suc_T_unit"], "K"
+                )
+            except Exception as exc:  # pragma: no cover - pint edge cases
+                raise forms.ValidationError(f"Unit conversion failed: {exc}")
+
+        return cleaned
+
+
+DesignCaseFormSet = formset_factory(DesignCaseForm, extra=0, min_num=5, max_num=5)
+
+
+class PIServerConfigForm(forms.Form):
+    """PI server connection settings."""
+
+    pi_server_name = forms.CharField(required=False, label="PI Server Name")
+    pi_auth_method = forms.ChoiceField(
+        choices=AUTH_CHOICES, initial="kerberos", label="Authentication"
+    )
+    pi_username = forms.CharField(required=False, label="Username")
+    pi_password = forms.CharField(
+        required=False, label="Password", widget=forms.PasswordInput(render_value=False)
+    )
+
+    def clean(self):
+        cleaned = super().clean()
+        if cleaned.get("pi_auth_method") == "basic":
+            if not cleaned.get("pi_username"):
+                self.add_error("pi_username", "Username required for basic auth.")
+        return cleaned
+
+
+class TagMappingForm(forms.Form):
+    """Single-parameter dual-tag + dual-unit row.
+
+    Mirrors ``dual_tag_input_row`` in ``common.tags_config_section``.
+    """
+
+    parameter = forms.CharField(widget=forms.HiddenInput)
+    tag_1 = forms.CharField(required=False)
+    unit_1 = forms.CharField(required=False)
+    tag_2 = forms.CharField(required=False)
+    unit_2 = forms.CharField(required=False)
+
+
+class FlowMethodForm(forms.Form):
+    """Flow measurement method selector + orifice geometry."""
+
+    flow_method = forms.ChoiceField(
+        choices=FLOW_METHOD_CHOICES, initial="Direct", label="Flow Measurement Method"
+    )
+    orifice_tappings = forms.ChoiceField(
+        choices=TAPPING_CHOICES, initial="flange", required=False
+    )
+    orifice_D = forms.FloatField(required=False, min_value=0, label="Pipe Diameter D")
+    orifice_D_unit = forms.ChoiceField(
+        choices=_unit_choices(unit_helpers.LENGTH_UNITS), initial="m", required=False
+    )
+    orifice_d = forms.FloatField(
+        required=False, min_value=0, label="Orifice Diameter d"
+    )
+    orifice_d_unit = forms.ChoiceField(
+        choices=_unit_choices(unit_helpers.LENGTH_UNITS), initial="m", required=False
+    )
+
+    def clean(self):
+        cleaned = super().clean()
+        if cleaned.get("flow_method") == "Orifice":
+            for key in ("orifice_D", "orifice_d"):
+                val = cleaned.get(key)
+                if val is None or val <= 0:
+                    self.add_error(key, "Required when method is Orifice.")
+        return cleaned
+
+
+class FluidSourceForm(forms.Form):
+    """Select whether the process fluid is fixed or read from PI component tags."""
+
+    fluid_source = forms.ChoiceField(
+        choices=FLUID_SOURCE_CHOICES, initial="Fixed Operation Fluid"
+    )
+    operation_fluid_gas = forms.CharField(required=False)
+
+
+class DateRangeForm(forms.Form):
+    """Data time range selection."""
+
+    start_date = forms.DateField(widget=forms.DateInput(attrs={"type": "date"}))
+    start_time = forms.TimeField(widget=forms.TimeInput(attrs={"type": "time"}))
+    end_date = forms.DateField(widget=forms.DateInput(attrs={"type": "date"}))
+    end_time = forms.TimeField(widget=forms.TimeInput(attrs={"type": "time"}))
+
+    def clean(self):
+        cleaned = super().clean()
+        sd, st_ = cleaned.get("start_date"), cleaned.get("start_time")
+        ed, et_ = cleaned.get("end_date"), cleaned.get("end_time")
+        if sd and st_ and ed and et_:
+            from datetime import datetime
+
+            start = datetime.combine(sd, st_)
+            end = datetime.combine(ed, et_)
+            if end <= start:
+                raise forms.ValidationError("End must be after start.")
+            cleaned["start_datetime"] = start
+            cleaned["end_datetime"] = end
+        return cleaned
+
+
+class AIOptionsForm(forms.Form):
+    """AI report analysis toggle + provider settings."""
+
+    ai_enabled = forms.BooleanField(
+        required=False, label="AI Analysis in Report", initial=False
+    )
+    ai_provider = forms.ChoiceField(
+        choices=AI_PROVIDER_CHOICES, initial="gemini", required=False
+    )
+    ai_api_key = forms.CharField(
+        required=False, widget=forms.PasswordInput(render_value=True), label="API Key"
+    )
+    ai_azure_endpoint = forms.CharField(required=False, label="Azure Endpoint")
+    ai_azure_deployment = forms.CharField(required=False, label="Azure Deployment")
+
+    def clean(self):
+        cleaned = super().clean()
+        if cleaned.get("ai_enabled"):
+            if not cleaned.get("ai_api_key"):
+                self.add_error("ai_api_key", "API key required when AI is enabled.")
+            if cleaned.get("ai_provider") == "azure":
+                if not cleaned.get("ai_azure_endpoint"):
+                    self.add_error("ai_azure_endpoint", "Azure endpoint required.")
+                if not cleaned.get("ai_azure_deployment"):
+                    self.add_error("ai_azure_deployment", "Azure deployment required.")
+        return cleaned
+
+
+class SessionMetaForm(forms.Form):
+    """Session name + loaded .ccp file upload (sidebar form)."""
+
+    session_name = forms.CharField(required=False, label="Session name")
+    ccp_file = forms.FileField(required=False, label="Open File")
+
+
+class CurvesUnitsForm(forms.Form):
+    """Units for the Engauge-digitised performance curves."""
+
+    loaded_curves_speed_units = forms.ChoiceField(
+        choices=_unit_choices(unit_helpers.SPEED_UNITS), initial="rpm"
+    )
+    loaded_curves_flow_units = forms.ChoiceField(
+        choices=_unit_choices(unit_helpers.FLOW_UNITS), initial="m³/h"
+    )
+    loaded_curves_head_units = forms.ChoiceField(
+        choices=_unit_choices(unit_helpers.HEAD_UNITS), initial="J/kg"
+    )
+    loaded_curves_power_units = forms.ChoiceField(
+        choices=_unit_choices(unit_helpers.POWER_UNITS), initial="kW"
+    )
+
+
+TAG_PARAMETERS_DIRECT = [
+    ("suc_p", "Suction Pressure", unit_helpers.PRESSURE_UNITS),
+    ("suc_T", "Suction Temperature", unit_helpers.TEMPERATURE_UNITS),
+    ("disch_p", "Discharge Pressure", unit_helpers.PRESSURE_UNITS),
+    ("disch_T", "Discharge Temperature", unit_helpers.TEMPERATURE_UNITS),
+    ("speed", "Speed", unit_helpers.SPEED_UNITS),
+    ("flow", "Flow", unit_helpers.FLOW_UNITS),
+]
+
+TAG_PARAMETERS_ORIFICE = [
+    ("suc_p", "Suction Pressure", unit_helpers.PRESSURE_UNITS),
+    ("suc_T", "Suction Temperature", unit_helpers.TEMPERATURE_UNITS),
+    ("disch_p", "Discharge Pressure", unit_helpers.PRESSURE_UNITS),
+    ("disch_T", "Discharge Temperature", unit_helpers.TEMPERATURE_UNITS),
+    ("speed", "Speed", unit_helpers.SPEED_UNITS),
+    ("delta_p", "Delta P", unit_helpers.PRESSURE_UNITS),
+    ("p_downstream", "Downstream P", unit_helpers.PRESSURE_UNITS),
+]
+
+
+def tag_parameters_for(flow_method: str):
+    """Return the tag parameter list matching the flow measurement method."""
+    if flow_method == "Orifice":
+        return TAG_PARAMETERS_ORIFICE
+    return TAG_PARAMETERS_DIRECT
+
+
+def default_fluid_components():
+    """Return the default fluid component list for the component-tags form."""
+    return gas_composition.FLUID_LIST

--- a/ccp/app/django-app/apps/performance_evaluation/pytest.ini
+++ b/ccp/app/django-app/apps/performance_evaluation/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = apps.performance_evaluation.tests._test_settings
+pythonpath = ../..
+testpaths = tests

--- a/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_ai_options.html
+++ b/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_ai_options.html
@@ -1,0 +1,18 @@
+{# AI analysis options partial. #}
+<details class="ccp-expander">
+  <summary>Opções de IA</summary>
+  <div class="ccp-row">
+    {{ forms.ai_form.ai_enabled }} {{ forms.ai_form.ai_enabled.label_tag }}
+  </div>
+  <div class="ccp-row">
+    {{ forms.ai_form.ai_provider.label_tag }} {{ forms.ai_form.ai_provider }}
+    {{ forms.ai_form.ai_api_key.label_tag }} {{ forms.ai_form.ai_api_key }}
+  </div>
+  <div class="ccp-row">
+    {{ forms.ai_form.ai_azure_endpoint.label_tag }} {{ forms.ai_form.ai_azure_endpoint }}
+    {{ forms.ai_form.ai_azure_deployment.label_tag }} {{ forms.ai_form.ai_azure_deployment }}
+  </div>
+  {% for field in forms.ai_form %}
+    {% for err in field.errors %}<p class="errors">{{ field.label }}: {{ err }}</p>{% endfor %}
+  {% endfor %}
+</details>

--- a/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_base_fallback.html
+++ b/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_base_fallback.html
@@ -1,0 +1,23 @@
+{# Local fallback used only when templates/base.html (Unit 1) is absent. #}
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}ccp - Performance Evaluation{% endblock %}</title>
+  <style>
+    body { font-family: monospace; color: #2c3e50; }
+    .ccp-expander { border: 1px solid #2c3e50; padding: 0.5rem; margin-bottom: 0.5rem; }
+    .ccp-expander > summary { font-weight: bold; cursor: pointer; }
+    .ccp-row { display: flex; gap: 0.25rem; margin-bottom: 0.25rem; }
+    label { display: block; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>ccp - Centrifugal Compressor Performance</h1>
+  </header>
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>

--- a/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_design_cases.html
+++ b/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_design_cases.html
@@ -1,0 +1,48 @@
+{# Design cases A-E suction conditions grid. #}
+<details class="ccp-expander" open>
+  <summary>Condições de Sucção - Casos de Projeto</summary>
+  <p>Defina as condições de sucção de cada caso de projeto (A, B, C, D, E).</p>
+
+  {{ forms.design_formset.management_form }}
+  <table class="design-cases">
+    <thead>
+      <tr>
+        <th>Parâmetro</th>
+        {% for case in cases %}<th>Caso {{ case }}</th>{% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Gas</td>
+        {% for form in forms.design_formset %}
+          <td>{{ form.case }}{{ form.gas }}</td>
+        {% endfor %}
+      </tr>
+      <tr>
+        <td>Pressão de Sucção {% with first=forms.design_formset.0 %}{{ first.suc_p_unit }}{% endwith %}</td>
+        {% for form in forms.design_formset %}
+          <td>{{ form.suc_p }}{% for e in form.suc_p.errors %}<span class="errors">{{ e }}</span>{% endfor %}</td>
+        {% endfor %}
+      </tr>
+      <tr>
+        <td>Temperatura de Sucção {% with first=forms.design_formset.0 %}{{ first.suc_T_unit }}{% endwith %}</td>
+        {% for form in forms.design_formset %}
+          <td>{{ form.suc_T }}{% for e in form.suc_T.errors %}<span class="errors">{{ e }}</span>{% endfor %}</td>
+        {% endfor %}
+      </tr>
+    </tbody>
+  </table>
+
+  <h4>Upload de Curvas de Desempenho</h4>
+  {% for case in cases %}
+    <div class="case-curves">
+      <strong>Caso {{ case }}</strong>
+      <form method="post" action="{% url 'performance_evaluation:upload_curves' case %}" enctype="multipart/form-data">
+        {% csrf_token %}
+        <input type="file" name="curves_file_1" accept=".csv">
+        <input type="file" name="curves_file_2" accept=".csv">
+        <button type="submit">Carregar Curvas do Caso {{ case }}</button>
+      </form>
+    </div>
+  {% endfor %}
+</details>

--- a/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_pi_config.html
+++ b/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_pi_config.html
@@ -1,0 +1,17 @@
+{# PI server configuration partial. #}
+<details class="ccp-expander" open>
+  <summary>Servidor PI</summary>
+  <div class="ccp-row">
+    <div>{{ forms.pi_form.pi_server_name.label_tag }} {{ forms.pi_form.pi_server_name }}</div>
+    <div>{{ forms.pi_form.pi_auth_method.label_tag }} {{ forms.pi_form.pi_auth_method }}</div>
+    <div x-data="{ auth: '{{ forms.pi_form.pi_auth_method.value }}' }" x-init="$watch('auth', v => v)">
+      <template x-if="auth === 'basic'">
+        <div>
+          {{ forms.pi_form.pi_username.label_tag }} {{ forms.pi_form.pi_username }}
+          {{ forms.pi_form.pi_password.label_tag }} {{ forms.pi_form.pi_password }}
+        </div>
+      </template>
+    </div>
+  </div>
+  {% for err in forms.pi_form.non_field_errors %}<p class="errors">{{ err }}</p>{% endfor %}
+</details>

--- a/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_tag_mappings.html
+++ b/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_tag_mappings.html
@@ -1,0 +1,38 @@
+{# Tag mappings HTMX block. Re-rendered on flow-method change. #}
+<details class="ccp-expander" open id="tag-mappings-block">
+  <summary>Configuração de Tags</summary>
+
+  <div class="ccp-row">
+    {{ forms.flow_form.flow_method.label_tag }}
+    <select name="flow-flow_method"
+            hx-post="{% url 'performance_evaluation:flow_method_change' %}"
+            hx-trigger="change"
+            hx-target="#tag-mappings-rows"
+            hx-include="closest form">
+      {% for value, label in forms.flow_form.flow_method.field.choices %}
+        <option value="{{ value }}" {% if value == flow_method %}selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+  </div>
+
+  <div id="tag-mappings-rows">
+    <p>Cada parâmetro aceita um ou dois tags. Quando ambos são válidos, o tag 2 é convertido para a unidade do tag 1 e os valores são médios.</p>
+    {% for row in tag_rows %}
+      {% include "performance_evaluation/_tag_row.html" with row=row %}
+    {% endfor %}
+  </div>
+
+  {% if flow_method == "Orifice" %}
+    <div class="ccp-row">
+      {{ forms.flow_form.orifice_tappings.label_tag }} {{ forms.flow_form.orifice_tappings }}
+      {{ forms.flow_form.orifice_D.label_tag }} {{ forms.flow_form.orifice_D }} {{ forms.flow_form.orifice_D_unit }}
+      {{ forms.flow_form.orifice_d.label_tag }} {{ forms.flow_form.orifice_d }} {{ forms.flow_form.orifice_d_unit }}
+    </div>
+  {% endif %}
+
+  <h4>Componente do Fluido</h4>
+  <div class="ccp-row">
+    {{ forms.fluid_source_form.fluid_source.label_tag }} {{ forms.fluid_source_form.fluid_source }}
+    {{ forms.fluid_source_form.operation_fluid_gas.label_tag }} {{ forms.fluid_source_form.operation_fluid_gas }}
+  </div>
+</details>

--- a/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_tag_row.html
+++ b/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/_tag_row.html
@@ -1,0 +1,16 @@
+{# Single tag-mapping row for parameter ``row.parameter``. HTMX-swappable. #}
+<div class="ccp-row tag-row" data-parameter="{{ row.parameter }}">
+  <label>{{ row.label }}</label>
+  <input type="text" name="tag_{{ row.parameter }}_tag_1" value="{{ row.tag_1 }}" placeholder="Tag 1">
+  <select name="tag_{{ row.parameter }}_unit_1">
+    {% for u in row.units %}<option value="{{ u }}" {% if u == row.unit_1 %}selected{% endif %}>{{ u }}</option>{% endfor %}
+  </select>
+  <input type="text" name="tag_{{ row.parameter }}_tag_2" value="{{ row.tag_2 }}" placeholder="Tag 2">
+  <select name="tag_{{ row.parameter }}_unit_2">
+    {% for u in row.units %}<option value="{{ u }}" {% if u == row.unit_2 %}selected{% endif %}>{{ u }}</option>{% endfor %}
+  </select>
+  <button type="button"
+          hx-post="{% url 'performance_evaluation:tag_mapping_remove' row.parameter %}"
+          hx-target="closest .tag-row"
+          hx-swap="outerHTML">Remover</button>
+</div>

--- a/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/config.html
+++ b/ccp/app/django-app/apps/performance_evaluation/templates/performance_evaluation/config.html
@@ -1,0 +1,60 @@
+{% extends base_template %}
+{% load static %}
+
+{% block title %}ccp - Avaliação de Desempenho{% endblock %}
+
+{% block content %}
+<section class="performance-evaluation-config">
+  <h2>Performance Evaluation</h2>
+  <p>Avaliação de desempenho histórica do compressor centrífugo. Carregue os arquivos de curvas, configure os tags do PI e selecione o intervalo de dados desejado.</p>
+
+  <details class="ccp-expander" open>
+    <summary>Sessão / Arquivo</summary>
+    <form method="post" action="{% url 'performance_evaluation:load_ccp' %}" enctype="multipart/form-data">
+      {% csrf_token %}
+      {{ forms.session_form.session_name.label_tag }} {{ forms.session_form.session_name }}
+      {{ forms.session_form.ccp_file.label_tag }} {{ forms.session_form.ccp_file }}
+      <button type="submit">Carregar</button>
+    </form>
+  </details>
+
+  <form method="post" action="{% url 'performance_evaluation:config' %}" id="pe-config-form">
+    {% csrf_token %}
+
+    {% include "performance_evaluation/_design_cases.html" %}
+    {% include "performance_evaluation/_pi_config.html" %}
+    {% include "performance_evaluation/_tag_mappings.html" %}
+    {% include "performance_evaluation/_ai_options.html" %}
+
+    <details class="ccp-expander" open>
+      <summary>Intervalo de Dados</summary>
+      <div class="ccp-row">
+        <div>{{ forms.date_form.start_date.label_tag }} {{ forms.date_form.start_date }}</div>
+        <div>{{ forms.date_form.start_time.label_tag }} {{ forms.date_form.start_time }}</div>
+        <div>{{ forms.date_form.end_date.label_tag }} {{ forms.date_form.end_date }}</div>
+        <div>{{ forms.date_form.end_time.label_tag }} {{ forms.date_form.end_time }}</div>
+      </div>
+      {% for err in forms.date_form.non_field_errors %}<p class="errors">{{ err }}</p>{% endfor %}
+    </details>
+
+    <details class="ccp-expander" open>
+      <summary>Unidades das Curvas Carregadas</summary>
+      <div class="ccp-row">
+        {% for f in forms.curves_units_form %}
+          <div>{{ f.label_tag }} {{ f }}</div>
+        {% endfor %}
+      </div>
+    </details>
+
+    <button type="submit">Salvar configuração</button>
+  </form>
+
+  <p>
+    <a href="{% url 'performance_evaluation:compute' %}">Executar avaliação</a>
+    &middot;
+    <a href="{% url 'performance_evaluation:monitoring' %}">Monitoramento online</a>
+    &middot;
+    <a href="{% url 'performance_evaluation:results' %}">Resultados</a>
+  </p>
+</section>
+{% endblock %}

--- a/ccp/app/django-app/apps/performance_evaluation/tests/_test_settings.py
+++ b/ccp/app/django-app/apps/performance_evaluation/tests/_test_settings.py
@@ -1,0 +1,52 @@
+"""Minimal Django settings used only to run Unit 8's own tests in isolation.
+
+Unit 1 ships the real ``ccp_web.settings``; this shim lets tests pass while
+the other worktrees are still in flight.
+"""
+
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[4]
+SECRET_KEY = "unit-8-test-secret"
+DEBUG = True
+ALLOWED_HOSTS = ["*"]
+USE_TZ = True
+
+INSTALLED_APPS = [
+    "django.contrib.contenttypes",
+    "django.contrib.auth",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "apps.performance_evaluation",
+]
+
+MIDDLEWARE = [
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+]
+
+ROOT_URLCONF = "apps.performance_evaluation.tests._test_urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]
+
+DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
+
+SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+
+STATIC_URL = "/static/"
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/ccp/app/django-app/apps/performance_evaluation/tests/_test_urls.py
+++ b/ccp/app/django-app/apps/performance_evaluation/tests/_test_urls.py
@@ -1,0 +1,10 @@
+"""Test URL conf - mounts only the performance_evaluation app."""
+
+from django.urls import include, path
+
+urlpatterns = [
+    path(
+        "performance-evaluation/",
+        include("apps.performance_evaluation.urls", namespace="performance_evaluation"),
+    ),
+]

--- a/ccp/app/django-app/apps/performance_evaluation/tests/conftest.py
+++ b/ccp/app/django-app/apps/performance_evaluation/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Pytest bootstrap: configure Django settings before tests import modules."""
+
+import os
+import sys
+from pathlib import Path
+
+DJANGO_APP_DIR = Path(__file__).resolve().parents[3]
+if str(DJANGO_APP_DIR) not in sys.path:
+    sys.path.insert(0, str(DJANGO_APP_DIR))
+
+os.environ.setdefault(
+    "DJANGO_SETTINGS_MODULE",
+    "apps.performance_evaluation.tests._test_settings",
+)
+
+import django  # noqa: E402
+
+django.setup()

--- a/ccp/app/django-app/apps/performance_evaluation/tests/test_config_view.py
+++ b/ccp/app/django-app/apps/performance_evaluation/tests/test_config_view.py
@@ -1,0 +1,152 @@
+"""View-level tests for the performance_evaluation config page."""
+
+from __future__ import annotations
+
+import pytest
+from django.test import Client
+
+from apps.performance_evaluation import forms
+from apps.performance_evaluation._compat import session_store
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+def _post_payload(**overrides):
+    data = {
+        "design-TOTAL_FORMS": "5",
+        "design-INITIAL_FORMS": "5",
+        "design-MIN_NUM_FORMS": "5",
+        "design-MAX_NUM_FORMS": "5",
+        "pi-pi_server_name": "srv1",
+        "pi-pi_auth_method": "kerberos",
+        "pi-pi_username": "",
+        "pi-pi_password": "",
+        "flow-flow_method": "Direct",
+        "flow-orifice_tappings": "flange",
+        "flow-orifice_D_unit": "m",
+        "flow-orifice_d_unit": "m",
+        "fluid-fluid_source": "Fixed Operation Fluid",
+        "fluid-operation_fluid_gas": "ng",
+        "date-start_date": "2024-01-01",
+        "date-start_time": "00:00",
+        "date-end_date": "2024-01-02",
+        "date-end_time": "00:00",
+        "ai-ai_provider": "gemini",
+        "curves-loaded_curves_speed_units": "rpm",
+        "curves-loaded_curves_flow_units": "m³/h",
+        "curves-loaded_curves_head_units": "J/kg",
+        "curves-loaded_curves_power_units": "kW",
+        "tag_suc_p_tag_1": "FT-001",
+        "tag_suc_p_unit_1": "bar",
+    }
+    for idx, case in enumerate(forms.CASES):
+        data[f"design-{idx}-case"] = case
+        data[f"design-{idx}-gas"] = ""
+        data[f"design-{idx}-suc_p"] = ""
+        data[f"design-{idx}-suc_p_unit"] = "bar"
+        data[f"design-{idx}-suc_T"] = ""
+        data[f"design-{idx}-suc_T_unit"] = "degC"
+    data.update(overrides)
+    return data
+
+
+def test_get_config_renders_200(client):
+    response = client.get("/performance-evaluation/config/")
+    assert response.status_code == 200
+    assert b"Performance Evaluation" in response.content
+
+
+def test_get_config_contains_design_cases_and_tag_mappings(client):
+    response = client.get("/performance-evaluation/config/")
+    body = response.content.decode("utf-8")
+    for case in forms.CASES:
+        assert f"Caso {case}" in body
+    assert "Servidor PI" in body
+    assert "Suction Pressure" in body or "suc_p" in body
+
+
+def test_post_config_happy_path_persists_state(client):
+    response = client.post("/performance-evaluation/config/", data=_post_payload())
+    assert response.status_code == 200
+
+    sid = client.session.session_key or "anonymous"
+    state = session_store.get_session(sid)
+    assert state.get("pi_server_name") == "srv1"
+    assert state.get("flow_method") == "Direct"
+    assert state.get("suc_p_tag") == "FT-001"
+
+
+def test_post_config_invalid_date_range_returns_400(client):
+    payload = _post_payload(
+        **{
+            "date-start_date": "2024-02-01",
+            "date-end_date": "2024-01-01",
+        }
+    )
+    response = client.post("/performance-evaluation/config/", data=payload)
+    assert response.status_code == 400
+
+
+def test_htmx_flow_method_change_returns_partial(client):
+    response = client.post(
+        "/performance-evaluation/tag-mappings/flow-method/",
+        data={"flow_method": "Orifice"},
+    )
+    assert response.status_code == 200
+    body = response.content.decode("utf-8")
+    assert "Delta P" in body or "delta_p" in body
+
+
+def test_htmx_tag_mapping_add(client):
+    response = client.post(
+        "/performance-evaluation/tag-mappings/add/",
+        data={"parameter": "oil_flow"},
+    )
+    assert response.status_code == 200
+    assert b"oil_flow" in response.content
+
+
+def test_htmx_tag_mapping_remove(client):
+    # Seed some state first
+    client.get("/performance-evaluation/config/")
+    sid = client.session.session_key or "anonymous"
+    state = session_store.get_session(sid)
+    state["suc_p_tag"] = "FT-99"
+    state["suc_p_unit"] = "bar"
+    session_store.set_session(sid, state)
+
+    response = client.post("/performance-evaluation/tag-mappings/remove/suc_p/")
+    assert response.status_code == 200
+    state = session_store.get_session(sid)
+    assert "suc_p_tag" not in state
+
+
+def test_compute_placeholder_returns_204(client):
+    assert client.get("/performance-evaluation/compute/").status_code == 204
+    assert client.get("/performance-evaluation/monitoring/").status_code == 204
+    assert client.get("/performance-evaluation/results/").status_code == 204
+
+
+def test_upload_curves_persists_file_bytes(client):
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    client.get("/performance-evaluation/config/")
+    f1 = SimpleUploadedFile("curve-head.csv", b"x,y\n1,2\n")
+    f2 = SimpleUploadedFile("curve-eff.csv", b"x,y\n1,0.8\n")
+    response = client.post(
+        "/performance-evaluation/upload-curves/A/",
+        data={"curves_file_1": f1, "curves_file_2": f2},
+    )
+    assert response.status_code == 200
+    sid = client.session.session_key or "anonymous"
+    state = session_store.get_session(sid)
+    assert state["curves_file_1_case_A"]["name"] == "curve-head.csv"
+    assert state["curves_file_2_case_A"]["content"].startswith(b"x,y")
+
+
+def test_upload_curves_rejects_unknown_case(client):
+    response = client.post("/performance-evaluation/upload-curves/Z/")
+    assert response.status_code == 400

--- a/ccp/app/django-app/apps/performance_evaluation/tests/test_forms.py
+++ b/ccp/app/django-app/apps/performance_evaluation/tests/test_forms.py
@@ -1,0 +1,162 @@
+"""Form-level validation tests for the performance_evaluation app."""
+
+from __future__ import annotations
+
+from datetime import date, time
+
+import pytest
+
+from apps.performance_evaluation import forms
+
+
+def _formset_data(cases):
+    data = {
+        "design-TOTAL_FORMS": "5",
+        "design-INITIAL_FORMS": "5",
+        "design-MIN_NUM_FORMS": "5",
+        "design-MAX_NUM_FORMS": "5",
+    }
+    for idx, cd in enumerate(cases):
+        for key, value in cd.items():
+            data[f"design-{idx}-{key}"] = value
+    return data
+
+
+def test_design_case_form_valid():
+    form = forms.DesignCaseForm(
+        data={
+            "case": "A",
+            "gas": "ng",
+            "suc_p": 10.0,
+            "suc_p_unit": "bar",
+            "suc_T": 25.0,
+            "suc_T_unit": "degC",
+        }
+    )
+    assert form.is_valid(), form.errors
+    cd = form.cleaned_data
+    assert cd["_populated"] is True
+    assert cd["suc_p_Pa"] == pytest.approx(1e6)
+    assert cd["suc_T_K"] == pytest.approx(298.15)
+
+
+def test_design_case_form_empty_is_unpopulated():
+    form = forms.DesignCaseForm(
+        data={
+            "case": "B",
+            "gas": "",
+            "suc_p": "",
+            "suc_p_unit": "bar",
+            "suc_T": "",
+            "suc_T_unit": "degC",
+        }
+    )
+    assert form.is_valid()
+    assert form.cleaned_data["_populated"] is False
+
+
+def test_design_case_form_rejects_negative_pressure():
+    form = forms.DesignCaseForm(
+        data={
+            "case": "A",
+            "gas": "ng",
+            "suc_p": -1.0,
+            "suc_p_unit": "bar",
+            "suc_T": 25.0,
+            "suc_T_unit": "degC",
+        }
+    )
+    assert not form.is_valid()
+    assert "suc_p" in form.errors
+
+
+def test_design_formset_requires_five_cases():
+    data = _formset_data(
+        [
+            {
+                "case": c,
+                "gas": "",
+                "suc_p": "",
+                "suc_p_unit": "bar",
+                "suc_T": "",
+                "suc_T_unit": "degC",
+            }
+            for c in forms.CASES
+        ]
+    )
+    fs = forms.DesignCaseFormSet(data=data, prefix="design")
+    assert fs.is_valid(), fs.errors
+
+
+def test_pi_form_basic_requires_username():
+    form = forms.PIServerConfigForm(
+        data={"pi_server_name": "srv", "pi_auth_method": "basic", "pi_username": ""}
+    )
+    assert not form.is_valid()
+    assert "pi_username" in form.errors
+
+
+def test_flow_method_orifice_requires_diameters():
+    form = forms.FlowMethodForm(
+        data={
+            "flow_method": "Orifice",
+            "orifice_tappings": "flange",
+            "orifice_D": "",
+            "orifice_D_unit": "m",
+            "orifice_d": "",
+            "orifice_d_unit": "m",
+        }
+    )
+    assert not form.is_valid()
+    assert "orifice_D" in form.errors
+    assert "orifice_d" in form.errors
+
+
+def test_flow_method_direct_is_ok_without_diameters():
+    form = forms.FlowMethodForm(
+        data={
+            "flow_method": "Direct",
+            "orifice_tappings": "flange",
+            "orifice_D_unit": "m",
+            "orifice_d_unit": "m",
+        }
+    )
+    assert form.is_valid(), form.errors
+
+
+def test_date_range_form_rejects_reversed_interval():
+    form = forms.DateRangeForm(
+        data={
+            "start_date": date(2024, 1, 10),
+            "start_time": time(12, 0),
+            "end_date": date(2024, 1, 1),
+            "end_time": time(0, 0),
+        }
+    )
+    assert not form.is_valid()
+
+
+def test_ai_options_requires_key_when_enabled():
+    form = forms.AIOptionsForm(
+        data={
+            "ai_enabled": "on",
+            "ai_provider": "gemini",
+            "ai_api_key": "",
+        }
+    )
+    assert not form.is_valid()
+    assert "ai_api_key" in form.errors
+
+
+def test_ai_options_disabled_needs_nothing():
+    form = forms.AIOptionsForm(data={"ai_provider": "gemini"})
+    assert form.is_valid(), form.errors
+
+
+def test_tag_parameters_direct_vs_orifice():
+    direct = {k for k, _, _ in forms.tag_parameters_for("Direct")}
+    orifice = {k for k, _, _ in forms.tag_parameters_for("Orifice")}
+    assert "flow" in direct
+    assert "flow" not in orifice
+    assert "delta_p" in orifice
+    assert "p_downstream" in orifice

--- a/ccp/app/django-app/apps/performance_evaluation/urls.py
+++ b/ccp/app/django-app/apps/performance_evaluation/urls.py
@@ -1,0 +1,55 @@
+"""URL configuration for the Performance Evaluation Django app.
+
+Unit 8 owns ``/`` and ``/config/`` plus HTMX partial endpoints for the
+tag-mapping UI. ``/compute/``, ``/monitoring/`` and ``/results/`` are
+declared here as placeholder views returning HTTP 204 - Unit 9 replaces
+them at merge time.
+"""
+
+from django.http import HttpResponse
+from django.urls import path
+
+from .views import config as config_views
+
+app_name = "performance_evaluation"
+
+
+def _placeholder(_request, *_args, **_kwargs):
+    """Return HTTP 204 until Unit 9 ships the real view."""
+    return HttpResponse(status=204)
+
+
+urlpatterns = [
+    path("", config_views.config_view, name="index"),
+    path("config/", config_views.config_view, name="config"),
+    path(
+        "upload-impeller/<str:case>/",
+        config_views.upload_impeller,
+        name="upload_impeller",
+    ),
+    path(
+        "upload-curves/<str:case>/",
+        config_views.upload_curves,
+        name="upload_curves",
+    ),
+    path(
+        "tag-mappings/add/",
+        config_views.tag_mapping_add,
+        name="tag_mapping_add",
+    ),
+    path(
+        "tag-mappings/remove/<str:parameter>/",
+        config_views.tag_mapping_remove,
+        name="tag_mapping_remove",
+    ),
+    path(
+        "tag-mappings/flow-method/",
+        config_views.flow_method_change,
+        name="flow_method_change",
+    ),
+    path("load-ccp/", config_views.load_ccp_view, name="load_ccp"),
+    # Unit 9 placeholders
+    path("compute/", _placeholder, name="compute"),
+    path("monitoring/", _placeholder, name="monitoring"),
+    path("results/", _placeholder, name="results"),
+]

--- a/ccp/app/django-app/apps/performance_evaluation/views/__init__.py
+++ b/ccp/app/django-app/apps/performance_evaluation/views/__init__.py
@@ -1,0 +1,1 @@
+"""Performance Evaluation views package."""

--- a/ccp/app/django-app/apps/performance_evaluation/views/config.py
+++ b/ccp/app/django-app/apps/performance_evaluation/views/config.py
@@ -1,0 +1,354 @@
+"""Config page + HTMX partial endpoints for the Performance Evaluation app.
+
+This view owns the input side: design cases, PI configuration, tag
+mappings, date range, AI options, and .ccp file loading. Computation,
+monitoring, and results belong to Unit 9.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from functools import lru_cache
+
+from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
+from django.shortcuts import render
+from django.template import TemplateDoesNotExist
+from django.template.loader import get_template
+from django.views.decorators.http import require_http_methods
+
+from .. import forms
+from .._compat import load_ccp_file, session_store
+
+
+@lru_cache(maxsize=1)
+def _base_template() -> str:
+    """Return Unit 1's base.html when available, else our local fallback."""
+    try:
+        get_template("base.html")
+        return "base.html"
+    except TemplateDoesNotExist:
+        return "performance_evaluation/_base_fallback.html"
+
+
+def _session_id(request) -> str:
+    """Return a stable session id for the current Django session."""
+    key = request.session.session_key
+    if key:
+        return key
+    try:
+        request.session.save()
+    except Exception:
+        pass
+    return request.session.session_key or "anonymous"
+
+
+def _load_state(request) -> dict:
+    return session_store.get_session(_session_id(request))
+
+
+def _save_state(request, state: dict) -> None:
+    session_store.set_session(_session_id(request), state)
+
+
+def _default_dates() -> tuple[datetime, datetime]:
+    end = datetime.now().replace(microsecond=0)
+    start = end - timedelta(days=30)
+    return start, end
+
+
+def _initial_design_cases(state: dict) -> list[dict]:
+    return [
+        {
+            "case": case,
+            "gas": state.get(f"gas_case_{case}", ""),
+            "suc_p": state.get(f"suc_p_case_{case}", 0.0),
+            "suc_p_unit": state.get("design_suc_p_unit", "bar"),
+            "suc_T": state.get(f"suc_T_case_{case}", 0.0),
+            "suc_T_unit": state.get("design_suc_T_unit", "degC"),
+        }
+        for case in forms.CASES
+    ]
+
+
+def _build_forms(state: dict, data=None):
+    start, end = _default_dates()
+    date_initial = {
+        "start_date": state.get("eval_start_date", start.date()),
+        "start_time": state.get("eval_start_time", start.time()),
+        "end_date": state.get("eval_end_date", end.date()),
+        "end_time": state.get("eval_end_time", end.time()),
+    }
+    return {
+        "design_formset": forms.DesignCaseFormSet(
+            data=data,
+            prefix="design",
+            initial=_initial_design_cases(state),
+        ),
+        "pi_form": forms.PIServerConfigForm(
+            data=data,
+            prefix="pi",
+            initial={
+                "pi_server_name": state.get("pi_server_name", ""),
+                "pi_auth_method": state.get("pi_auth_method", "kerberos"),
+                "pi_username": state.get("pi_username", ""),
+            },
+        ),
+        "flow_form": forms.FlowMethodForm(
+            data=data,
+            prefix="flow",
+            initial={
+                "flow_method": state.get("flow_method", "Direct"),
+                "orifice_tappings": state.get("orifice_tappings", "flange"),
+                "orifice_D": state.get("orifice_D", 0.0),
+                "orifice_d": state.get("orifice_d", 0.0),
+            },
+        ),
+        "fluid_source_form": forms.FluidSourceForm(
+            data=data,
+            prefix="fluid",
+            initial={
+                "fluid_source": state.get("fluid_source", "Fixed Operation Fluid"),
+                "operation_fluid_gas": state.get("operation_fluid_gas", ""),
+            },
+        ),
+        "date_form": forms.DateRangeForm(
+            data=data, prefix="date", initial=date_initial
+        ),
+        "ai_form": forms.AIOptionsForm(
+            data=data,
+            prefix="ai",
+            initial={
+                "ai_enabled": state.get("ai_enabled", False),
+                "ai_provider": state.get("ai_provider", "gemini"),
+                "ai_api_key": state.get("ai_api_key", ""),
+                "ai_azure_endpoint": state.get("ai_azure_endpoint", ""),
+                "ai_azure_deployment": state.get("ai_azure_deployment", ""),
+            },
+        ),
+        "curves_units_form": forms.CurvesUnitsForm(
+            data=data,
+            prefix="curves",
+            initial={
+                "loaded_curves_speed_units": state.get(
+                    "loaded_curves_speed_units", "rpm"
+                ),
+                "loaded_curves_flow_units": state.get(
+                    "loaded_curves_flow_units", "m³/h"
+                ),
+                "loaded_curves_head_units": state.get(
+                    "loaded_curves_head_units", "J/kg"
+                ),
+                "loaded_curves_power_units": state.get(
+                    "loaded_curves_power_units", "kW"
+                ),
+            },
+        ),
+        "session_form": forms.SessionMetaForm(
+            prefix="session",
+            initial={"session_name": state.get("session_name", "")},
+        ),
+    }
+
+
+def _tag_rows(state: dict, flow_method: str) -> list[dict]:
+    rows = []
+    for key, label, units in forms.tag_parameters_for(flow_method):
+        rows.append(
+            {
+                "parameter": key,
+                "label": label,
+                "units": units,
+                "tag_1": state.get(f"{key}_tag", ""),
+                "tag_2": state.get(f"{key}_tag_2", ""),
+                "unit_1": state.get(f"{key}_unit", units[0] if units else ""),
+                "unit_2": state.get(f"{key}_unit_2", units[0] if units else ""),
+            }
+        )
+    return rows
+
+
+def _render_config(request, state: dict, forms_dict: dict, status: int = 200):
+    flow_method = forms_dict["flow_form"]["flow_method"].value() or "Direct"
+    context = {
+        "forms": forms_dict,
+        "cases": forms.CASES,
+        "tag_rows": _tag_rows(state, flow_method),
+        "flow_method": flow_method,
+        "fluid_components": forms.default_fluid_components(),
+        "state": state,
+        "base_template": _base_template(),
+    }
+    return render(
+        request,
+        "performance_evaluation/config.html",
+        context,
+        status=status,
+    )
+
+
+@require_http_methods(["GET", "HEAD", "POST"])
+def config_view(request):
+    """Render the config page (GET) or persist submitted forms (POST)."""
+    state = _load_state(request)
+
+    if request.method in ("GET", "HEAD"):
+        forms_dict = _build_forms(state)
+        return _render_config(request, state, forms_dict)
+
+    forms_dict = _build_forms(state, data=request.POST)
+    all_valid = True
+    for key in (
+        "design_formset",
+        "pi_form",
+        "flow_form",
+        "fluid_source_form",
+        "date_form",
+        "ai_form",
+        "curves_units_form",
+    ):
+        form = forms_dict[key]
+        if not form.is_valid():
+            all_valid = False
+
+    if not all_valid:
+        return _render_config(request, state, forms_dict, status=400)
+
+    # Persist cleaned data into the session_store state dict.
+    for i, form in enumerate(forms_dict["design_formset"].forms):
+        cd = form.cleaned_data
+        case = cd.get("case") or forms.CASES[i]
+        state[f"gas_case_{case}"] = cd.get("gas", "")
+        state[f"suc_p_case_{case}"] = cd.get("suc_p") or 0.0
+        state[f"suc_T_case_{case}"] = cd.get("suc_T") or 0.0
+        state["design_suc_p_unit"] = cd.get("suc_p_unit", "bar")
+        state["design_suc_T_unit"] = cd.get("suc_T_unit", "degC")
+
+    state.update(forms_dict["pi_form"].cleaned_data)
+    state.update(forms_dict["flow_form"].cleaned_data)
+    state.update(forms_dict["fluid_source_form"].cleaned_data)
+    state.update(forms_dict["curves_units_form"].cleaned_data)
+
+    ai = forms_dict["ai_form"].cleaned_data
+    state.update(ai)
+
+    date_cd = forms_dict["date_form"].cleaned_data
+    state["eval_start_date"] = date_cd.get("start_date")
+    state["eval_start_time"] = date_cd.get("start_time")
+    state["eval_end_date"] = date_cd.get("end_date")
+    state["eval_end_time"] = date_cd.get("end_time")
+
+    # Parse per-parameter tag mapping rows out of the POST body.
+    flow_method = state.get("flow_method", "Direct")
+    for key, _label, _units in forms.tag_parameters_for(flow_method):
+        state[f"{key}_tag"] = request.POST.get(f"tag_{key}_tag_1", "")
+        state[f"{key}_tag_2"] = request.POST.get(f"tag_{key}_tag_2", "")
+        state[f"{key}_unit"] = request.POST.get(f"tag_{key}_unit_1", "")
+        state[f"{key}_unit_2"] = request.POST.get(f"tag_{key}_unit_2", "")
+
+    _save_state(request, state)
+
+    forms_dict = _build_forms(state)
+    return _render_config(request, state, forms_dict)
+
+
+@require_http_methods(["POST"])
+def upload_impeller(request, case: str):
+    """Store an uploaded impeller TOML file in session state."""
+    if case not in forms.CASES:
+        return HttpResponseBadRequest("unknown case")
+    state = _load_state(request)
+    f = request.FILES.get("impeller")
+    if f is None:
+        return HttpResponseBadRequest("missing file")
+    state[f"impeller_case_{case}"] = {"name": f.name, "size": f.size}
+    _save_state(request, state)
+    return JsonResponse({"case": case, "name": f.name})
+
+
+@require_http_methods(["POST"])
+def upload_curves(request, case: str):
+    """Store uploaded Engauge curve CSV files in session state."""
+    if case not in forms.CASES:
+        return HttpResponseBadRequest("unknown case")
+    state = _load_state(request)
+    saved = []
+    for idx in (1, 2):
+        f = request.FILES.get(f"curves_file_{idx}")
+        if f is not None:
+            state[f"curves_file_{idx}_case_{case}"] = {
+                "name": f.name,
+                "content": f.read(),
+            }
+            saved.append(f.name)
+    _save_state(request, state)
+    return JsonResponse({"case": case, "saved": saved})
+
+
+@require_http_methods(["POST"])
+def tag_mapping_add(request):
+    """HTMX endpoint: return an additional tag-mapping row partial."""
+    parameter = request.POST.get("parameter", "custom")
+    row = {
+        "parameter": parameter,
+        "label": parameter.replace("_", " ").title(),
+        "units": [],
+        "tag_1": "",
+        "tag_2": "",
+        "unit_1": "",
+        "unit_2": "",
+    }
+    return render(
+        request,
+        "performance_evaluation/_tag_row.html",
+        {"row": row},
+    )
+
+
+@require_http_methods(["POST", "DELETE"])
+def tag_mapping_remove(request, parameter: str):
+    """HTMX endpoint: drop a tag-mapping row from session state."""
+    state = _load_state(request)
+    for key in (
+        f"{parameter}_tag",
+        f"{parameter}_tag_2",
+        f"{parameter}_unit",
+        f"{parameter}_unit_2",
+    ):
+        state.pop(key, None)
+    _save_state(request, state)
+    return HttpResponse(status=200)
+
+
+@require_http_methods(["POST"])
+def flow_method_change(request):
+    """HTMX endpoint: re-render the tag-mappings block when method changes."""
+    flow_method = request.POST.get("flow_method", "Direct")
+    state = _load_state(request)
+    state["flow_method"] = flow_method
+    _save_state(request, state)
+    return render(
+        request,
+        "performance_evaluation/_tag_mappings.html",
+        {
+            "tag_rows": _tag_rows(state, flow_method),
+            "flow_method": flow_method,
+        },
+    )
+
+
+@require_http_methods(["POST"])
+def load_ccp_view(request):
+    """Load a .ccp session archive into session state."""
+    f = request.FILES.get("ccp_file")
+    if f is None:
+        return HttpResponseBadRequest("missing file")
+    try:
+        loaded = load_ccp_file(f)
+    except Exception as exc:
+        return HttpResponseBadRequest(f"invalid .ccp file: {exc}")
+    state = _load_state(request)
+    state.update(loaded)
+    state["session_name"] = f.name.replace(".ccp", "")
+    _save_state(request, state)
+    forms_dict = _build_forms(state)
+    return _render_config(request, state, forms_dict)


### PR DESCRIPTION
## Summary

Unit 8 of the Streamlit → Django migration. Ports the config/input side of `ccp/app/pages/4_performance_evaluation.py` (design cases, PI configuration, tag mappings, date range, AI options, flow method) into `ccp/app/django-app/apps/performance_evaluation/`.

- Forms: `DesignCaseFormSet` (A–E), `PIServerConfigForm`, `FlowMethodForm`, `FluidSourceForm`, `DateRangeForm`, `AIOptionsForm`, `CurvesUnitsForm`, `TagMappingForm`, `SessionMetaForm`. Unit conversions go through `ccp.Q_` / pint — never hand-rolled arithmetic.
- Views: `config_view` (GET/POST), HTMX partials for flow-method swap and tag-mapping add/remove, upload endpoints for impellers and Engauge curve CSVs, `.ccp` file loader. `/compute/`, `/monitoring/`, `/results/` are declared as HTTP 204 placeholders that Unit 9 will replace.
- Templates: `config.html` extends `base.html` (with a local fallback used when Unit 1 has not landed yet) and composes partials `_design_cases`, `_pi_config`, `_tag_mappings`, `_tag_row`, `_ai_options`. Portuguese UI copy preserved.
- `_compat.py`: try/except shim that prefers `apps.core.*` / `apps.integrations.*` when present and falls back to local `_stubs/` modules so this app is runnable in isolation until Units 2/3/4/11 merge.
- Tests: 21 pytest cases (`tests/test_forms.py` + `tests/test_config_view.py`) covering form validation, GET/POST happy path, HTMX flow-method/add/remove, upload endpoints and placeholder 204s.

## Test plan

- [x] `uv run pytest apps/performance_evaluation/tests/` — 21 passed
- [x] `python -m django check` with the local test settings — no issues
- [x] `curl -sI http://127.0.0.1:8000/performance-evaluation/config/` → HTTP 200
- [ ] Cross-unit smoke check to be done by the coordinator after Units 1/2/3/4/11 merge