### PR TITLE
Change in `disch_from_suc_head_eff``

### DIFF
--- a/ccp/point.py
+++ b/ccp/point.py
@@ -2818,12 +2818,24 @@ def disch_from_suc_head_eff(suc, head, eff, polytropic_method=None):
     #  consider first an isentropic compression
     disch = State(h=h_disch, s=suc.s(), fluid=suc.fluid)
 
-    def update_pressure(p):
-        disch.update(h=h_disch, p=p)
+    def update_state(x, update_type):
+        if update_type == "pressure":
+            disch.update(h=h_disch, p=x)
+        elif update_type == "temperature":
+            disch.update(h=h_disch, T=x)
         new_head = head_calc_func(suc, disch)
         return (new_head - head).magnitude
 
-    newton(update_pressure, disch.p().magnitude, tol=1e-1)
+    try:
+        newton(update_state, disch.p().magnitude, args=("pressure",), tol=1e-1)
+    except (RuntimeError, ValueError):
+        disch = State(h=h_disch, s=suc.s(), fluid=suc.fluid)
+        newton(
+            update_state,
+            disch.T().magnitude,
+            args=("temperature",),
+            tol=1e-1,
+        )
 
     return disch
 

--- a/ccp/state.py
+++ b/ccp/state.py
@@ -878,6 +878,8 @@ class State(CP.AbstractState):
                 super().update(CP.HmassSmass_INPUTS, h.magnitude, s.magnitude)
             elif T is not None and s is not None:
                 super().update(CP.SmassT_INPUTS, s.magnitude, T.magnitude)
+            elif T is not None and h is not None:
+                super().update(CP.HmassT_INPUTS, h.magnitude, T.magnitude)
             else:
                 raise KeyError(f"Update key {args} not implemented")
         except ValueError as e:


### PR DESCRIPTION
I've inserted an alternative routine to the `disch` calculation to make this process more robust.

The motivation is that, when converting some curves of a CO2 compressor (from approx. 60 bara to 130 bara) on a fluid with 70% CO2, the thermodynamic state was causing the newton minimizer to fail.

Specifically, the pressure from the isentropic discharge state, when combined with the discharge enthalpy, resulted in a discharge temperature of around 64 Kelvin. My assumption is that this "broken" state was causing the minimizer to diverge.

To address this, I added an `update_type` argument to the `disch_from_suc_head_eff` function (similar to the approach in `_calc_from_eff_phi_psi_suc_volume_ratio`, line [454 of `point.py`](https://github.com/petrobras/ccp/blob/8907957567edfb181a7a4e37f46388c12187cc33/ccp/point.py#L454)). This allows the routine to first attempt the calculation using pressure as before, and, if that fails, to retry using temperature as the initial guess.