### PR TITLE
Extrapolation Method Improved

### DIFF
--- a/ccp/app/pages/3_curves_conversion.py
+++ b/ccp/app/pages/3_curves_conversion.py
@@ -389,6 +389,13 @@ def main():
                     index=0,
                 )
 
+            option_container = st.container()
+            show_design_curves = option_container.checkbox(
+                "Plot design curves",
+                value=False,
+                key="show_design_curves",
+            )
+
             if plot_curves_flow_units in flow_v_units:
                 plot_curves_flow_v_units = plot_curves_flow_units
             else:
@@ -406,35 +413,41 @@ def main():
                 power_units,
                 disch_T_units,
                 disch_p_units,
+                similarity,
             ):
                 head_plot = _impeller.head_plot(
                     flow_v_units=point_flow_v_units,
                     head_units=head_units,
                     flow_v=Q_(point_flow, point_flow_v_units),
                     speed=Q_(point_speed, point_speed_units),
+                    similarity=similarity,
                 )
                 power_plot = _impeller.power_plot(
                     flow_v_units=point_flow_v_units,
                     power_units=power_units,
                     flow_v=Q_(point_flow, point_flow_v_units),
                     speed=Q_(point_speed, point_speed_units),
+                    similarity=similarity,
                 )
                 disch_T_plot = _impeller.disch.T_plot(
                     flow_v_units=point_flow_v_units,
                     T_units=disch_T_units,
                     flow_v=Q_(point_flow, point_flow_v_units),
                     speed=Q_(point_speed, point_speed_units),
+                    similarity=similarity,
                 )
                 eff_plot = _impeller.eff_plot(
                     flow_v_units=point_flow_v_units,
                     flow_v=Q_(point_flow, point_flow_v_units),
                     speed=Q_(point_speed, point_speed_units),
+                    similarity=similarity,
                 )
                 disch_p_plot = _impeller.disch.p_plot(
                     flow_v_units=point_flow_v_units,
                     p_units=disch_p_units,
                     flow_v=Q_(point_flow, point_flow_v_units),
                     speed=Q_(point_speed, point_speed_units),
+                    similarity=similarity,
                 )
                 point = _impeller.point(
                     flow_v=Q_(point_flow, point_flow_v_units),
@@ -452,7 +465,7 @@ def main():
 
             def render_impeller_plots(impeller, key_prefix, label):
                 flow_container = st.container()
-                flow_col1, flow_col2, _, _ = flow_container.columns(4)
+                flow_col1, flow_col2, flow_col3, _ = flow_container.columns(4)
                 flow_col1.markdown(f"Operational Flow (**{plot_curves_flow_v_units}**)")
                 project_flow = flow_col2.number_input(
                     f"{label} Flow",
@@ -476,6 +489,12 @@ def main():
                     label_visibility="collapsed",
                     key=f"{key_prefix}_speed_input",
                 )
+                options_container = st.container()
+                similarity = options_container.checkbox(
+                    "Show similarity",
+                    value=False,
+                    key=f"{key_prefix}_show_similarity",
+                )
 
                 (
                     head_plot,
@@ -495,6 +514,7 @@ def main():
                     power_units=plot_curves_power_units,
                     disch_T_units=plot_curves_disch_T_units,
                     disch_p_units=plot_curves_disch_p_units,
+                    similarity=similarity,
                 )
 
                 plot_col1, plot_col2 = st.columns(2)
@@ -523,43 +543,41 @@ def main():
                         reverse=True,
                     )
                     gas_lines = "\n".join(
-                        f"                                {comp.lower():<22s} {frac * 100:>7.3f} %"
+                        f"    {comp.lower():<22s} {frac * 100:>7.3f} %"
                         for comp, frac in gas_items
                     )
+                    
+                    summary = "\n".join([
+                        "-----------------------------",
+                        f"    Speed:                 {project_point.speed.to("rpm").m:.0f} {plot_curves_speed_units}",
+                        f"    Flow:                  {project_point.flow_v.to(plot_curves_flow_v_units).m:.2f} {plot_curves_flow_v_units}",
+                        f"    Head:                  {project_point.head.to(plot_curves_head_units).m:.2f} {plot_curves_head_units}",
+                        f"    Eff:                   {(project_point.eff.m * 100):.2f} %",
+                        f"    Power:                 {project_point.power.to(plot_curves_power_units).m:.2f} {plot_curves_power_units}",
+                        "",
+                        "    Suction Conditions",
+                        "    --------------------",
+                        f"    Suction Pressure:      {project_point.suc.p(plot_curves_disch_p_units).m:.2f} {plot_curves_disch_p_units}",
+                        f"    Suction Temperature:   {project_point.suc.T(plot_curves_disch_T_units).m:.2f} {plot_curves_disch_T_units}",
+                        "",
+                        "    Discharge Conditions",
+                        "    --------------------",
+                        f"    Discharge Pressure:    {project_point.disch.p(plot_curves_disch_p_units).m:.2f} {plot_curves_disch_p_units}",
+                        f"    Discharge Temperature: {project_point.disch.T(plot_curves_disch_T_units).m:.2f} {plot_curves_disch_T_units}",
+                        "",
+                        "    Gas Composition (mol %)",
+                        "    --------------------\n",
+                    ]) + gas_lines
 
                     st.markdown(f"#### {label} Point")
-                    st.code(
-                        f"""
-                            -----------------------------\n
-                                Speed:                 {project_point.speed.to("rpm").m:.0f} {plot_curves_speed_units}
-                                Flow:                  {project_point.flow_v.to(plot_curves_flow_v_units).m:.2f} {plot_curves_flow_v_units}
-                                Head:                  {project_point.head.to(plot_curves_head_units).m:.2f} {plot_curves_head_units}
-                                Eff:                   {project_point.eff.m:.2f} %
-                                Power:                 {project_point.power.to(plot_curves_power_units).m:.2f} {plot_curves_power_units}
-
-                                Suction Conditions
-                                --------------------
-                                Suction Pressure:      {project_point.suc.p(plot_curves_disch_p_units).m:.2f} {plot_curves_disch_p_units}
-                                Suction Temperature:   {project_point.suc.T(plot_curves_disch_T_units).m:.2f} {plot_curves_disch_T_units}
-
-                                Discharge Conditions
-                                --------------------
-                                Discharge Pressure:    {project_point.disch.p(plot_curves_disch_p_units).m:.2f} {plot_curves_disch_p_units}
-                                Discharge Temperature: {project_point.disch.T(plot_curves_disch_T_units).m:.2f} {plot_curves_disch_T_units}
-
-                                Gas Composition (mol %)
-                                --------------------
-{gas_lines}
-
-""",
-                    )
+                    st.code(summary)
 
             @st.fragment
             def display_results():
                 available_cases, impellers_list = get_available_impellers()
                 converted_imp = st.session_state.converted_impeller
 
-                if available_cases:
+                if available_cases and show_design_curves:
                     st.markdown("### Original (Design) Curves")
                     tabs = st.tabs([f"Case {c}" for c in available_cases])
                     for tab, case, imp in zip(tabs, available_cases, impellers_list):

--- a/ccp/impeller.py
+++ b/ccp/impeller.py
@@ -16,7 +16,6 @@ from scipy.interpolate import interp1d, UnivariateSpline, PchipInterpolator
 from scipy.optimize import fsolve
 
 from ccp import Q_, State, Point, Curve
-from ccp.point import phi, psi, mach, reynolds
 from ccp.config.units import check_units
 from ccp.config.utilities import r_getattr, r_setattr
 from ccp.data_io.read_csv import read_data_from_engauge_csv
@@ -662,9 +661,14 @@ class Impeller:
                     curves[0], speed, number_of_points, p0, power_losses, extrapolated
                 )
             else:
-                current_curve = interpolate_between_curves(
-                    curves, speed, number_of_points, p0, power_losses, extrapolated
-                )
+                if len(speeds) == 1: # Only one curve
+                    current_curve = extrapolated_curve(
+                        curves[0], speed, number_of_points, p0, power_losses, extrapolated
+                    )
+                else:
+                    current_curve = interpolate_between_curves(
+                        curves, speed, number_of_points, p0, power_losses, extrapolated
+                    )
         else:
             if len(speeds) == 1: # Only one curve
                 current_curve = extrapolated_curve(
@@ -1657,11 +1661,22 @@ def extrapolated_curve(
         head = ((speed.m / curve.speed.m) ** 2) * curve[i].head.m
         eff = curve[i].eff.m
 
-        phi_ratio = phi(flow_v, speed, p0.D) / curve[i].phi
-        psi_ratio = psi(head, speed, p0.D) / curve[i].psi
-        reynolds_ratio = reynolds(p0.suc, speed, p0.b, p0.D) / curve[i].reynolds
-        volume_ratio_ratio = 1
-        mach_diff = mach(p0.suc, speed, p0.D) - curve[i].mach
+        p_i = Point(
+            suc=p0.suc,
+            head=head,
+            eff=eff,
+            flow_v=flow_v,
+            speed=speed,
+            power_losses=power_losses,
+            b=p0.b,
+            D=p0.D,
+        )
+
+        phi_ratio = p_i.phi / curve[i].phi
+        psi_ratio = p_i.psi / curve[i].psi
+        reynolds_ratio = p_i.reynolds / curve[i].reynolds
+        mach_diff = p_i.mach - curve[i].mach
+        volume_ratio_ratio = p_i.volume_ratio / curve[i].volume_ratio
 
         p = Point(
             suc=p0.suc,

--- a/ccp/impeller.py
+++ b/ccp/impeller.py
@@ -16,6 +16,7 @@ from scipy.interpolate import interp1d, UnivariateSpline, PchipInterpolator
 from scipy.optimize import fsolve
 
 from ccp import Q_, State, Point, Curve
+from ccp.point import phi, psi, mach, reynolds
 from ccp.config.units import check_units
 from ccp.config.utilities import r_getattr, r_setattr
 from ccp.data_io.read_csv import read_data_from_engauge_csv
@@ -622,15 +623,6 @@ class Impeller:
         """
         speeds = np.array([curve.speed.magnitude for curve in self.curves])
 
-        # handle case where we only have one curve and can't interpolate
-        if len(speeds) == 1:
-            current_curve = self.curves[0]
-            if speed is not None and not np.allclose(speed, current_curve.speed):
-                raise ValueError(
-                    f"Can only interpolate for speed={current_curve.speed}"
-                )
-            return current_curve
-
         # calculate power losses
         power_losses = calculate_power_losses(
             power_losses_ref=self.curves[0].power_losses,
@@ -644,10 +636,6 @@ class Impeller:
             self.curves[closest_curves_idxs[1]],
         ]
 
-        # calculate factor
-        speed_range = curves[1].speed.m - curves[0].speed.m
-        factor_0 = (speed.m - curves[0].speed.m) / speed_range
-        factor_1 = (curves[1].speed.m - speed.m) / speed_range
         # if curve was extrapolated from two other curves extrapolated is true
         if np.all([p._extrapolated for p in curves[0].points]) or np.all(
             [p._extrapolated for p in curves[1].points]
@@ -658,64 +646,34 @@ class Impeller:
         else:
             extrapolated = True
 
-        current_curve = []
         p0 = self.points[0]
         number_of_points = len(curves[0])
 
-        for i in range(number_of_points):
-            flow_eff, eff = get_interpolated_values(
-                factor_0,
-                factor_1,
-                curves[0][i].flow_v.magnitude,
-                curves[0][i].eff.m,
-                curves[1][i].flow_v.magnitude,
-                curves[1][i].eff.m,
-            )
-            flow_head, head = get_interpolated_values(
-                factor_0,
-                factor_1,
-                curves[0][i].flow_v.magnitude,
-                curves[0][i].head.m,
-                curves[1][i].flow_v.magnitude,
-                curves[1][i].head.m,
-            )
+        if extrapolated:
+            if speed.m > curves[1].speed.m:
+                # The extrapolated curve is above the maximum speed of the performance map
+                current_curve = extrapolated_parameters(
+                    curves[1], speed, number_of_points, p0, power_losses, extrapolated
+                )
 
-            phi_ratio = (
-                factor_1 * curves[0][i].phi_ratio + factor_0 * curves[1][i].phi_ratio
-            )
-            psi_ratio = (
-                factor_1 * curves[0][i].psi_ratio + factor_0 * curves[1][i].psi_ratio
-            )
-            volume_ratio_ratio = (
-                factor_1 * curves[0][i].volume_ratio_ratio
-                + factor_0 * curves[1][i].volume_ratio_ratio
-            )
-            reynolds_ratio = (
-                factor_1 * curves[0][i].reynolds_ratio
-                + factor_0 * curves[1][i].reynolds_ratio
-            )
-            mach_diff = (
-                factor_1 * curves[0][i].mach_diff + factor_0 * curves[1][i].mach_diff
-            )
-
-            p = Point(
-                suc=p0.suc,
-                head=head,
-                eff=eff,
-                flow_v=(flow_eff + flow_head) / 2,
-                speed=speed,
-                power_losses=power_losses,
-                b=p0.b,
-                D=p0.D,
-                phi_ratio=phi_ratio,
-                psi_ratio=psi_ratio,
-                volume_ratio_ratio=volume_ratio_ratio,
-                reynolds_ratio=reynolds_ratio,
-                mach_diff=mach_diff,
-                extrapolated=extrapolated,
-            )
-
-            current_curve.append(p)
+            elif speed.m < curves[0].speed.m:
+                # The extrapolated curve is below the minimum speed of the performance map
+                current_curve = extrapolated_parameters(
+                    curves[0], speed, number_of_points, p0, power_losses, extrapolated
+                )
+            else:
+                current_curve = interpolate_between_curves(
+                    curves, speed, number_of_points, p0, power_losses, extrapolated
+                )
+        else:
+            if len(speeds) == 1: # Only one curve
+                current_curve = extrapolated_parameters(
+                    curves[0], speed, number_of_points, p0, power_losses, extrapolated
+                )
+            else:
+                current_curve = interpolate_between_curves(
+                    curves, speed, number_of_points, p0, power_losses, extrapolated
+                )
 
         current_curve = Curve(current_curve, extrapolated)
 
@@ -1457,6 +1415,9 @@ def find_closest_speeds(array, value):
     diff = array - value
     idx = np.abs(diff).argmin()
 
+    if len(array) == 1:
+        return [0, 0]
+
     if idx == 0:
         return [0, 1]
     elif idx == len(array) - 1:
@@ -1570,3 +1531,155 @@ def calc_min_head_point(x, speed, imp, min_head):
     except ValueError:
         head = -x + min_head
     return head - min_head
+
+
+def interpolate_between_curves(
+    curves, speed, number_of_points, p0, power_losses, extrapolated
+):
+    """Function to interpolate between two given curves.
+
+    Parameters
+    ----------
+    curves : list
+        List of curves with the lower and upper curve where the interpolation is going to take place.
+    speed : pint.Quantity
+        Speed (rad/s) of the interpolated curve.
+    number_of_points : int
+        The number of points to be interpolated.
+    p0 : ccp.Point
+        Reference point to acquire suction conditions and geometric parameters.
+    power_losses : pint.Quantity
+        Mechanical power losses (Watt) which includes bearing and seal.
+    extrapolated : bool
+        If true, the point is an extrapolation from other curves or its flow is
+        outside surge and choke limits.
+
+    Returns
+    -------
+        current_curve : list
+            List with the interpolated points.
+    """
+    # calculate factor
+    speed_range = curves[1].speed.m - curves[0].speed.m
+    factor_0 = (speed.m - curves[0].speed.m) / speed_range
+    factor_1 = (curves[1].speed.m - speed.m) / speed_range
+
+    current_curve = []
+
+    for i in range(number_of_points):
+        flow_eff, eff = get_interpolated_values(
+            factor_0,
+            factor_1,
+            curves[0][i].flow_v.magnitude,
+            curves[0][i].eff.m,
+            curves[1][i].flow_v.magnitude,
+            curves[1][i].eff.m,
+        )
+        flow_head, head = get_interpolated_values(
+            factor_0,
+            factor_1,
+            curves[0][i].flow_v.magnitude,
+            curves[0][i].head.m,
+            curves[1][i].flow_v.magnitude,
+            curves[1][i].head.m,
+        )
+
+        phi_ratio = (
+            factor_1 * curves[0][i].phi_ratio + factor_0 * curves[1][i].phi_ratio
+        )
+        psi_ratio = (
+            factor_1 * curves[0][i].psi_ratio + factor_0 * curves[1][i].psi_ratio
+        )
+        volume_ratio_ratio = (
+            factor_1 * curves[0][i].volume_ratio_ratio
+            + factor_0 * curves[1][i].volume_ratio_ratio
+        )
+        reynolds_ratio = (
+            factor_1 * curves[0][i].reynolds_ratio
+            + factor_0 * curves[1][i].reynolds_ratio
+        )
+        mach_diff = (
+            factor_1 * curves[0][i].mach_diff + factor_0 * curves[1][i].mach_diff
+        )
+
+        p = Point(
+            suc=p0.suc,
+            head=head,
+            eff=eff,
+            flow_v=(flow_eff + flow_head) / 2,
+            speed=speed,
+            power_losses=power_losses,
+            b=p0.b,
+            D=p0.D,
+            phi_ratio=phi_ratio,
+            psi_ratio=psi_ratio,
+            volume_ratio_ratio=volume_ratio_ratio,
+            reynolds_ratio=reynolds_ratio,
+            mach_diff=mach_diff,
+            extrapolated=extrapolated,
+        )
+
+        current_curve.append(p)
+
+    return current_curve
+
+
+def extrapolated_parameters(
+    curve, speed, number_of_points, p0, power_losses, extrapolated
+):
+    """Function to interpolate between two given curves.
+
+    Parameters
+    ----------
+    curve : ccp.Curve
+        Curve on which the extrapolation will occur.
+    speed : pint.Quantity
+        Speed (rad/s) of the interpolated curve.
+    number_of_points : int
+        The number of points to be interpolated.
+    p0 : ccp.Point
+        Reference point to acquire suction conditions and geometric parameters.
+    power_losses : pint.Quantity
+        Mechanical power losses (Watt) which includes bearing and seal.
+    extrapolated : bool
+        If true, the point is an extrapolation from other curves or its flow is
+        outside surge and choke limits.
+
+    Returns
+    -------
+        current_curve : list
+            List with the interpolated points.
+    """
+    current_curve = []
+
+    for i in range(number_of_points):
+        flow_v = (speed.m / curve.speed.m) * curve[i].flow_v.m
+        head = ((speed.m / curve.speed.m) ** 2) * curve[i].head.m
+        eff = curve[i].eff.m
+
+        phi_ratio = phi(flow_v, speed, p0.D) / curve[i].phi
+        psi_ratio = psi(head, speed, p0.D) / curve[i].psi
+        reynolds_ratio = reynolds(p0.suc, speed, p0.b, p0.D) / curve[i].reynolds
+        volume_ratio_ratio = 1
+        mach_diff = mach(p0.suc, speed, p0.D) - curve[i].mach
+
+        p = Point(
+            suc=p0.suc,
+            head=head,
+            eff=eff,
+            flow_v=flow_v,
+            speed=speed,
+            power_losses=power_losses,
+            b=p0.b,
+            D=p0.D,
+            phi_ratio=phi_ratio,
+            psi_ratio=psi_ratio,
+            volume_ratio_ratio=volume_ratio_ratio,
+            reynolds_ratio=reynolds_ratio,
+            mach_diff=mach_diff,
+            extrapolated=extrapolated,
+        )
+
+        current_curve.append(p)
+
+    return current_curve

--- a/ccp/impeller.py
+++ b/ccp/impeller.py
@@ -652,13 +652,13 @@ class Impeller:
         if extrapolated:
             if speed.m > curves[1].speed.m:
                 # The extrapolated curve is above the maximum speed of the performance map
-                current_curve = extrapolated_parameters(
+                current_curve = extrapolated_curve(
                     curves[1], speed, number_of_points, p0, power_losses, extrapolated
                 )
 
             elif speed.m < curves[0].speed.m:
                 # The extrapolated curve is below the minimum speed of the performance map
-                current_curve = extrapolated_parameters(
+                current_curve = extrapolated_curve(
                     curves[0], speed, number_of_points, p0, power_losses, extrapolated
                 )
             else:
@@ -667,7 +667,7 @@ class Impeller:
                 )
         else:
             if len(speeds) == 1: # Only one curve
-                current_curve = extrapolated_parameters(
+                current_curve = extrapolated_curve(
                     curves[0], speed, number_of_points, p0, power_losses, extrapolated
                 )
             else:
@@ -1624,10 +1624,10 @@ def interpolate_between_curves(
     return current_curve
 
 
-def extrapolated_parameters(
+def extrapolated_curve(
     curve, speed, number_of_points, p0, power_losses, extrapolated
 ):
-    """Function to interpolate between two given curves.
+    """Function to extrapolate a curve based on another. The efficiency and volume ratio is considered the same, therefore the polytropic head is calculated through the fan law.
 
     Parameters
     ----------
@@ -1648,7 +1648,7 @@ def extrapolated_parameters(
     Returns
     -------
         current_curve : list
-            List with the interpolated points.
+            List with the extrapolated points.
     """
     current_curve = []
 


### PR DESCRIPTION
The extrapolation is now based on the following assumptions:

1. The `extrapolated head` is calculated through considering the $$\psi$$ coefficient as constant and hence: $$H_{extrapolated} =\left(\frac{N_{extrapolated}}{N_{reference}}\right)^{2}\cdot H_{reference}$$;
2. The `extrapolated flow` is calculated through $$Q_{extrapolated} =\left(\frac{N_{extrapolated}}{N_{reference}}\right)\cdot Q_{reference}$$
3. From `1` and `2` the efficiency shall be the equal to the `reference point`.

The `reference point\curve` is the closest speed to the extrapolation speed.

Through this procedure, it is possible to convert maps with only one curve (i.e. fixed speed compressors). The results are satisfactory for a extrapolation and the curve shapes are compliant.

Thanks to @CisneirosRaphael for the technical consult :grin: