### PR TITLE
Add flow columns to evaluation results table

### DIFF
--- a/ccp/app/pages/4_performance_evaluation.py
+++ b/ccp/app/pages/4_performance_evaluation.py
@@ -1247,6 +1247,8 @@ def main():
                     st.markdown("### Evaluation Results Data")
 
                     display_cols = [
+                        "flow_v",
+                        "flow_m",
                         "eff",
                         "expected_eff",
                         "delta_eff",


### PR DESCRIPTION
## Summary
- Add `flow_v` and `flow_m` as the first columns of the Data Table in the performance evaluation app, so volumetric and mass flow are shown alongside the other results (and included in the Excel export).

Closes #127

## Test plan
- [x] Run `uv run streamlit run ccp/app/ccp_app.py`, open the Performance Evaluation page, run an evaluation and confirm `flow_v` / `flow_m` appear in the Data Table tab and in the downloaded Excel file.