### PR TITLE
Add disch_p curve type to engauge/dict impeller loaders

### DIFF
--- a/ccp/impeller.py
+++ b/ccp/impeller.py
@@ -864,6 +864,7 @@ class Impeller:
         power_curves=None,
         power_shaft_curves=None,
         pressure_ratio_curves=None,
+        disch_p_curves=None,
         disch_T_curves=None,
         b=Q_(0.005, "m"),
         D=Q_(0.5, "m"),
@@ -874,10 +875,12 @@ class Impeller:
         flow_units_power=None,
         flow_units_power_shaft=None,
         flow_units_pressure_ratio=None,
+        flow_units_disch_p=None,
         flow_units_disch_T=None,
         head_units="J/kg",
         eff_units="dimensionless",
         pressure_ratio_units="dimensionless",
+        disch_p_units="Pa",
         disch_T_units="degK",
         power_units="W",
         power_shaft_units="W",
@@ -927,6 +930,9 @@ class Impeller:
         flow_units_pressure_ratio: str
             Flow units used  in the dict for pressure ratio curves.
             Only needed when flow units for efficiency curve differs from other curves.
+        flow_units_disch_p: str
+            Flow units used  in the dict for discharge pressure curves.
+            Only needed when flow units for discharge pressure curve differs from other curves.
         flow_units_disch_T: str
             Flow units used  in the dict for discharge Temperature curves.
             Only needed when flow units for efficiency curve differs from other curves.
@@ -943,6 +949,8 @@ class Impeller:
             Mechanical power losses units used in the dict.
         pressure_ratio_units : str
             Pressure ratio units used in the dict.
+        disch_p_units : str
+            Discharge pressure units used in the dict.
         disch_T_units : str
             Discharge temperature units used in the dict.
         speed_units : str
@@ -1218,6 +1226,7 @@ class Impeller:
         flow_units_power=None,
         flow_units_power_shaft=None,
         flow_units_pressure_ratio=None,
+        flow_units_disch_p=None,
         flow_units_disch_T=None,
         head_units="J/kg",
         eff_units="dimensionless",
@@ -1225,6 +1234,7 @@ class Impeller:
         power_shaft_units="W",
         power_losses_units="W",
         pressure_ratio_units="dimensionless",
+        disch_p_units="Pa",
         disch_T_units="degK",
         speed_units="RPM",
         **kwargs,
@@ -1305,6 +1315,7 @@ class Impeller:
             "power",
             "power_shaft",
             "pressure_ratio",
+            "disch_p",
             "disch_T",
         ]:
             param_path = curve_path / (curve_name + f"-{param}.csv")
@@ -1335,10 +1346,12 @@ class Impeller:
             flow_units_power=flow_units_power,
             flow_units_power_shaft=flow_units_power_shaft,
             flow_units_pressure_ratio=flow_units_pressure_ratio,
+            flow_units_disch_p=flow_units_disch_p,
             flow_units_disch_T=flow_units_disch_T,
             eff_units=eff_units,
             speed_units=speed_units,
             pressure_ratio_units=pressure_ratio_units,
+            disch_p_units=disch_p_units,
             disch_T_units=disch_T_units,
             **curves_path_dict,
         )


### PR DESCRIPTION
## Summary

PR #138's point solver can already build a `Point` from `suc` + `disch_p` + `disch_T` (via `_disch_from_disch_T_disch_p`), but the impeller loaders (`load_from_engauge_csv` / `load_from_dict`) only exposed `pressure_ratio` + `disch_T` as a curve pair. This wires up `disch_p` as a recognized curve so a map can be loaded **directly** from measured discharge-pressure and discharge-temperature curves, without first converting discharge pressure to a dimensionless ratio.

## Changes

- `load_from_dict`: new `disch_p_curves`, `flow_units_disch_p`, and `disch_p_units` (default `"Pa"`) arguments, mirroring the existing `pressure_ratio` plumbing. The generic point-building loop already maps any recognized curve param to its `Point` kwarg, so no further changes were needed there.
- `load_from_engauge_csv`: `disch_p` added to the scanned curve params, plus the matching `flow_units_disch_p` / `disch_p_units` pass-through.

With this, a case is loaded from `<curve_name>-disch_p.csv` and `<curve_name>-disch_T.csv`; the solver derives head and efficiency from the suction state and the two discharge curves.

## Usage

```python
imp = ccp.Impeller.load_from_engauge_csv(
    suc=suc,
    curve_name="case-a1",
    curve_path=path,
    flow_units="m³/h",
    disch_p_units="bar",
    disch_T_units="degC",
)
```

## Testing

- Existing engauge loader tests pass (`pytest ccp/tests/test_impeller.py -k "save_load or engauge"`).
- Exercised end-to-end on a real dataset (an export-compressor section digitized as discharge-pressure + discharge-temperature curves): 6 cases load correctly and `convert_from` runs across the full source→target matrix with head/eff derived from the discharge curves.

A dedicated `disch_p` fixture + expected-value test would be a good follow-up.