### PR TITLE
Save class objects in json and toml

### DIFF
--- a/ccp/curve.py
+++ b/ccp/curve.py
@@ -2,6 +2,7 @@ import csv
 
 import numpy as np
 import toml
+import json
 from scipy.interpolate import interp1d
 import plotly.graph_objects as go
 import pandas as pd
@@ -451,11 +452,16 @@ class Curve:
         file_name: str
             Name of the file.
         file_type: str
-            File type can be: toml.
+            File type can be: toml or json.
         """
-        if file_type == "toml":
-            with open(file_name, mode="w") as f:
-                toml.dump(self._dict_to_save(), f)
+        file_path = ".".join([file_name, file_type])
+        with open(file_path, mode="w") as f:
+            # add points to file
+            dict_to_save = self._dict_to_save()
+            if file_type == "toml":
+                toml.dump(dict_to_save, f)
+            elif file_type == "json":
+                json.dump(dict_to_save, f)
 
     def save_hysys_csv(self, curve_path):
         """Save curve to a csv with hysys format.
@@ -480,7 +486,10 @@ class Curve:
     @classmethod
     def load(cls, file_name):
         with open(file_name) as f:
-            parameters = toml.load(f)
+            if "toml" in file_name:
+                parameters = toml.load(f)
+            if "json" in file_name:
+                parameters = json.load(f)
 
         return cls(
             [Point(**Point._dict_from_load(kwargs)) for kwargs in parameters.values()]

--- a/ccp/curve.py
+++ b/ccp/curve.py
@@ -454,7 +454,17 @@ class Curve:
         file_type: str
             File type can be: toml or json.
         """
-        file_path = ".".join([file_name, file_type])
+        try:
+            if file_type not in file_name.suffix:
+                file_path = ".".join([file_name, file_type])
+            else:
+                file_path = file_name
+        except (TypeError, AttributeError):
+            if file_type not in file_name:
+                file_path = ".".join([file_name, file_type])
+            else:
+                file_path = file_name
+        
         with open(file_path, mode="w") as f:
             # add points to file
             dict_to_save = self._dict_to_save()
@@ -486,10 +496,16 @@ class Curve:
     @classmethod
     def load(cls, file_name):
         with open(file_name) as f:
-            if "toml" in file_name:
-                parameters = toml.load(f)
-            if "json" in file_name:
-                parameters = json.load(f)
+            try:
+                if "toml" in file_name.suffix:
+                    parameters = toml.load(f)
+                if "json" in file_name.suffix:
+                    parameters = json.load(f)
+            except (TypeError, AttributeError):
+                if "toml" in file_name:
+                    parameters = toml.load(f)
+                if "json" in file_name:
+                    parameters = json.load(f)
 
         return cls(
             [Point(**Point._dict_from_load(kwargs)) for kwargs in parameters.values()]

--- a/ccp/impeller.py
+++ b/ccp/impeller.py
@@ -1354,7 +1354,17 @@ class Impeller:
         file_type: str
             File type can be: toml or json.
         """
-        file_path = ".".join([file_name, file_type])
+        try:
+            if file_type not in file_name.suffix:
+                file_path = ".".join([file_name, file_type])
+            else:
+                file_path = file_name
+        except (TypeError, AttributeError):
+            if file_type not in file_name:
+                file_path = ".".join([file_name, file_type])
+            else:
+                file_path = file_name
+
         with open(file_path, mode="w") as f:
             # add points to file
             dict_to_save = self._dict_to_save()
@@ -1384,10 +1394,16 @@ class Impeller:
             Impeller object.
         """
         with open(file_name) as f:
-            if "toml" in file_name:
-                parameters = toml.load(f)
-            if "json" in file_name:
-                parameters = json.load(f)
+            try:
+                if "toml" in file_name.suffix:
+                    parameters = toml.load(f)
+                if "json" in file_name.suffix:
+                    parameters = json.load(f)
+            except (TypeError, AttributeError):
+                if "toml" in file_name:
+                    parameters = toml.load(f)
+                if "json" in file_name:
+                    parameters = json.load(f)
         points = [
             Point(**Point._dict_from_load(kwargs)) for kwargs in parameters.values()
         ]

--- a/ccp/impeller.py
+++ b/ccp/impeller.py
@@ -5,6 +5,7 @@ import multiprocessing
 import warnings
 
 import toml
+import json
 from copy import deepcopy
 from itertools import groupby
 from pathlib import Path
@@ -1343,19 +1344,24 @@ class Impeller:
             **curves_path_dict,
         )
 
-    def save(self, file):
-        """Save impeller to a toml file.
+    def save(self, file_name, file_type="toml"):
+        """Save impeller to a toml or json file.
 
         Parameters
         ----------
-        file : str or pathlib.Path
+        file_name : str or pathlib.Path
             Filename to which the data is saved.
+        file_type: str
+            File type can be: toml or json.
         """
-
-        with open(file, mode="w") as f:
+        file_path = ".".join([file_name, file_type])
+        with open(file_path, mode="w") as f:
             # add points to file
             dict_to_save = self._dict_to_save()
-            toml.dump(dict_to_save, f)
+            if file_type == "toml":
+                toml.dump(dict_to_save, f)
+            elif file_type == "json":
+                json.dump(dict_to_save, f)
 
     def _dict_to_save(self):
         dict_to_save = {
@@ -1364,8 +1370,8 @@ class Impeller:
         return dict_to_save
 
     @classmethod
-    def load(cls, file):
-        """Load impeller from toml file.
+    def load(cls, file_name):
+        """Load impeller from toml or json file.
 
         Parameters
         ----------
@@ -1377,7 +1383,11 @@ class Impeller:
         impeller : ccp.Impeller
             Impeller object.
         """
-        parameters = toml.load(file)
+        with open(file_name) as f:
+            if "toml" in file_name:
+                parameters = toml.load(f)
+            if "json" in file_name:
+                parameters = json.load(f)
         points = [
             Point(**Point._dict_from_load(kwargs)) for kwargs in parameters.values()
         ]

--- a/ccp/point.py
+++ b/ccp/point.py
@@ -1016,7 +1016,17 @@ class Point:
         file_type: str
             File type can be: toml or json.
         """
-        file_path = ".".join([file_name, file_type])
+        try:
+            if file_type not in file_name.suffix:
+                file_path = ".".join([file_name, file_type])
+            else:
+                file_path = file_name
+        except (TypeError, AttributeError):
+            if file_type not in file_name:
+                file_path = ".".join([file_name, file_type])
+            else:
+                file_path = file_name
+
         with open(file_path, mode="w") as f:
             if file_type == "toml":
                 toml.dump(self._dict_to_save(), f)
@@ -1027,10 +1037,16 @@ class Point:
     def load(cls, file_name):
         """Load point from toml or json file."""
         with open(file_name) as f:
-            if "toml" in file_name:
-                parameters = toml.load(f)
-            if "json" in file_name:
-                parameters = json.load(f)
+            try:
+                if "toml" in file_name.suffix:
+                    parameters = toml.load(f)
+                if "json" in file_name.suffix:
+                    parameters = json.load(f)
+            except (TypeError, AttributeError):
+                if "toml" in file_name:
+                    parameters = toml.load(f)
+                if "json" in file_name:
+                    parameters = json.load(f)
 
         return cls(**cls._dict_from_load(parameters))
 

--- a/ccp/point.py
+++ b/ccp/point.py
@@ -1,3 +1,4 @@
+import json
 from copy import copy
 
 import numpy as np
@@ -1005,16 +1006,23 @@ class Point:
             **{k: Q_(v) for k, v in dict_parameters.items()},
         )
 
-    def save(self, file_name):
-        """Save point to toml file."""
-        with open(file_name, mode="w") as f:
-            toml.dump(self._dict_to_save(), f)
+    def save(self, file_name, file_type="toml"):
+        """Save point to toml or json file."""
+        file_path = ".".join([file_name, file_type])
+        with open(file_path, mode="w") as f:
+            if file_type == "toml":
+                toml.dump(self._dict_to_save(), f)
+            elif file_type == "json":
+                json.dump(self._dict_to_save(), f)
 
     @classmethod
     def load(cls, file_name):
-        """Load point from toml file."""
+        """Load point from toml or json file."""
         with open(file_name) as f:
-            parameters = toml.load(f)
+            if "toml" in file_name:
+                parameters = toml.load(f)
+            if "json" in file_name:
+                parameters = json.load(f)
 
         return cls(**cls._dict_from_load(parameters))
 

--- a/ccp/point.py
+++ b/ccp/point.py
@@ -1007,7 +1007,15 @@ class Point:
         )
 
     def save(self, file_name, file_type="toml"):
-        """Save point to toml or json file."""
+        """Save point to a toml or json file.
+
+        Parameters
+        ----------
+        file_name : str or pathlib.Path
+            Filename to which the data is saved.
+        file_type: str
+            File type can be: toml or json.
+        """
         file_path = ".".join([file_name, file_type])
         with open(file_path, mode="w") as f:
             if file_type == "toml":


### PR DESCRIPTION
Now, the user can save `ccp` class objects (`Point`, `Curve` and `Impeller`) into `json` or `toml` file.