### PR TITLE
Preserve forced phase through Point and Impeller

### DIFF
--- a/ccp/point.py
+++ b/ccp/point.py
@@ -460,7 +460,7 @@ class Point:
         disch_rho = 1 / disch_v
 
         # consider first an isentropic compression
-        disch = State(rho=disch_rho, s=suc.s(), fluid=suc.fluid)
+        disch = State(rho=disch_rho, s=suc.s(), fluid=suc.fluid, phase=suc.phase)
 
         def update_state(x, update_type):
             if update_type == "pressure":
@@ -478,7 +478,7 @@ class Point:
         except ValueError:
             # re-instantiate disch, since update with temperature not converging
             # might break the state
-            disch = State(rho=disch_rho, s=suc.s(), fluid=suc.fluid)
+            disch = State(rho=disch_rho, s=suc.s(), fluid=suc.fluid, phase=suc.phase)
             newton(update_state, disch.p().magnitude, args=("pressure",), tol=1e-1)
 
         self.disch = disch
@@ -739,7 +739,7 @@ class Point:
         disch_T = self.disch_T
         pressure_ratio = self.pressure_ratio
         disch_p = suc.p() * pressure_ratio
-        self.disch = State(p=disch_p, T=disch_T, fluid=suc.fluid)
+        self.disch = State(p=disch_p, T=disch_T, fluid=suc.fluid, phase=suc.phase)
         self._calc_from_disch_flow_v_speed_suc()
 
     def _calc_from_disch_T_flow_v_pressure_ratio_speed_suc_torque(self):
@@ -747,7 +747,7 @@ class Point:
         disch_T = self.disch_T
         pressure_ratio = self.pressure_ratio
         disch_p = suc.p() * pressure_ratio
-        self.disch = State(p=disch_p, T=disch_T, fluid=suc.fluid)
+        self.disch = State(p=disch_p, T=disch_T, fluid=suc.fluid, phase=suc.phase)
         self._calc_from_disch_flow_v_speed_suc_torque()
 
     def _calc_from_disch_T_flow_v_power_losses_pressure_ratio_speed_suc(self):
@@ -755,7 +755,7 @@ class Point:
         disch_T = self.disch_T
         pressure_ratio = self.pressure_ratio
         disch_p = suc.p() * pressure_ratio
-        self.disch = State(p=disch_p, T=disch_T, fluid=suc.fluid)
+        self.disch = State(p=disch_p, T=disch_T, fluid=suc.fluid, phase=suc.phase)
         self._calc_from_disch_flow_v_power_losses_speed_suc()
 
     def _calc_from_disch_T_flow_m_pressure_ratio_speed_suc(self):
@@ -763,7 +763,7 @@ class Point:
         disch_T = self.disch_T
         pressure_ratio = self.pressure_ratio
         disch_p = suc.p() * pressure_ratio
-        self.disch = State(p=disch_p, T=disch_T, fluid=suc.fluid)
+        self.disch = State(p=disch_p, T=disch_T, fluid=suc.fluid, phase=suc.phase)
         self._calc_from_disch_flow_m_speed_suc()
 
     def _calc_from_disch_T_flow_m_pressure_ratio_speed_suc_torque(self):
@@ -771,7 +771,7 @@ class Point:
         disch_T = self.disch_T
         pressure_ratio = self.pressure_ratio
         disch_p = suc.p() * pressure_ratio
-        self.disch = State(p=disch_p, T=disch_T, fluid=suc.fluid)
+        self.disch = State(p=disch_p, T=disch_T, fluid=suc.fluid, phase=suc.phase)
         self._calc_from_disch_flow_m_speed_suc_torque()
 
     def _calc_from_disch_T_flow_m_power_losses_pressure_ratio_speed_suc(self):
@@ -779,7 +779,7 @@ class Point:
         disch_T = self.disch_T
         pressure_ratio = self.pressure_ratio
         disch_p = suc.p() * pressure_ratio
-        self.disch = State(p=disch_p, T=disch_T, fluid=suc.fluid)
+        self.disch = State(p=disch_p, T=disch_T, fluid=suc.fluid, phase=suc.phase)
         self._calc_from_disch_flow_m_power_losses_speed_suc()
 
     def _calc_from_disch_T_flow_v_head_speed_suc(self):
@@ -968,6 +968,7 @@ class Point:
             p=str(self.suc.p()),
             T=str(self.suc.T()),
             fluid=self.suc.fluid,
+            phase=str(self.suc.phase),
             speed=str(self.speed),
             flow_v=str(self.flow_v),
             head=str(self.head),
@@ -987,10 +988,16 @@ class Point:
     @staticmethod
     def _dict_from_load(dict_parameters):
         """Change dict to format that can be used by load constructor."""
+        phase = dict_parameters.pop("phase", None)
+        # backwards compatibility: older files store no phase, newer ones may
+        # store the string "None" when no phase was forced.
+        if phase in (None, "None", ""):
+            phase = None
         suc = State(
             p=Q_(dict_parameters.pop("p")),
             T=Q_(dict_parameters.pop("T")),
             fluid=dict_parameters.pop("fluid"),
+            phase=phase,
         )
         extrapolated = dict_parameters.pop("extrapolated", False)
         # Convert string to boolean if needed (for backwards compatibility)
@@ -2090,7 +2097,7 @@ def head_reference(suc, disch, num_steps=100):
     """
 
     def calc_step_discharge_temp(T1, p1, p0, h0, v0, e):
-        s1 = State(p=p1, T=T1, fluid=suc.fluid)
+        s1 = State(p=p1, T=T1, fluid=suc.fluid, phase=suc.phase)
         h1 = s1.h()
 
         vm = (v0 + s1.v()) / 2
@@ -2117,11 +2124,11 @@ def head_reference(suc, disch, num_steps=100):
 
         # TODO implement p_intervals considering pressure ratio
         for p0, p1 in zip(p_intervals[:-1], p_intervals[1:]):
-            s0 = State(p=p0, T=T0, fluid=suc.fluid)
+            s0 = State(p=p0, T=T0, fluid=suc.fluid, phase=suc.phase)
             T1 = newton(
                 calc_step_discharge_temp, (T0 + 1e-3), args=(p1, p0, s0.h(), s0.v(), e)
             )
-            s1 = State(p=p1, T=T1, fluid=suc.fluid)
+            s1 = State(p=p1, T=T1, fluid=suc.fluid, phase=suc.phase)
             _ref_H += head_pol(s0, s1)
 
             T0 = T1
@@ -2183,7 +2190,7 @@ def head_reference_2017(suc, disch, num_steps=100):
         p = next_p
         p_intervals.append(p)
 
-    state1 = ccp.State(p=suc.p(), s=suc.s(), fluid=suc.fluid)
+    state1 = ccp.State(p=suc.p(), s=suc.s(), fluid=suc.fluid, phase=suc.phase)
 
     def calc_step_discharge_z(s1, s0, p1, p0, z0, R, e):
         state1.update(p=p1, s=s1)
@@ -2202,11 +2209,11 @@ def head_reference_2017(suc, disch, num_steps=100):
         s0 = suc.s().magnitude
 
         for p0, p1 in zip(p_intervals[:-1], p_intervals[1:]):
-            state0 = ccp.State(p=p0, s=s0, fluid=suc.fluid)
+            state0 = ccp.State(p=p0, s=s0, fluid=suc.fluid, phase=suc.phase)
             z0 = state0.z()
 
             s1 = newton(calc_step_discharge_z, (s0 + 1e-8), args=(s0, p1, p0, z0, R, e))
-            state1 = ccp.State(p=p1, s=s1, fluid=suc.fluid)
+            state1 = ccp.State(p=p1, s=s1, fluid=suc.fluid, phase=suc.phase)
             _ref_H_2017 += ccp.point.head_pol(state0, state1)
 
             s0 = s1
@@ -2345,11 +2352,15 @@ def head_pol_sandberg_colby_multistep(suc, disch, nstep=10):
 
             for _ in range(nstep):
                 # Isentropic discharge state for step j
-                disch_j = ccp.State(p=pd_j, s=suc_j.s(), fluid=suc_j.fluid)
+                disch_j = ccp.State(
+                    p=pd_j, s=suc_j.s(), fluid=suc_j.fluid, phase=suc_j.phase
+                )
 
                 def calc_delta_eff_p(Td_j):
                     """Calculate Δη_p = η_p,j - η_p for step j."""
-                    disch_j = ccp.State(p=pd_j, T=Td_j, fluid=suc_j.fluid)
+                    disch_j = ccp.State(
+                        p=pd_j, T=Td_j, fluid=suc_j.fluid, phase=suc_j.phase
+                    )
                     wp_j = head_pol_sandberg_colby(suc_j, disch_j)
                     eff_p_j = wp_j / (disch_j.h() - suc_j.h())
                     return (eff_p_j - eff_p).m
@@ -2361,7 +2372,9 @@ def head_pol_sandberg_colby_multistep(suc, disch, nstep=10):
                 Td_j = brentq(calc_delta_eff_p, T_isen, T_isen + 20)
 
                 # Update discharge state with calculated temperature
-                disch_j = ccp.State(p=pd_j, T=Td_j, fluid=suc_j.fluid)
+                disch_j = ccp.State(
+                    p=pd_j, T=Td_j, fluid=suc_j.fluid, phase=suc_j.phase
+                )
 
                 # Prepare for next step: suc_j+1 = disch_j
                 suc_j.update(p=disch_j.p(), T=disch_j.T())
@@ -2541,7 +2554,7 @@ def eff_pol_huntington(suc, disch, disch_s=None):
     error = 1
     n = 0
     while error > 1e-10:
-        state3 = State(p=p3, T=T3, fluid=suc.fluid)
+        state3 = State(p=p3, T=T3, fluid=suc.fluid, phase=suc.phase)
         s3 = state3.s()
         z3 = state3.z()
         cp3 = state3.cp()
@@ -2816,7 +2829,7 @@ def disch_from_suc_head_eff(suc, head, eff, polytropic_method=None):
     h_disch = head / eff + suc.h()
 
     #  consider first an isentropic compression
-    disch = State(h=h_disch, s=suc.s(), fluid=suc.fluid)
+    disch = State(h=h_disch, s=suc.s(), fluid=suc.fluid, phase=suc.phase)
 
     def update_state(x, update_type):
         if update_type == "pressure":
@@ -2829,7 +2842,7 @@ def disch_from_suc_head_eff(suc, head, eff, polytropic_method=None):
     try:
         newton(update_state, disch.p().magnitude, args=("pressure",), tol=1e-1)
     except (RuntimeError, ValueError):
-        disch = State(h=h_disch, s=suc.s(), fluid=suc.fluid)
+        disch = State(h=h_disch, s=suc.s(), fluid=suc.fluid, phase=suc.phase)
         newton(
             update_state,
             disch.T().magnitude,
@@ -2861,7 +2874,7 @@ def disch_from_suc_disch_p_eff(suc, disch_p, eff, polytropic_method=None):
     if polytropic_method is None:
         polytropic_method = ccp.config.POLYTROPIC_METHOD
 
-    disch = ccp.State(p=disch_p, s=suc.s(), fluid=suc.fluid)
+    disch = ccp.State(p=disch_p, s=suc.s(), fluid=suc.fluid, phase=suc.phase)
     eff_calc_func = globals()[f"eff_pol_{polytropic_method}"]
 
     def update_state(x):
@@ -2896,7 +2909,7 @@ def disch_from_suc_disch_T_head(suc, disch_T, head, polytropic_method=None):
     if polytropic_method is None:
         polytropic_method = ccp.config.POLYTROPIC_METHOD
 
-    disch = ccp.State(T=disch_T, s=suc.s(), fluid=suc.fluid)
+    disch = ccp.State(T=disch_T, s=suc.s(), fluid=suc.fluid, phase=suc.phase)
     head_calc_func = globals()[f"head_pol_{polytropic_method}"]
 
     def update_state(x):

--- a/ccp/state.py
+++ b/ccp/state.py
@@ -153,9 +153,7 @@ class State(CP.AbstractState):
                 from collections import Counter
 
                 dupes = [
-                    name
-                    for name, count in Counter(constituents).items()
-                    if count > 1
+                    name for name, count in Counter(constituents).items() if count > 1
                 ]
                 raise ValueError(
                     f"Repeated components in the fluid dictionary: {dupes}. "
@@ -666,7 +664,9 @@ class State(CP.AbstractState):
         return conductivity
 
     def __reduce__(self):
-        kwargs = dict(p=self.p(), T=self.T(), fluid=self.fluid)
+        kwargs = dict(
+            p=self.p(), T=self.T(), fluid=self.fluid, EOS=self.EOS, phase=self.phase
+        )
         return self._rebuild, (self.__class__, kwargs)
 
     @staticmethod

--- a/ccp/tests/test_impeller.py
+++ b/ccp/tests/test_impeller.py
@@ -95,6 +95,35 @@ def imp1():
     return imp1
 
 
+def test_impeller_phase_propagation():
+    # a forced suction phase must propagate to every state held by the impeller
+    # (suction and discharge of every point), survive construction (deepcopy)
+    # and survive conversion to a new suction state.
+    fluid = {"methane": 0.7, "ethane": 0.2, "propane": 0.1}
+    points = []
+    for flow_v, head, eff in [(0.4, 90, 0.42), (0.5, 88, 0.46), (0.6, 84, 0.45)]:
+        suc = State(p=Q_(20, "bar"), T=Q_(310, "K"), fluid=fluid, phase="gas")
+        points.append(
+            Point(
+                suc=suc,
+                head=Q_(head, "kJ/kg"),
+                eff=eff,
+                flow_v=Q_(flow_v, "m**3/s"),
+                speed=Q_(1000, "rad/s"),
+                b=Q_(0.01, "m"),
+                D=Q_(0.3, "m"),
+            )
+        )
+    imp = Impeller(points)
+    assert all(p.suc.phase == "gas" for p in imp.points)
+    assert all(p.disch.phase == "gas" for p in imp.points)
+
+    new_suc = State(p=Q_(25, "bar"), T=Q_(305, "K"), fluid=fluid, phase="gas")
+    imp_conv = Impeller.convert_from(imp, suc=new_suc, find="speed")
+    assert all(p.suc.phase == "gas" for p in imp_conv.points)
+    assert all(p.disch.phase == "gas" for p in imp_conv.points)
+
+
 def test_impeller_new_suction(imp1):
     new_suc = State(p=Q_(0.2, "MPa"), T=301.58, fluid={"n2": 1 - 1e-15, "co2": 1e-15})
     imp2 = Impeller.convert_from(imp1, suc=new_suc, find="speed")

--- a/ccp/tests/test_state.py
+++ b/ccp/tests/test_state.py
@@ -1,6 +1,7 @@
 import pytest
 import pickle
 import ccp
+from copy import copy, deepcopy
 from ccp.state import *
 from numpy.testing import assert_allclose
 
@@ -315,6 +316,22 @@ def test_mix_composition():
 def test_pickle():
     state = State(p=100000, T=300, fluid={"Methane": 1 - 1e-15, "Ethane": 1e-15})
     assert pickle.loads(pickle.dumps(state)) == state
+
+
+def test_copy_preserves_phase_and_eos():
+    # forced phase (and EOS) must survive copy/deepcopy/pickle so that it
+    # propagates through Point and Impeller (which deepcopy/pickle their states).
+    state = State(
+        p=100000,
+        T=300,
+        fluid={"Methane": 0.5, "Ethane": 0.5},
+        phase="gas",
+    )
+    assert state.phase == "gas"
+    assert copy(state).phase == "gas"
+    assert deepcopy(state).phase == "gas"
+    assert pickle.loads(pickle.dumps(state)).phase == "gas"
+    assert deepcopy(state).EOS == state.EOS
 
 
 def test_improved_error_message():


### PR DESCRIPTION
## Summary

The phase forced on a `State` (e.g. `State(..., phase="gas")`) was **silently dropped** as soon as the state entered a `Point` or `Impeller`. As a result, performance was always computed with automatic phase determination, even when the user explicitly forced a phase — and the documented `phase` argument had no effect beyond the bare `State`.

This PR makes the forced phase propagate end-to-end: `State` → `Point` → `Impeller`, including conversion and save/load.

## Root causes

1. **`State.__reduce__`** only serialized `p`, `T` and `fluid`, so any `copy`/`deepcopy`/`pickle` of a state lost its `phase` (and `EOS`). `Impeller.__init__` deepcopies all points, and `Impeller.convert_from` pickles them for multiprocessing — so the forced phase never survived entering an impeller.
2. **Internally computed states** (discharge states, polytropic-path integration steps, conversion helpers in `point.py`) were always built with `fluid=suc.fluid` but never `phase=suc.phase`.
3. **`Point` save/load (toml)** did not persist `phase`.

## Changes

- `State.__reduce__` now also serializes `EOS` and `phase`.
- All internal `State(...)` constructions in `point.py` propagate `phase=suc.phase` (or `suc_j.phase`).
- `_dict_to_save` / `_dict_from_load` persist `phase` (backwards compatible: files with no `phase` key, or the string `"None"`, load as `phase=None`).
- New tests:
  - `test_copy_preserves_phase_and_eos` — phase/EOS survive copy/deepcopy/pickle.
  - `test_impeller_phase_propagation` — phase propagates through `Impeller` construction and conversion.

## Performance

Forcing the phase skips the expensive flash phase determination. Benchmarked on `impeller_example` (REFPROP backend, 5 runs after warmup):

| phase        | best   | avg    |
|--------------|--------|--------|
| `None` (auto)| 6.306s | 6.386s |
| `"gas"`      | 4.530s | 4.695s |

**~26% faster** (avg 6.39s → 4.70s, ~1.7s saved per build), with **numerically identical** results (max relative difference: head `0`, eff `0`, power `5e-16`).

## Testing

- `uv run pytest ccp/tests/test_state.py` → 26 passed
- `uv run pytest ccp/tests/test_point.py` → 42 passed
- `uv run pytest ccp/tests/test_impeller.py` → 14 passed
- New tests pass; doctests for `state.py`/`point.py` pass.

> Note: a pre-existing cross-file test-isolation issue (REFPROP/`fork()` flakiness) causes some impeller tests to fail when `test_state.py`+`test_point.py`+`test_impeller.py` run in one process. This reproduces identically on `main` and is unrelated to this change.