### PR TITLE
Fix convert_from for dense fluids: robust isentropic discharge and efficiency solve

### DIFF
--- a/ccp/point.py
+++ b/ccp/point.py
@@ -460,7 +460,7 @@ class Point:
         disch_rho = 1 / disch_v
 
         # consider first an isentropic compression
-        disch = State(rho=disch_rho, s=suc.s(), fluid=suc.fluid, phase=suc.phase)
+        disch = isentropic_disch_from_rho(suc, disch_rho)
 
         def update_state(x, update_type):
             if update_type == "pressure":
@@ -475,11 +475,16 @@ class Point:
 
         try:
             newton(update_state, disch.T().magnitude, args=("temperature",), tol=1e-1)
-        except ValueError:
+        except (ValueError, RuntimeError):
             # re-instantiate disch, since update with temperature not converging
             # might break the state
-            disch = State(rho=disch_rho, s=suc.s(), fluid=suc.fluid, phase=suc.phase)
-            newton(update_state, disch.p().magnitude, args=("pressure",), tol=1e-1)
+            try:
+                disch = isentropic_disch_from_rho(suc, disch_rho)
+                newton(update_state, disch.p().magnitude, args=("pressure",), tol=1e-1)
+            except (ValueError, RuntimeError):
+                # the secant can diverge for dense fluids; fall back to a robust
+                # bracketed efficiency solve at fixed density.
+                disch = disch_from_suc_rho_eff(suc, disch_rho, eff, self.eff_calc_func)
 
         self.disch = disch
         self.head = self.head_calc_func(suc, disch, self._dummy_state)
@@ -2803,6 +2808,109 @@ def head_from_psi(D, psi, speed):
     head = psi * (u**2 / 2)
 
     return head.to("J/kg")
+
+
+def isentropic_disch_from_rho(suc, disch_rho):
+    """Discharge state of an isentropic compression to a target density.
+
+    The discharge is normally obtained from a ``State(rho=disch_rho, s=suc.s())``
+    flash (CoolProp ``DmassSmass`` inputs). For dense fluids that flash can return a
+    spurious root: two states share the same ``(rho, s)`` — the physical compression
+    (``disch.p >= suc.p``) and a cold, liquid-like root *below* suction pressure — and
+    the flash may return the cold one. Seeding the downstream efficiency solve from
+    that non-physical root makes it diverge (e.g. converting a performance map to a
+    dense, CO2-rich, near-critical suction condition).
+
+    When the flash lands on such a non-compression root we re-solve for the pressure
+    on the suction isentrope that matches ``disch_rho``. Density increases
+    monotonically with pressure along an isentrope, so bracketing from the suction
+    pressure upward selects the physical compression root.
+
+    Parameters
+    ----------
+    suc : ccp.State
+        Suction state.
+    disch_rho : pint.Quantity
+        Target discharge density.
+
+    Returns
+    -------
+    disch : ccp.State
+        Discharge state of the isentropic compression to ``disch_rho``.
+    """
+    disch = State(rho=disch_rho, s=suc.s(), fluid=suc.fluid, phase=suc.phase)
+
+    # for a compression (disch_rho > suc.rho) the physical isentropic discharge must
+    # have disch.p >= suc.p; otherwise the (rho, s) flash returned a spurious root.
+    if not (disch_rho > suc.rho() and disch.p() < suc.p()):
+        return disch
+
+    s_suc = suc.s()
+    rho_target = disch_rho.to("kg/m**3").magnitude
+
+    def rho_err(p_pa):
+        disch.update(p=Q_(p_pa, "Pa"), s=s_suc)
+        return disch.rho().to("kg/m**3").magnitude - rho_target
+
+    # bracket: rho_err < 0 at suction pressure; expand the upper bound until the
+    # isentrope reaches the target density (rho_err >= 0).
+    p_lo = suc.p().to("Pa").magnitude
+    p_hi = 2.0 * p_lo
+    for _ in range(60):
+        if rho_err(p_hi) >= 0.0:
+            break
+        p_hi *= 2.0
+    p_sol = brentq(rho_err, p_lo, p_hi, xtol=1.0)
+    disch.update(p=Q_(p_sol, "Pa"), s=s_suc)
+    return disch
+
+
+def disch_from_suc_rho_eff(suc, disch_rho, eff, eff_calc_func):
+    """Discharge at a fixed density matching a polytropic efficiency.
+
+    Robust alternative to the secant iteration used in the volume-ratio conversion.
+    Starting from the isentropic discharge (polytropic efficiency ~ 1.0), the
+    polytropic efficiency decreases monotonically as temperature rises at constant
+    density, so the target efficiency (< 1) is bracketed between the isentropic
+    temperature and a higher one and found with ``brentq``. The secant can diverge
+    for dense fluids — its tiny initial step yields a near-zero efficiency slope and
+    overshoots to a non-physical state — so this is used as a fallback there.
+
+    Parameters
+    ----------
+    suc : ccp.State
+        Suction state.
+    disch_rho : pint.Quantity
+        Target discharge density.
+    eff : pint.Quantity, float
+        Target polytropic efficiency.
+    eff_calc_func : callable
+        ``eff_calc_func(suc, disch)`` returning the polytropic efficiency.
+
+    Returns
+    -------
+    disch : ccp.State
+        Discharge state.
+    """
+    disch = isentropic_disch_from_rho(suc, disch_rho)
+    T_lo = disch.T().to("kelvin").magnitude
+
+    def eff_err(T):
+        disch.update(rho=disch_rho, T=Q_(T, "kelvin"))
+        return (eff_calc_func(suc, disch) - eff).magnitude
+
+    f_lo = eff_err(T_lo)
+    T_hi = T_lo * 1.02
+    for _ in range(80):
+        if f_lo * eff_err(T_hi) < 0:
+            break
+        T_hi *= 1.02
+    else:
+        raise ValueError("Could not bracket efficiency in volume-ratio conversion")
+
+    T_sol = brentq(eff_err, T_lo, T_hi, xtol=1e-2)
+    disch.update(rho=disch_rho, T=Q_(T_sol, "kelvin"))
+    return disch
 
 
 def disch_from_suc_head_eff(suc, head, eff, polytropic_method=None):

--- a/ccp/tests/test_point.py
+++ b/ccp/tests/test_point.py
@@ -496,6 +496,59 @@ def test_converted_from_find_speed(point_eff_flow_v_head_speed_suc_1):
     assert_allclose(point_converted_from_find_speed.power.m, 1084977.717171, rtol=1e-2)
 
 
+def test_isentropic_disch_from_rho_dense_co2():
+    # dense, CO2-rich, near-critical suction: the compressed discharge density admits
+    # two states with the same (rho, s) and CoolProp's flash may return the spurious
+    # low-pressure root. isentropic_disch_from_rho must return the physical
+    # compression root (disch.p > suc.p) with the target density and suction entropy.
+    fluid = dict(
+        co2=0.70823,
+        methane=0.27457,
+        ethane=0.0121,
+        propane=0.0022,
+        n2=0.002,
+        nbutane=0.0004,
+        ibutane=0.0002,
+        h2s=0.0002,
+        npentane=0.0001,
+    )
+    suc = State(p=Q_(104.6, "bar"), T=Q_(40, "degC"), fluid=fluid)
+    disch_rho = suc.rho() * 1.554831  # volume ratio of a measured curve point
+
+    disch = isentropic_disch_from_rho(suc, disch_rho)
+
+    assert disch.p() > suc.p()
+    assert_allclose(
+        disch.rho().to("kg/m**3").m, disch_rho.to("kg/m**3").m, rtol=1e-4
+    )
+    assert_allclose(disch.s().m, suc.s().m, rtol=1e-4)
+
+
+def test_converted_from_find_speed_dense_co2_target(point_eff_flow_v_head_speed_suc_1):
+    # converting a map to a dense, CO2-rich, near-critical suction used to raise
+    # "Could not calculate point" because the discharge solve was seeded from a
+    # spurious flash root; it must now succeed with efficiency preserved.
+    fluid = dict(
+        co2=0.70823,
+        methane=0.27457,
+        ethane=0.0121,
+        propane=0.0022,
+        n2=0.002,
+        nbutane=0.0004,
+        ibutane=0.0002,
+        h2s=0.0002,
+        npentane=0.0001,
+    )
+    suc_dense = State(p=Q_(104.6, "bar"), T=Q_(40, "degC"), fluid=fluid)
+    converted = Point.convert_from(
+        original_point=point_eff_flow_v_head_speed_suc_1, suc=suc_dense, find="speed"
+    )
+    assert converted.disch.p() > suc_dense.p()
+    assert_allclose(
+        converted.eff.m, point_eff_flow_v_head_speed_suc_1.eff.m, rtol=1e-3
+    )
+
+
 def test_converted_from_find_volume_ratio(point_eff_flow_v_head_speed_suc_1):
     suc_2 = State(p=Q_(0.2, "MPa"), T=301.58, fluid={"n2": 1 - 1e-15, "co2": 1e-15})
     point_converted_from_find_volume_ratio = Point.convert_from(


### PR DESCRIPTION
## Problem

Converting a performance map to a **dense, CO2-rich, near-critical suction condition**
(via `Impeller.convert_from` / `Point.convert_from(..., find="speed")`) frequently fails
with `ValueError: Could not calculate point`. On a real high-pressure CO2 dataset
(5 cases, P ≈ 100–123 bar, 36–83 % CO2 at 40 °C) **17 of 20** source→target conversions
failed this way. The failures partition cleanly by *target*: only conversions to the
least-dense, methane-rich case succeeded.

The failure originates in the volume-ratio solver
`Point._calc_from_eff_phi_psi_suc_volume_ratio`, and is actually **two distinct numerical
problems**:

### 1. Spurious `(rho, s)` flash root

The isentropic discharge is seeded with `State(rho=disch_rho, s=suc.s())`. For dense
fluids two states share that `(rho, s)`: the physical compression (`disch.p >= suc.p`) and
a spurious **cold, liquid-like root below suction pressure**. CoolProp's `DmassSmass` flash
can return the cold root (e.g. seeding the discharge at *91 bar / 8 °C* when suction is
104 bar / 40 °C, instead of the physical ~236 bar / 99 °C), and the phase hint does not
disambiguate it. The downstream efficiency solve, started from that non-physical state,
diverges.

### 2. Efficiency-match secant divergence

Even with the correct root, `scipy.optimize.newton` (secant) for the efficiency match can
diverge for dense fluids: its tiny initial step gives a near-zero efficiency slope and
overshoots to a non-physical state (`"Efficiency did not converge"`), then the pressure
fallback fails to converge as well.

## Fix

- **`isentropic_disch_from_rho(suc, disch_rho)`** — detects a non-compression flash root
  (`disch.p < suc.p` for `disch_rho > suc.rho`) and re-solves for the pressure on the
  suction isentrope that matches the target density (`brentq`; density is monotonic in
  pressure along an isentrope), selecting the physical compression root.

- **`disch_from_suc_rho_eff(suc, disch_rho, eff, eff_calc_func)`** — a robust bracketed
  efficiency solve: at fixed density the polytropic efficiency decreases monotonically with
  temperature from ~1.0 at the isentropic discharge through the target, so it is bracketed
  and solved with `brentq`. It is wired in **only as a fallback** after the existing secant
  attempts, so well-behaved conversions keep their exact previous numerical path and results.

## Validation

- On the dataset above, failures dropped from **17/20 → 1/20** (one residual near-critical
  edge case remains).
- New regression tests: `test_isentropic_disch_from_rho_dense_co2` (helper returns the
  physical compression root with the target density and suction entropy) and
  `test_converted_from_find_speed_dense_co2_target` (end-to-end conversion to a dense
  CO2-rich suction now succeeds with efficiency preserved).
- Existing conversion tests are unaffected by this change (the fallback paths only run for
  previously-failing dense points).

> Note: 5 pre-existing `test_converted_from_find_volume_ratio*` failures on `main` in my
> environment are unrelated to this change (they reproduce on a clean `main`, and this PR
> does not touch the `find="volume_ratio"` path).
