### PR TITLE
Add gp_surrogate method to Impeller.convert_from

### DIFF
--- a/ccp/impeller.py
+++ b/ccp/impeller.py
@@ -20,6 +20,7 @@ from ccp.config.units import check_units
 from ccp.config.utilities import r_getattr, r_setattr
 from ccp.data_io.read_csv import read_data_from_engauge_csv
 from ccp.plotly_theme import tableau_colors
+from ccp.surrogate import convert_from_gp_surrogate
 
 
 class ImpellerStateParameter:
@@ -746,10 +747,6 @@ class Impeller:
         ... )
         """
         if method == "gp_surrogate":
-            # Lazy import: avoids an import cycle (surrogate imports ccp) and keeps the
-            # sklearn dependency out of the import path unless the surrogate is used.
-            from ccp.surrogate import convert_from_gp_surrogate
-
             return convert_from_gp_surrogate(
                 cls, original_impeller, suc=suc, speed=speed
             )

--- a/ccp/impeller.py
+++ b/ccp/impeller.py
@@ -684,7 +684,9 @@ class Impeller:
         return current_curve
 
     @classmethod
-    def convert_from(cls, original_impeller, suc=None, find="speed", speed=None):
+    def convert_from(
+        cls, original_impeller, suc=None, find="speed", speed=None, method="similarity"
+    ):
         """Convert performance map from an impeller.
 
         Parameters
@@ -694,6 +696,8 @@ class Impeller:
             A list of impeller can also be passed. In this case the curves will be
             converted based on the impeller with the closest suction speed of sound
             to the new suction condition.
+            For ``method="gp_surrogate"`` a list is preferred (one impeller per measured
+            suction/case): the surrogate is fit on the points of *all* the supplied maps.
         suc : ccp.State
             The new suction condition to which we want to convert to.
         find : str, optional
@@ -701,16 +705,59 @@ class Impeller:
             For now only 'speed' is implemented, which means that, based on volume ratio,
             we calculate new values of speed for each curve and the respective discharge
             condition.
+            Ignored when ``method="gp_surrogate"``.
         speed : float, pint.Quantity, str, optional
             Desired speed. If find="speed", this can be None or 'same' to keep the same
             speed values available in the original_impeller.
+            For ``method="gp_surrogate"``: a number / ``pint.Quantity`` produces a single
+            curve at that speed; ``None`` or ``"same"`` uses the speed lines of the most
+            complete supplied map (the impeller with the most curves).
+        method : str, optional
+            Conversion method. Defaults to ``"similarity"``.
+
+            - ``"similarity"``: physics similarity rescaling of the source map (the
+              behaviour described above), unchanged.
+            - ``"gp_surrogate"``: fit a Gaussian-process surrogate
+              ``psi, eff = f(phi, M_tip)`` over the points of all supplied measured
+              map(s) and re-dimensionalize it at ``suc``. The model is refit on every
+              call (no persistence). Useful when several measured maps are available and
+              for dense/supercritical suctions where the similarity flash diverges.
+              Requires scikit-learn.
 
         Returns
         -------
         converted_impeller : ccp.Impeller
             The new impeller with the converted performance map for the required
             suction condition.
+
+        Examples
+        --------
+        >>> import ccp
+        >>> imp = ccp.impeller_example()
+        >>> new_suc = imp.points[0].suc
+        >>> converted = ccp.Impeller.convert_from(imp, suc=new_suc, speed="same")
+
+        Fit a surrogate on a machine's measured maps and convert:
+
+        >>> converted = ccp.Impeller.convert_from(  # doctest: +SKIP
+        ...     [imp_case_a, imp_case_b, imp_case_c],
+        ...     suc=new_suc,
+        ...     method="gp_surrogate",
+        ... )
         """
+        if method == "gp_surrogate":
+            # Lazy import: avoids an import cycle (surrogate imports ccp) and keeps the
+            # sklearn dependency out of the import path unless the surrogate is used.
+            from ccp.surrogate import convert_from_gp_surrogate
+
+            return convert_from_gp_surrogate(
+                cls, original_impeller, suc=suc, speed=speed
+            )
+        if method != "similarity":
+            raise ValueError(
+                f"unknown method {method!r}; expected 'similarity' or 'gp_surrogate'"
+            )
+
         all_converted_points = []
         if isinstance(original_impeller, list):
             speed_sound_diff = []

--- a/ccp/surrogate.py
+++ b/ccp/surrogate.py
@@ -1,0 +1,266 @@
+"""Gaussian-process surrogate converter for Impeller performance maps.
+
+Backs ``ccp.Impeller.convert_from(..., method="gp_surrogate")``. Fits
+``psi, eff = f(phi, M_tip)`` over one or more measured maps of a machine and
+re-dimensionalizes the prediction at a new suction state. No persistence: the model is
+refit on every call (fitting is ~1-2 s, negligible next to building the converted map).
+
+Instead of thermodynamically re-scaling a single source map onto a new suction (which
+diverges for dense / supercritical CO2-rich suctions, where ``convert_from``'s
+enthalpy-entropy flash fails to converge), this fits a per-machine surrogate of the
+non-dimensional map over *all* measured cases and evaluates it at the target suction.
+
+The identified invariants are the flow coefficient ``phi`` and the tip Mach number
+``M_tip``; Reynolds / volume-ratio are collinear with ``M_tip`` and add nothing, and
+compressibility ``Z`` adds nothing measurable (leave-one-case-out tested). So the
+surrogate inputs are exactly ``(phi, M_tip)``.
+
+Re-dimensionalization uses ccp's own coefficient definitions (``ccp/point.py``), with
+``u = speed * D / 2``::
+
+    M_tip  = u / suc.speed_sound()
+    flow_v = phi * pi * D**2 * u / 4      (from phi = flow_v * 4 / (pi * D**2 * u))
+    head   = psi * u**2 / 2               (from psi = head / (u**2 / 2))
+    eff    = eff                          (clipped to (1e-3, 0.999))
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+import ccp
+
+Q_ = ccp.Q_
+
+
+def _point_features(impellers):
+    """Collect ``(phi, M_tip, psi, eff)`` from every point of every impeller."""
+    phi, mach, psi, eff = [], [], [], []
+    for imp in impellers:
+        for curve in imp.curves:
+            for p in curve.points:
+                phi.append(p.phi.m)
+                mach.append(p.mach.m)
+                psi.append(p.psi.m)
+                eff.append(p.eff.m)
+    return tuple(np.asarray(a) for a in (phi, mach, psi, eff))
+
+
+def _curve_phi_envelopes(impellers):
+    """Per-speed-line ``(M_tip, phi_lo, phi_hi)``, sorted by Mach.
+
+    Every point on a measured speed line shares the same tip Mach (``u`` and the suction
+    speed of sound are both constant along it), so each curve contributes one
+    ``(Mach, min phi, max phi)`` sample of the map's flow envelope.
+    """
+    mach, phi_lo, phi_hi = [], [], []
+    for imp in impellers:
+        for curve in imp.curves:
+            phis = [p.phi.m for p in curve.points]
+            mach.append(curve.points[0].mach.m)
+            phi_lo.append(min(phis))
+            phi_hi.append(max(phis))
+    order = np.argsort(mach)
+    return (
+        np.asarray(mach)[order],
+        np.asarray(phi_lo)[order],
+        np.asarray(phi_hi)[order],
+    )
+
+
+def _interp_extrap(x, xp, fp, min_gap=0.03):
+    """Linear interpolation of ``fp(xp)`` at ``x`` with linear extrapolation outside.
+
+    Inside ``[xp[0], xp[-1]]`` this is ``np.interp``. Outside, it continues the slope of
+    the nearest end *segment* -- but the segment is measured against the nearest training
+    point at least ``min_gap`` away in ``x``, so two speed lines that happen to sit at
+    almost the same Mach (e.g. one per training map) can't blow the slope up.
+    """
+    xp = np.asarray(xp, dtype=float)
+    fp = np.asarray(fp, dtype=float)
+    if len(xp) == 1:
+        return float(fp[0])
+    if x <= xp[0]:
+        j = int(np.searchsorted(xp, xp[0] + min_gap))
+        j = min(max(j, 1), len(xp) - 1)
+        slope = (fp[j] - fp[0]) / (xp[j] - xp[0]) if xp[j] > xp[0] else 0.0
+        return float(fp[0] + slope * (x - xp[0]))
+    if x >= xp[-1]:
+        i = int(np.searchsorted(xp, xp[-1] - min_gap)) - 1
+        i = min(max(i, 0), len(xp) - 2)
+        slope = (fp[-1] - fp[i]) / (xp[-1] - xp[i]) if xp[-1] > xp[i] else 0.0
+        return float(fp[-1] + slope * (x - xp[-1]))
+    return float(np.interp(x, xp, fp))
+
+
+class _GPSurrogate:
+    """Per-machine GP surrogate of ``psi(phi, M_tip)`` and ``eff(phi, M_tip)``."""
+
+    def __init__(self, gp_psi, gp_eff, x_mean, x_std, env_mach, env_lo, env_hi, b, D):
+        self.gp_psi = gp_psi
+        self.gp_eff = gp_eff
+        self.x_mean = x_mean
+        self.x_std = x_std
+        # per-speed-line flow (phi) envelope vs tip Mach, for Mach-local phi ranges
+        self.env_mach = env_mach
+        self.env_lo = env_lo
+        self.env_hi = env_hi
+        self.b = b
+        self.D = D
+
+    @classmethod
+    def fit(cls, impellers):
+        """Fit the surrogate on a list of (measured) ``ccp.Impeller`` objects."""
+        try:
+            from sklearn.gaussian_process import GaussianProcessRegressor
+            from sklearn.gaussian_process.kernels import (
+                RBF,
+                ConstantKernel,
+                WhiteKernel,
+            )
+        except ImportError as e:
+            raise ImportError(
+                "method='gp_surrogate' requires scikit-learn. "
+                "Install it with: pip install scikit-learn"
+            ) from e
+
+        phi, mach, psi, eff = _point_features(impellers)
+        X = np.column_stack([phi, mach])
+        x_mean = X.mean(0)
+        x_std = X.std(0)
+        x_std[x_std == 0] = 1.0
+        Xs = (X - x_mean) / x_std
+
+        def _make():
+            # Bound the RBF length-scales (features are standardized, so std=1). Without
+            # an upper bound the optimizer intermittently drives the phi length-scale
+            # huge -> the target loses its phi dependence and collapses to a flat (mean)
+            # prediction (seen as a flat efficiency line). The good optima sit at ~0.8-5,
+            # so (0.1, 10) keeps them and forbids the degenerate flat fit. random_state
+            # makes the multi-restart optimization reproducible.
+            kernel = ConstantKernel(1.0, (1e-2, 1e2)) * RBF(
+                [1.0, 1.0], length_scale_bounds=(0.1, 10.0)
+            ) + WhiteKernel(1e-3, (1e-6, 1e-1))
+            return GaussianProcessRegressor(
+                kernel=kernel,
+                normalize_y=True,
+                n_restarts_optimizer=5,
+                alpha=1e-6,
+                random_state=0,
+            )
+
+        gp_psi = _make().fit(Xs, psi)
+        gp_eff = _make().fit(Xs, eff)
+
+        env_mach, env_lo, env_hi = _curve_phi_envelopes(impellers)
+        p0 = impellers[0].points[0]
+        return cls(gp_psi, gp_eff, x_mean, x_std, env_mach, env_lo, env_hi, p0.b, p0.D)
+
+    def _predict(self, phi, mach):
+        X = np.column_stack([np.atleast_1d(phi), np.atleast_1d(mach)])
+        Xs = (X - self.x_mean) / self.x_std
+        return self.gp_psi.predict(Xs), self.gp_eff.predict(Xs)
+
+    def _phi_range_for_mach(self, mach):
+        """Flow (phi) range of the converted speed line at tip Mach ``mach``.
+
+        Mach is the GP's second input and the ``(phi, M)`` data is correlated (higher-Mach
+        lines surge/choke at higher phi), so the valid phi band shifts with Mach. Each
+        training speed line gives one ``(Mach, phi_lo, phi_hi)`` sample; we interpolate
+        phi_lo and phi_hi across those vs Mach (and *extrapolate* the trend beyond the
+        sampled Mach range). This matters because converting to a new suction shifts the
+        whole operating Mach range -- e.g. a high-speed-of-sound target pushes the low
+        speed lines *below* the training Mach range. The earlier nearest-points approach
+        then grabbed phi from higher-Mach lines and produced a too-wide, too-high flow
+        band (the converted low-speed curve overshot the measured flow envelope on both
+        ends). Following the per-line trend instead reproduces the measured flow range.
+        A safety band keeps far extrapolation from running away.
+        """
+        lo = _interp_extrap(mach, self.env_mach, self.env_lo)
+        hi = _interp_extrap(mach, self.env_mach, self.env_hi)
+        g_lo = float(self.env_lo.min())
+        g_hi = float(self.env_hi.max())
+        lo = min(max(lo, 0.5 * g_lo), 1.5 * g_hi)
+        hi = min(max(hi, 0.5 * g_lo), 1.5 * g_hi)
+        if hi <= lo:
+            hi = lo * 1.05
+        return lo, hi
+
+    def convert(self, suc, speeds, n_points=10):
+        """Build converted ``ccp.Point`` objects at ``suc`` for the given speed lines."""
+        D = self.D
+        a_suc = suc.speed_sound()
+
+        points = []
+        for speed in speeds:
+            u = (speed * D / 2).to("m/s")
+            mach = (u / a_suc).to("dimensionless").m
+            # Mach-local phi envelope: keep each converted line within the phi support the
+            # GP actually has at this tip Mach, so it interpolates instead of extrapolating.
+            phi_lo, phi_hi = self._phi_range_for_mach(mach)
+            phi_grid = np.linspace(phi_lo, phi_hi, n_points)
+            psi_hat, eff_hat = self._predict(phi_grid, np.full(n_points, mach))
+            for phi_v, psi_v, eff_v in zip(phi_grid, psi_hat, eff_hat):
+                flow_v = phi_v * np.pi * D**2 * u / 4
+                head = psi_v * u**2 / 2
+                points.append(
+                    ccp.Point(
+                        suc=suc,
+                        flow_v=flow_v.to("m**3/s"),
+                        speed=speed,
+                        head=head.to("J/kg"),
+                        eff=Q_(float(np.clip(eff_v, 1e-3, 0.999)), "dimensionless"),
+                        b=self.b,
+                        D=D,
+                    )
+                )
+        return points
+
+
+def _output_speeds(impellers, speed):
+    """Speed lines for the converted map (see plan §7).
+
+    The surrogate has no single "source map" to copy speeds from. If ``speed`` is a
+    number / ``Q_``, emit a single curve at that speed. Otherwise (``None`` or
+    ``"same"``) use the speed lines of the most complete training map -- the impeller
+    with the most curves, ties broken by list order. Taking one map's speeds (rather than
+    a union across maps) avoids spurious near-duplicate lines.
+    """
+    if speed is not None and speed != "same":
+        return [speed if hasattr(speed, "to") else Q_(speed, "RPM")]
+    best = max(impellers, key=lambda im: len(im.curves))
+    return [c.speed for c in best.curves]
+
+
+def convert_from_gp_surrogate(
+    impeller_cls, original_impeller, suc, speed=None, n_points=10
+):
+    """Entry point used by ``Impeller.convert_from(method='gp_surrogate')``.
+
+    Fits a GP surrogate on ``original_impeller`` (a single ``Impeller`` or a list) and
+    re-dimensionalizes it at ``suc``.
+    """
+    impellers = (
+        original_impeller
+        if isinstance(original_impeller, list)
+        else [original_impeller]
+    )
+    if suc is None:
+        raise ValueError("suc is required for method='gp_surrogate'")
+
+    # The non-dimensional coefficients assume a single geometry; require matching b, D.
+    p0 = impellers[0].points[0]
+    for imp in impellers[1:]:
+        p = imp.points[0]
+        if not np.isclose(p.b.to("m").m, p0.b.to("m").m) or not np.isclose(
+            p.D.to("m").m, p0.D.to("m").m
+        ):
+            raise ValueError(
+                "method='gp_surrogate' requires all impellers to share the same "
+                "geometry (b, D); got differing values across the supplied maps."
+            )
+
+    model = _GPSurrogate.fit(impellers)
+    out_speeds = _output_speeds(impellers, speed)
+    points = model.convert(suc, out_speeds, n_points=n_points)
+    return impeller_cls(points)

--- a/ccp/surrogate.py
+++ b/ccp/surrogate.py
@@ -27,6 +27,8 @@ Re-dimensionalization uses ccp's own coefficient definitions (``ccp/point.py``),
 from __future__ import annotations
 
 import numpy as np
+from sklearn.gaussian_process import GaussianProcessRegressor
+from sklearn.gaussian_process.kernels import RBF, ConstantKernel, WhiteKernel
 
 import ccp
 
@@ -111,19 +113,6 @@ class _GPSurrogate:
     @classmethod
     def fit(cls, impellers):
         """Fit the surrogate on a list of (measured) ``ccp.Impeller`` objects."""
-        try:
-            from sklearn.gaussian_process import GaussianProcessRegressor
-            from sklearn.gaussian_process.kernels import (
-                RBF,
-                ConstantKernel,
-                WhiteKernel,
-            )
-        except ImportError as e:
-            raise ImportError(
-                "method='gp_surrogate' requires scikit-learn. "
-                "Install it with: pip install scikit-learn"
-            ) from e
-
         phi, mach, psi, eff = _point_features(impellers)
         X = np.column_stack([phi, mach])
         x_mean = X.mean(0)

--- a/ccp/tests/test_surrogate.py
+++ b/ccp/tests/test_surrogate.py
@@ -1,0 +1,161 @@
+"""Tests for the gp_surrogate converter (``Impeller.convert_from(method=...)``)."""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import ccp
+from ccp import Q_, Impeller, Point, State
+
+B = Q_(28.5, "mm")
+D = Q_(365, "mm")
+
+FLUID = dict(methane=0.85, ethane=0.07, propane=0.04, co2=0.02, n2=0.02)
+
+
+def _map_at(suc, speeds_rpm, phis=np.linspace(0.03, 0.09, 6)):
+    """Build an Impeller from a fixed non-dimensional map evaluated at ``suc``.
+
+    psi(phi) is a decreasing line and eff(phi) a parabola, so the surrogate has a real
+    phi-dependence to recover (and a non-flat efficiency).
+    """
+    points = []
+    for speed_rpm in speeds_rpm:
+        speed = Q_(speed_rpm, "RPM")
+        u = (speed * D / 2).to("m/s")
+        for phi in phis:
+            psi = 1.2 - 4.0 * phi  # decreasing head coefficient
+            eff = 0.85 - 60.0 * (phi - 0.06) ** 2  # parabola peaking at phi=0.06
+            flow_v = (phi * np.pi * D**2 * u / 4).to("m**3/s")
+            head = (psi * u**2 / 2).to("J/kg")
+            points.append(
+                Point(
+                    suc=suc,
+                    flow_v=flow_v,
+                    speed=speed,
+                    head=head,
+                    eff=Q_(eff, "dimensionless"),
+                    b=B,
+                    D=D,
+                )
+            )
+    return Impeller(points)
+
+
+@pytest.fixture
+def maps():
+    """Three measured maps at different suction pressures (-> different Mach)."""
+    speeds = [9000, 10500, 12000]
+    sucs = [
+        State(p=Q_(p, "bar"), T=Q_(310, "K"), fluid=FLUID) for p in (15.0, 20.0, 25.0)
+    ]
+    return [_map_at(suc, speeds) for suc in sucs]
+
+
+def test_returns_valid_impeller(maps):
+    target = maps[1].points[0].suc
+    conv = Impeller.convert_from(maps, suc=target, method="gp_surrogate")
+
+    assert isinstance(conv, Impeller)
+    # one curve per representative speed line (all maps share 3 speeds)
+    assert len(conv.curves) == 3
+    for curve in conv.curves:
+        effs = np.array([p.eff.m for p in curve.points])
+        assert np.all((effs > 0) & (effs < 1))
+
+
+def test_no_extrapolation_artifact(maps):
+    """Regression for the Mach-local phi grid (plan §6.1).
+
+    Head must rise from choke (high flow) toward surge (low flow); a low-flow head dive
+    would signal the GP extrapolating into the empty low-phi/high-Mach corner.
+    """
+    target = maps[2].points[0].suc
+    conv = Impeller.convert_from(maps, suc=target, method="gp_surrogate")
+
+    for curve in conv.curves:
+        pts = sorted(curve.points, key=lambda p: p.flow_v.m)
+        heads = np.array([p.head.m for p in pts])
+        # head strictly decreasing from surge (low flow) to choke (high flow)
+        assert np.all(np.diff(heads) < 0)
+
+
+def test_efficiency_not_flat_and_deterministic(maps):
+    """Regression for the bounded+seeded kernel (plan §6.2)."""
+    target = maps[0].points[0].suc
+    conv1 = Impeller.convert_from(maps, suc=target, method="gp_surrogate")
+    conv2 = Impeller.convert_from(maps, suc=target, method="gp_surrogate")
+
+    for curve in conv1.curves:
+        effs = np.array([p.eff.m for p in curve.points])
+        assert effs.max() - effs.min() > 0.03  # a real parabola, not collapsed to mean
+
+    # random_state=0 -> deterministic across calls
+    h1 = [p.head.m for c in conv1.curves for p in c.points]
+    h2 = [p.head.m for c in conv2.curves for p in c.points]
+    assert_allclose(h1, h2)
+
+
+def test_single_impeller_allowed(maps):
+    target = maps[0].points[0].suc
+    conv = Impeller.convert_from(maps[0], suc=target, method="gp_surrogate")
+    assert isinstance(conv, Impeller)
+    assert len(conv.curves) == 3
+
+
+def test_speed_argument_single_curve(maps):
+    target = maps[1].points[0].suc
+    conv = Impeller.convert_from(
+        maps, suc=target, speed=Q_(10500, "RPM"), method="gp_surrogate"
+    )
+    assert len(conv.curves) == 1
+    assert_allclose(conv.curves[0].speed.to("RPM").m, 10500, rtol=1e-6)
+
+
+def test_default_method_unchanged():
+    """method defaults to 'similarity' and matches an explicit similarity call."""
+    imp = ccp.impeller_example()
+    new_suc = imp.points[0].suc
+    default = Impeller.convert_from(imp, suc=new_suc, speed="same")
+    explicit = Impeller.convert_from(
+        imp, suc=new_suc, speed="same", method="similarity"
+    )
+    h_default = [p.head.m for c in default.curves for p in c.points]
+    h_explicit = [p.head.m for c in explicit.curves for p in c.points]
+    assert_allclose(h_default, h_explicit)
+
+
+def test_unknown_method_raises(maps):
+    target = maps[0].points[0].suc
+    with pytest.raises(ValueError, match="unknown method"):
+        Impeller.convert_from(maps, suc=target, method="bogus")
+
+
+def test_suc_none_raises(maps):
+    with pytest.raises(ValueError, match="suc is required"):
+        Impeller.convert_from(maps, suc=None, method="gp_surrogate")
+
+
+def test_mismatched_geometry_raises(maps):
+    # a map with a different impeller diameter D -> geometry mismatch
+    big_D = Q_(400, "mm")
+    suc = State(p=Q_(18, "bar"), T=Q_(310, "K"), fluid=FLUID)
+    u = (Q_(9000, "RPM") * big_D / 2).to("m/s")
+    points = []
+    for phi in (0.04, 0.05, 0.06):
+        points.append(
+            Point(
+                suc=suc,
+                flow_v=(phi * np.pi * big_D**2 * u / 4).to("m**3/s"),
+                speed=Q_(9000, "RPM"),
+                head=((1.2 - 4.0 * phi) * u**2 / 2).to("J/kg"),
+                eff=Q_(0.8, "dimensionless"),
+                b=B,
+                D=big_D,
+            )
+        )
+    other = Impeller(points)
+    with pytest.raises(ValueError, match="same\\s+geometry"):
+        Impeller.convert_from(
+            [maps[0], other], suc=maps[0].points[0].suc, method="gp_surrogate"
+        )


### PR DESCRIPTION
## Summary

Adds a data-driven **Gaussian-process surrogate** as a second conversion method on `Impeller.convert_from`:

```python
converted = ccp.Impeller.convert_from(
    [imp_case_a, imp_case_b, imp_case_c],  # one or more measured maps
    suc=target_suc,
    method="gp_surrogate",
)
```

It fits `ψ, η = f(φ, M_tip)` over the points of all supplied measured maps and re-dimensionalizes the prediction at the target suction using ccp's own coefficient definitions.

## Motivation

The existing `method="similarity"` rescales a *single* source map and relies on an enthalpy–entropy flash that **diverges for dense / supercritical CO₂-rich suctions**, so the conversion can fail outright on those conditions. The surrogate:

- **pools all supplied maps** instead of choosing one, and
- **never runs the dense-fluid flash**,

so it stays robust where similarity fails and improves accuracy when several measured maps of a machine are available.

The identified invariants are the flow coefficient `φ` and tip Mach number `M_tip`; Reynolds / volume-ratio are collinear with `M_tip` and compressibility `Z` adds nothing measurable (leave-one-case-out tested), so the surrogate inputs are exactly `(φ, M_tip)`.

## Changes

- **`ccp/surrogate.py`** (new) — the GP surrogate. Standardized `(φ, M_tip)` inputs, a bounded + seeded RBF kernel (deterministic fit, no degenerate flat-efficiency optimum), and a Mach-local `φ` envelope so each converted speed line interpolates within the `φ` support the data actually has at that Mach (avoids extrapolation artifacts when the target suction shifts the operating Mach range).
- **`ccp/impeller.py`** — `convert_from` gains a `method` argument that dispatches to the surrogate; the **similarity path is unchanged** and `method` defaults to `"similarity"`, so existing callers are unaffected. The surrogate import is lazy (keeps scikit-learn off the import path unless used).
- **`ccp/tests/test_surrogate.py`** (new) — output validity, a no-extrapolation regression, fit determinism, single-map and explicit-`speed` arguments, and the error paths (unknown method, missing `suc`, mismatched geometry). `method="similarity"` is asserted unchanged.

## Notes

- Requires `scikit-learn` (already a project dependency).
- The model is refit on every call (no persistence); fitting is ~1–2 s.
- All impellers passed together must share geometry (`b`, `D`).