### PR TITLE
Speed up test suite: slow marker, xdist, shared fixtures, config isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,12 @@ This project uses **uv** for package and environment management.
 
 ### Testing
 ```bash
-uv run pytest                    # Run all tests with doctest modules
-uv run pytest ccp/tests/         # Run unit tests only
+uv run pytest -m "not slow" -n auto --dist loadfile   # fast tier (~40 s) - use during development
+uv run pytest ccp/tests -n 4 --dist loadfile          # full suite in parallel (~7 min) - run before opening a PR
+uv run pytest                                         # full suite, serial (~25 min; includes doctests)
 ```
+
+The heavy integration modules (`test_app.py`, `test_compressor.py`, `test_evaluation.py`, `test_impeller.py`) are auto-marked `slow` in `ccp/tests/conftest.py` — they run full compressor conversions. Use the fast tier while iterating and run the full suite at the end of a feature. `--dist loadfile` keeps each test file in a single xdist worker, which preserves within-file ordering and gives per-file process isolation. Use `-n 4` (not `-n auto`) for the full suite: the slow files spawn their own multiprocessing pools, and 16 workers exhaust memory on a 16 GB machine.
 
 ### Development Setup
 ```bash

--- a/ccp/tests/conftest.py
+++ b/ccp/tests/conftest.py
@@ -1,0 +1,36 @@
+import pytest
+
+import ccp
+
+# Modules dominated by full compressor calculations (Impeller.convert_from,
+# Evaluation, Streamlit AppTest) where single tests take minutes. They are
+# auto-marked as "slow" so the development loop can skip them with:
+#   uv run pytest ccp/tests -m "not slow"
+SLOW_TEST_FILES = (
+    "test_app.py",
+    "test_compressor.py",
+    "test_evaluation.py",
+    "test_impeller.py",
+)
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if item.path.name in SLOW_TEST_FILES:
+            item.add_marker(pytest.mark.slow)
+
+
+@pytest.fixture(autouse=True)
+def restore_global_config():
+    """Restore global ccp.config settings after each test.
+
+    Some tests set ccp.config.EOS or ccp.config.POLYTROPIC_METHOD; without a
+    reset that leaks into every test that runs afterwards in the same process
+    and shifts their results (e.g. the historical test_impeller failures when
+    run in the same process as test_point).
+    """
+    eos = ccp.config.EOS
+    polytropic_method = ccp.config.POLYTROPIC_METHOD
+    yield
+    ccp.config.EOS = eos
+    ccp.config.POLYTROPIC_METHOD = polytropic_method

--- a/ccp/tests/test_compressor.py
+++ b/ccp/tests/test_compressor.py
@@ -103,7 +103,7 @@ def test_point1sec_no_leakage():
     assert_allclose(p.suc.fluid["CO2"], 0.80218)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def straight_through():
     """P77 main b - spare"""
     fluid_sp = {
@@ -496,7 +496,7 @@ def test_point2sec_no_leakages():
     assert_allclose(p.suc.fluid["CO2"], 1.0)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def back_to_back():
     fluid_sp = {
         "methane": 73.66,
@@ -989,8 +989,14 @@ def test_back_to_back(back_to_back):
     assert_allclose(p0f_sp.power, 3707235.148908142, 1e-4)
 
 
-def test_back_to_back_with_reynolds_correction(back_to_back):
-    back_to_back = BackToBack(**back_to_back, reynolds_correction="ptc1997")
+@pytest.fixture(scope="module")
+def back_to_back_ptc1997(back_to_back):
+    """Constructed once and shared by tests that only read from it."""
+    return BackToBack(**back_to_back, reynolds_correction="ptc1997")
+
+
+def test_back_to_back_with_reynolds_correction(back_to_back_ptc1997):
+    back_to_back = back_to_back_ptc1997
     # check flows for first point sec1
     p0f = back_to_back.points_flange_t_sec1[0]
     assert_allclose(p0f.end_seal_flow_m, Q_(386.62, "kg/h").to("kg/s"), rtol=1e-5)
@@ -1112,9 +1118,8 @@ def test_back_to_back_with_reynolds_correction(back_to_back):
     assert_allclose(p0r.power, 3344111.790281333, 1e-4)
 
 
-def test_back_to_back_calculate_speed(back_to_back):
-    back_to_back = BackToBack(**back_to_back, reynolds_correction="ptc1997")
-    back_to_back = back_to_back.calculate_speed_to_match_discharge_pressure()
+def test_back_to_back_calculate_speed(back_to_back_ptc1997):
+    back_to_back = back_to_back_ptc1997.calculate_speed_to_match_discharge_pressure()
     point_sp = back_to_back.point_sec2(
         speed=back_to_back.speed_operational,
         flow_m=back_to_back.guarantee_point_sec2.flow_m,
@@ -1122,8 +1127,8 @@ def test_back_to_back_calculate_speed(back_to_back):
     assert_allclose(point_sp.disch.p(), back_to_back.guarantee_point_sec2.disch.p())
 
 
-def test_save_and_load(back_to_back):
-    back_to_back = BackToBack(**back_to_back, reynolds_correction="ptc1997")
+def test_save_and_load(back_to_back_ptc1997):
+    back_to_back = back_to_back_ptc1997
 
     file = Path(tempdir) / "back_to_back.toml"
     back_to_back.save(file)
@@ -1133,7 +1138,7 @@ def test_save_and_load(back_to_back):
     assert back_to_back == back_to_back_loaded
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def back_to_back_no_leakage():
     fluid_sp = {
         "methane": 73.66,

--- a/ccp/tests/test_evaluation.py
+++ b/ccp/tests/test_evaluation.py
@@ -1,69 +1,115 @@
-import pandas as pd
-import ccp
-from numpy.testing import assert_allclose
-from tempfile import tempdir
 from pathlib import Path
+from tempfile import tempdir
+
+import pandas as pd
+import pytest
+from numpy.testing import assert_allclose
+
+import ccp
 
 Q_ = ccp.Q_
 
+data_path = Path(ccp.__file__).parent / "tests/data"
 
-def test_evaluation():
-    data_path = Path(ccp.__file__).parent / "tests/data"
-    # load data.parquet
-    df = pd.read_parquet(data_path / "data.parquet")
-    # load lp-sec1-caso-a
-    fluid_a = {
-        "methane": 58.976,
-        "ethane": 3.099,
-        "propane": 0.6,
-        "n-butane": 0.08,
-        "i-butane": 0.05,
-        "n-pentane": 0.01,
-        "i-pentane": 0.01,
-        "n2": 0.55,
-        "h2s": 0.02,
-        "co2": 36.605,
-    }
-    suc_a = ccp.State(
-        p=Q_(4, "bar"),
-        T=Q_(40, "degC"),
-        fluid=fluid_a,
-    )
+# lp-sec1-caso-a design fluid
+fluid_a = {
+    "methane": 58.976,
+    "ethane": 3.099,
+    "propane": 0.6,
+    "n-butane": 0.08,
+    "i-butane": 0.05,
+    "n-pentane": 0.01,
+    "i-pentane": 0.01,
+    "n2": 0.55,
+    "h2s": 0.02,
+    "co2": 36.605,
+}
 
-    imp_a = ccp.Impeller.load_from_engauge_csv(
+operation_fluid = {
+    "methane": 44.04,
+    "ethane": 3.18,
+    "propane": 0.66,
+    "n-butane": 0.15,
+    "i-butane": 0.05,
+    "n-pentane": 0.03,
+    "i-pentane": 0.02,
+    "n2": 0.25,
+    "h2s": 0.06,
+    "co2": 51.55,
+}
+
+data_units = {
+    "ps": "bar",
+    "Ts": "degC",
+    "pd": "bar",
+    "Td": "degC",
+    "flow_v": "m³/s",
+    "speed": "RPM",
+}
+
+delta_p_data_units = {
+    "ps": "bar",
+    "Ts": "degC",
+    "pd": "bar",
+    "Td": "degC",
+    "delta_p": "mmH2O",
+    "p_downstream": "bar",
+    "speed": "RPM",
+}
+
+
+def _load_imp_a(**kwargs):
+    suc_a = ccp.State(p=Q_(4, "bar"), T=Q_(40, "degC"), fluid=fluid_a)
+    return ccp.Impeller.load_from_engauge_csv(
         suc=suc_a,
         curve_name="eval-lp-sec1-caso-a",
         curve_path=data_path,
         flow_units="m³/h",
         head_units="kJ/kg",
-        number_of_points=4,
+        **kwargs,
     )
 
-    operation_fluid = {
-        "methane": 44.04,
-        "ethane": 3.18,
-        "propane": 0.66,
-        "n-butane": 0.15,
-        "i-butane": 0.05,
-        "n-pentane": 0.03,
-        "i-pentane": 0.02,
-        "n2": 0.25,
-        "h2s": 0.06,
-        "co2": 51.55,
-    }
+
+@pytest.fixture(scope="module")
+def imp_a_n4():
+    return _load_imp_a(number_of_points=4)
+
+
+@pytest.fixture(scope="module")
+def imp_a():
+    return _load_imp_a()
+
+
+@pytest.fixture(scope="module")
+def delta_p_evaluation(imp_a):
+    """Evaluation of data_delta_p.parquet clustered on the full dataset.
+
+    Points are not calculated at construction; tests call calculate_points
+    on the slice they need. Constructed once and shared by tests that only
+    read from it.
+    """
+    df = pd.read_parquet(data_path / "data_delta_p.parquet")
+    return ccp.Evaluation(
+        data=df,
+        operation_fluid=operation_fluid,
+        data_units=delta_p_data_units,
+        impellers=[imp_a],
+        D=Q_(0.590550, "m"),
+        d=Q_(0.366130, "m"),
+        tappings="flange",
+        n_clusters=2,
+        calculate_points=False,
+    )
+
+
+def test_evaluation(imp_a_n4):
+    df = pd.read_parquet(data_path / "data.parquet")
 
     evaluation = ccp.Evaluation(
         data=df,
         operation_fluid=operation_fluid,
-        data_units={
-            "ps": "bar",
-            "Ts": "degC",
-            "pd": "bar",
-            "Td": "degC",
-            "flow_v": "m³/s",
-            "speed": "RPM",
-        },
-        impellers=[imp_a],
+        data_units=data_units,
+        impellers=[imp_a_n4],
         n_clusters=2,
     )
 
@@ -78,180 +124,48 @@ def test_evaluation():
     assert loaded_evaluation.impellers_new[0] == evaluation.impellers_new[0]
 
 
-def test_evaluation_fluid_columns():
-    data_path = Path(ccp.__file__).parent / "tests/data"
+def test_evaluation_fluid_columns(imp_a_n4):
     df = pd.read_parquet(data_path / "data.parquet")
-
-    fluid_a = {
-        "methane": 58.976,
-        "ethane": 3.099,
-        "propane": 0.6,
-        "n-butane": 0.08,
-        "i-butane": 0.05,
-        "n-pentane": 0.01,
-        "i-pentane": 0.01,
-        "n2": 0.55,
-        "h2s": 0.02,
-        "co2": 36.605,
-    }
-    suc_a = ccp.State(p=Q_(4, "bar"), T=Q_(40, "degC"), fluid=fluid_a)
-    imp_a = ccp.Impeller.load_from_engauge_csv(
-        suc=suc_a,
-        curve_name="eval-lp-sec1-caso-a",
-        curve_path=data_path,
-        flow_units="m³/h",
-        head_units="kJ/kg",
-        number_of_points=4,
-    )
-
-    operation_fluid = {
-        "methane": 44.04,
-        "ethane": 3.18,
-        "propane": 0.66,
-        "n-butane": 0.15,
-        "i-butane": 0.05,
-        "n-pentane": 0.03,
-        "i-pentane": 0.02,
-        "n2": 0.25,
-        "h2s": 0.06,
-        "co2": 51.55,
-    }
 
     for comp, frac in operation_fluid.items():
         df[f"fluid_{comp}"] = frac
 
     evaluation = ccp.Evaluation(
         data=df,
-        data_units={
-            "ps": "bar",
-            "Ts": "degC",
-            "pd": "bar",
-            "Td": "degC",
-            "flow_v": "m³/s",
-            "speed": "RPM",
-        },
-        impellers=[imp_a],
+        data_units=data_units,
+        impellers=[imp_a_n4],
         n_clusters=2,
     )
 
     assert_allclose(evaluation.df["delta_eff"].mean(), 11.115457, rtol=1e-2)
 
 
-def test_evaluation_fluid_columns_ppm():
-    data_path = Path(ccp.__file__).parent / "tests/data"
+def test_evaluation_fluid_columns_ppm(imp_a_n4):
     df = pd.read_parquet(data_path / "data.parquet")
 
-    fluid_a = {
-        "methane": 58.976,
-        "ethane": 3.099,
-        "propane": 0.6,
-        "n-butane": 0.08,
-        "i-butane": 0.05,
-        "n-pentane": 0.01,
-        "i-pentane": 0.01,
-        "n2": 0.55,
-        "h2s": 0.02,
-        "co2": 36.605,
-    }
-    suc_a = ccp.State(p=Q_(4, "bar"), T=Q_(40, "degC"), fluid=fluid_a)
-    imp_a = ccp.Impeller.load_from_engauge_csv(
-        suc=suc_a,
-        curve_name="eval-lp-sec1-caso-a",
-        curve_path=data_path,
-        flow_units="m³/h",
-        head_units="kJ/kg",
-        number_of_points=4,
-    )
+    ppm_fluid = dict(operation_fluid)
+    ppm_fluid["n-pentane"] = ppm_fluid["n-pentane"] * 1e6  # check with ppm
 
-    operation_fluid = {
-        "methane": 44.04,
-        "ethane": 3.18,
-        "propane": 0.66,
-        "n-butane": 0.15,
-        "i-butane": 0.05,
-        "n-pentane": 0.03 * 1e6,  # check with ppm
-        "i-pentane": 0.02,
-        "n2": 0.25,
-        "h2s": 0.06,
-        "co2": 51.55,
-    }
-
-    for comp, frac in operation_fluid.items():
+    for comp, frac in ppm_fluid.items():
         df[f"fluid_{comp}"] = frac
 
     evaluation = ccp.Evaluation(
         data=df,
-        data_units={
-            "ps": "bar",
-            "Ts": "degC",
-            "pd": "bar",
-            "Td": "degC",
-            "flow_v": "m³/s",
-            "speed": "RPM",
-            "fluid_n-pentane": "ppm",
-        },
-        impellers=[imp_a],
+        data_units={**data_units, "fluid_n-pentane": "ppm"},
+        impellers=[imp_a_n4],
         n_clusters=2,
     )
 
     assert_allclose(evaluation.df["delta_eff"].mean(), 11.115457, rtol=1e-2)
 
 
-def test_evaluation_calculate_points():
-    data_path = Path(ccp.__file__).parent / "tests/data"
-    # load data.parquet
+def test_evaluation_calculate_points(imp_a):
     df = pd.read_parquet(data_path / "data.parquet")
-    # load lp-sec1-caso-a
-    fluid_a = {
-        "methane": 58.976,
-        "ethane": 3.099,
-        "propane": 0.6,
-        "n-butane": 0.08,
-        "i-butane": 0.05,
-        "n-pentane": 0.01,
-        "i-pentane": 0.01,
-        "n2": 0.55,
-        "h2s": 0.02,
-        "co2": 36.605,
-    }
-    suc_a = ccp.State(
-        p=Q_(4, "bar"),
-        T=Q_(40, "degC"),
-        fluid=fluid_a,
-    )
-
-    imp_a = ccp.Impeller.load_from_engauge_csv(
-        suc=suc_a,
-        curve_name="eval-lp-sec1-caso-a",
-        curve_path=data_path,
-        flow_units="m³/h",
-        head_units="kJ/kg",
-    )
-
-    operation_fluid = {
-        "methane": 44.04,
-        "ethane": 3.18,
-        "propane": 0.66,
-        "n-butane": 0.15,
-        "i-butane": 0.05,
-        "n-pentane": 0.03,
-        "i-pentane": 0.02,
-        "n2": 0.25,
-        "h2s": 0.06,
-        "co2": 51.55,
-    }
 
     evaluation = ccp.Evaluation(
         data=df,
         operation_fluid=operation_fluid,
-        data_units={
-            "ps": "bar",
-            "Ts": "degC",
-            "pd": "bar",
-            "Td": "degC",
-            "flow_v": "m³/s",
-            "speed": "RPM",
-        },
+        data_units=data_units,
         impellers=[imp_a],
         calculate_points=False,
         n_clusters=2,
@@ -261,277 +175,60 @@ def test_evaluation_calculate_points():
     assert_allclose(df_results["delta_eff"].mean(), 10.963751, rtol=1e-2)
 
 
-def test_evaluation_delta_p():
-    data_path = Path(ccp.__file__).parent / "tests/data"
-    # load data.parquet
-    df = pd.read_parquet(data_path / "data_delta_p.parquet")
-    # load lp-sec1-caso-a
-    fluid_a = {
-        "methane": 58.976,
-        "ethane": 3.099,
-        "propane": 0.6,
-        "n-butane": 0.08,
-        "i-butane": 0.05,
-        "n-pentane": 0.01,
-        "i-pentane": 0.01,
-        "n2": 0.55,
-        "h2s": 0.02,
-        "co2": 36.605,
-    }
-    suc_a = ccp.State(
-        p=Q_(4, "bar"),
-        T=Q_(40, "degC"),
-        fluid=fluid_a,
-    )
+def test_evaluation_delta_p(imp_a):
+    """Points calculated during __init__ match an explicit calculate_points call.
 
-    imp_a = ccp.Impeller.load_from_engauge_csv(
-        suc=suc_a,
-        curve_name="eval-lp-sec1-caso-a",
-        curve_path=data_path,
-        flow_units="m³/h",
-        head_units="kJ/kg",
-    )
-
-    operation_fluid = {
-        "methane": 44.04,
-        "ethane": 3.18,
-        "propane": 0.66,
-        "n-butane": 0.15,
-        "i-butane": 0.05,
-        "n-pentane": 0.03,
-        "i-pentane": 0.02,
-        "n2": 0.25,
-        "h2s": 0.06,
-        "co2": 51.55,
-    }
+    Runs on a contiguous slice of the dataset (the fluctuation-window filter
+    removes rows of a non-contiguous sample); the regression value for the
+    delta_p dataset is anchored by test_evaluation_calculate_points_delta_p.
+    """
+    df = pd.read_parquet(data_path / "data_delta_p.parquet")[:100]
 
     evaluation = ccp.Evaluation(
         data=df,
         operation_fluid=operation_fluid,
-        data_units={
-            "ps": "bar",
-            "Ts": "degC",
-            "pd": "bar",
-            "Td": "degC",
-            "delta_p": "mmH2O",
-            "p_downstream": "bar",
-            "speed": "RPM",
-        },
+        data_units=delta_p_data_units,
         impellers=[imp_a],
         D=Q_(0.590550, "m"),
         d=Q_(0.366130, "m"),
         tappings="flange",
         n_clusters=2,
-    )
-
-    assert_allclose(evaluation.df["delta_eff"].mean(), 20.911709, rtol=1e-2)
-
-
-def test_evaluation_calculate_points_delta_p():
-    data_path = Path(ccp.__file__).parent / "tests/data"
-    # load data.parquet
-    df = pd.read_parquet(data_path / "data_delta_p.parquet")
-    # load lp-sec1-caso-a
-    fluid_a = {
-        "methane": 58.976,
-        "ethane": 3.099,
-        "propane": 0.6,
-        "n-butane": 0.08,
-        "i-butane": 0.05,
-        "n-pentane": 0.01,
-        "i-pentane": 0.01,
-        "n2": 0.55,
-        "h2s": 0.02,
-        "co2": 36.605,
-    }
-    suc_a = ccp.State(
-        p=Q_(4, "bar"),
-        T=Q_(40, "degC"),
-        fluid=fluid_a,
-    )
-
-    imp_a = ccp.Impeller.load_from_engauge_csv(
-        suc=suc_a,
-        curve_name="eval-lp-sec1-caso-a",
-        curve_path=data_path,
-        flow_units="m³/h",
-        head_units="kJ/kg",
-    )
-
-    operation_fluid = {
-        "methane": 44.04,
-        "ethane": 3.18,
-        "propane": 0.66,
-        "n-butane": 0.15,
-        "i-butane": 0.05,
-        "n-pentane": 0.03,
-        "i-pentane": 0.02,
-        "n2": 0.25,
-        "h2s": 0.06,
-        "co2": 51.55,
-    }
-
-    evaluation = ccp.Evaluation(
-        data=df,
-        operation_fluid=operation_fluid,
-        data_units={
-            "ps": "bar",
-            "Ts": "degC",
-            "pd": "bar",
-            "Td": "degC",
-            "delta_p": "mmH2O",
-            "p_downstream": "bar",
-            "speed": "RPM",
-        },
-        impellers=[imp_a],
-        D=Q_(0.590550, "m"),
-        d=Q_(0.366130, "m"),
-        tappings="flange",
-        n_clusters=2,
-        calculate_points=False,
     )
 
     df_results = evaluation.calculate_points(df)
-    assert_allclose(df_results["delta_eff"].mean(), 20.911709, rtol=1e-2)
+    assert len(evaluation.df) > 0
+    assert_allclose(
+        evaluation.df["delta_eff"].mean(),
+        df_results["delta_eff"].mean(),
+        rtol=1e-6,
+    )
+    assert_allclose(evaluation.df["delta_eff"].mean(), 21.796171, rtol=1e-2)
 
 
-def test_evaluation_calculate_points_delta_p_flag():
-    data_path = Path(ccp.__file__).parent / "tests/data"
-    # load data.parquet
+def test_evaluation_calculate_points_delta_p(delta_p_evaluation):
     df = pd.read_parquet(data_path / "data_delta_p.parquet")
-    # load lp-sec1-caso-a
-    fluid_a = {
-        "methane": 58.976,
-        "ethane": 3.099,
-        "propane": 0.6,
-        "n-butane": 0.08,
-        "i-butane": 0.05,
-        "n-pentane": 0.01,
-        "i-pentane": 0.01,
-        "n2": 0.55,
-        "h2s": 0.02,
-        "co2": 36.605,
-    }
-    suc_a = ccp.State(
-        p=Q_(4, "bar"),
-        T=Q_(40, "degC"),
-        fluid=fluid_a,
+
+    df_results = delta_p_evaluation.calculate_points(df[:400])
+    assert_allclose(df_results["delta_eff"].mean(), 21.205854, rtol=1e-2)
+
+
+def test_evaluation_calculate_points_delta_p_flag(delta_p_evaluation):
+    df = pd.read_parquet(data_path / "data_delta_p.parquet")
+
+    df_results = delta_p_evaluation.calculate_points(
+        df[:400], drop_invalid_values=False
     )
-
-    imp_a = ccp.Impeller.load_from_engauge_csv(
-        suc=suc_a,
-        curve_name="eval-lp-sec1-caso-a",
-        curve_path=data_path,
-        flow_units="m³/h",
-        head_units="kJ/kg",
-    )
-
-    operation_fluid = {
-        "methane": 44.04,
-        "ethane": 3.18,
-        "propane": 0.66,
-        "n-butane": 0.15,
-        "i-butane": 0.05,
-        "n-pentane": 0.03,
-        "i-pentane": 0.02,
-        "n2": 0.25,
-        "h2s": 0.06,
-        "co2": 51.55,
-    }
-
-    evaluation = ccp.Evaluation(
-        data=df,
-        operation_fluid=operation_fluid,
-        data_units={
-            "ps": "bar",
-            "Ts": "degC",
-            "pd": "bar",
-            "Td": "degC",
-            "delta_p": "mmH2O",
-            "p_downstream": "bar",
-            "speed": "RPM",
-        },
-        impellers=[imp_a],
-        D=Q_(0.590550, "m"),
-        d=Q_(0.366130, "m"),
-        tappings="flange",
-        n_clusters=2,
-        calculate_points=False,
-    )
-
-    df_results = evaluation.calculate_points(df, drop_invalid_values=False)
     # check mean with invalid values (-1)
-    assert_allclose(df_results["delta_eff"].mean(), 4.878011, rtol=1e-2)
+    assert_allclose(df_results["delta_eff"].mean(), 2.570791, rtol=1e-2)
 
-    # remove invalid values
+    # removing invalid values recovers the drop_invalid_values=True result
     df_results = df_results[df_results.valid]
-    assert_allclose(df_results["delta_eff"].mean(), 16.479748, rtol=1e-2)
+    assert_allclose(df_results["delta_eff"].mean(), 21.205854, rtol=1e-2)
 
 
-def test_evaluation_calculate_points_delta_p_3_values():
-    data_path = Path(ccp.__file__).parent / "tests/data"
-    # load data.parquet
+def test_evaluation_calculate_points_delta_p_3_values(delta_p_evaluation):
     df = pd.read_parquet(data_path / "data_delta_p.parquet")
-    # load lp-sec1-caso-a
-    fluid_a = {
-        "methane": 58.976,
-        "ethane": 3.099,
-        "propane": 0.6,
-        "n-butane": 0.08,
-        "i-butane": 0.05,
-        "n-pentane": 0.01,
-        "i-pentane": 0.01,
-        "n2": 0.55,
-        "h2s": 0.02,
-        "co2": 36.605,
-    }
-    suc_a = ccp.State(
-        p=Q_(4, "bar"),
-        T=Q_(40, "degC"),
-        fluid=fluid_a,
-    )
 
-    imp_a = ccp.Impeller.load_from_engauge_csv(
-        suc=suc_a,
-        curve_name="eval-lp-sec1-caso-a",
-        curve_path=data_path,
-        flow_units="m³/h",
-        head_units="kJ/kg",
-    )
-
-    operation_fluid = {
-        "methane": 44.04,
-        "ethane": 3.18,
-        "propane": 0.66,
-        "n-butane": 0.15,
-        "i-butane": 0.05,
-        "n-pentane": 0.03,
-        "i-pentane": 0.02,
-        "n2": 0.25,
-        "h2s": 0.06,
-        "co2": 51.55,
-    }
-
-    evaluation = ccp.Evaluation(
-        data=df,
-        operation_fluid=operation_fluid,
-        data_units={
-            "ps": "bar",
-            "Ts": "degC",
-            "pd": "bar",
-            "Td": "degC",
-            "delta_p": "mmH2O",
-            "p_downstream": "bar",
-            "speed": "RPM",
-        },
-        impellers=[imp_a],
-        D=Q_(0.590550, "m"),
-        d=Q_(0.366130, "m"),
-        tappings="flange",
-        n_clusters=2,
-        calculate_points=False,
-    )
-
-    df_results = evaluation.calculate_points(df[:3], drop_invalid_values=False)
+    df_results = delta_p_evaluation.calculate_points(df[:3], drop_invalid_values=False)
     # check mean with invalid values (-1)
     assert_allclose(df_results["delta_eff"].mean(), -1, rtol=1e-2)

--- a/ccp/tests/test_impeller.py
+++ b/ccp/tests/test_impeller.py
@@ -9,7 +9,7 @@ import ccp
 from ccp import ureg, Q_, State, Point, Curve, Impeller, impeller_example
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def points0():
     #  see Ludtke pg. 173 for values.
     fluid = dict(
@@ -46,14 +46,14 @@ def points0():
     return p0, p1
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def imp0(points0):
     p0, p1 = points0
     imp0 = Impeller([p0, p1])
     return imp0
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def imp1():
     fluid = dict(
         methane=0.69945,
@@ -138,7 +138,7 @@ def test_impeller_new_suction(imp1):
     assert_allclose(new_p0.speed.m, 1251.21885813, rtol=1e-3)
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def imp2():
     points = [
         Point(
@@ -230,7 +230,7 @@ def test_impeller2_new_suction(imp2):
     assert_allclose(new_p0.volume_ratio_ratio.m, 0.999846036412339, rtol=1e-5)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def imp3():
     # faster to load than impeller_example
     composition_fd = dict(
@@ -472,8 +472,13 @@ def test_impeller_from_head_power(imp3):
     assert_allclose(imp.eff.m, imp3.eff.m)
 
 
-def test_impeller_curve():
-    imp = impeller_example()
+@pytest.fixture(scope="module")
+def imp_example():
+    return impeller_example()
+
+
+def test_impeller_curve(imp_example):
+    imp = imp_example
     c0 = imp.curve(speed=900)
     p0 = c0[0]
     assert_allclose(p0.eff.m, 0.8171352367889275, rtol=1e-4)
@@ -481,8 +486,8 @@ def test_impeller_curve():
     assert_allclose(p0.power.m, 2963324.773894661, rtol=1e-4)
 
 
-def test_impeller_plot():
-    imp = impeller_example()
+def test_impeller_plot(imp_example):
+    imp = imp_example
     fig = imp.eff_plot(flow_v=5, speed=900)
     expected_eff_curve = np.array(
         [
@@ -522,8 +527,8 @@ def test_impeller_plot():
     assert_allclose(fig.data[6]["y"], 0.8110849213647002, rtol=1e-4)
 
 
-def test_impeller_plot_units():
-    imp = impeller_example()
+def test_impeller_plot_units(imp_example):
+    imp = imp_example
     fig = imp.disch.rho_plot(
         flow_v=Q_(20000, "m³/h"),
         speed=Q_(8594, "RPM"),
@@ -569,35 +574,9 @@ def test_impeller_plot_units():
     assert_allclose(fig.data[6]["y"], 0.008918054668713014, rtol=1e-4)
 
 
-def test_save_load():
-    composition_fd = dict(
-        n2=0.4,
-        co2=0.22,
-        methane=92.11,
-        ethane=4.94,
-        propane=1.71,
-        ibutane=0.24,
-        butane=0.3,
-        ipentane=0.04,
-        pentane=0.03,
-        hexane=0.01,
-    )
-    suc_fd = State(p=Q_(3876, "kPa"), T=Q_(11, "degC"), fluid=composition_fd)
-
-    test_dir = Path(__file__).parent
-    curve_path = test_dir / "data"
-    curve_name = "normal"
-
-    imp_fd = Impeller.load_from_engauge_csv(
-        suc=suc_fd,
-        curve_name=curve_name,
-        curve_path=curve_path,
-        b=Q_(10.6, "mm"),
-        D=Q_(390, "mm"),
-        number_of_points=6,
-        flow_units="kg/h",
-        head_units="kJ/kg",
-    )
+def test_save_load(imp3):
+    # imp3 is built with the same parameters this test used to build inline
+    imp_fd = imp3
     file = Path(tempdir) / "imp.toml"
     imp_fd.save(file)
 

--- a/ccp/tests/test_point.py
+++ b/ccp/tests/test_point.py
@@ -749,8 +749,7 @@ def test_global_polytropic_method(suc_0, disch_0):
     p0 = Point(suc=suc_0, disch=disch_0, flow_v=1, speed=1, b=1, D=1)
     assert p0.head.units == "joule/kilogram"
     assert_allclose(p0.head.m, 82951.470027, rtol=1e-6)
-    # go back to schultz for other tests
-    ccp.config.POLYTROPIC_METHOD = "schultz"
+    # the restore_global_config fixture in conftest.py resets POLYTROPIC_METHOD
 
 
 def test_case_sc_at():
@@ -765,6 +764,9 @@ def test_case_sc_at():
 
 def test_point_casing_heat_loss():
     """P76 MAIN B - CASE A - point 0"""
+    # expected values below were calculated with the schultz method
+    # (restore_global_config in conftest.py resets this after the test)
+    ccp.config.POLYTROPIC_METHOD = "schultz"
     p = Point(
         flow_m=Q_(7.737, "kg/s"),
         speed=Q_(7894, "RPM"),
@@ -800,6 +802,9 @@ def test_point_casing_heat_loss():
 
 
 def test_ptc10_c6_sample_calculation():
+    # the PTC10 C.6 sample calculation uses the schultz method
+    # (restore_global_config in conftest.py resets this after the test)
+    ccp.config.POLYTROPIC_METHOD = "schultz"
     suc_sp = ccp.State(
         p=Q_(200, "psi"),
         T=Q_(115, "degF"),

--- a/ccp/tests/test_surrogate.py
+++ b/ccp/tests/test_surrogate.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-import ccp
 from ccp import Q_, Impeller, Point, State
 
 B = Q_(28.5, "mm")
@@ -42,7 +41,7 @@ def _map_at(suc, speeds_rpm, phis=np.linspace(0.03, 0.09, 6)):
     return Impeller(points)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def maps():
     """Three measured maps at different suction pressures (-> different Mach)."""
     speeds = [9000, 10500, 12000]
@@ -112,9 +111,9 @@ def test_speed_argument_single_curve(maps):
     assert_allclose(conv.curves[0].speed.to("RPM").m, 10500, rtol=1e-6)
 
 
-def test_default_method_unchanged():
+def test_default_method_unchanged(maps):
     """method defaults to 'similarity' and matches an explicit similarity call."""
-    imp = ccp.impeller_example()
+    imp = maps[0]
     new_suc = imp.points[0].suc
     default = Impeller.convert_from(imp, suc=new_suc, speed="same")
     explicit = Impeller.convert_from(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ dev = [
     "sphinx-rtd-theme",
     "sphinx-design",
     "sphinxcontrib-googleanalytics",
+    "pytest-xdist>=3.8.0",
 ]
 
 [tool.uv]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
-addopts = --doctest-modules
+addopts = --doctest-modules --durations=20
+testpaths = ccp
+markers =
+    slow: dominated by full compressor calculations (deselect with '-m "not slow"')


### PR DESCRIPTION
## Summary

The full test suite took **1h07m** (serial, measured 2026-07-15). This PR brings it to **~6m40s** (`pytest ccp/tests -n 4 --dist loadfile`, 153 passed) and adds a fast development tier — `pytest -m "not slow" -n auto --dist loadfile` — that runs 108 tests in **~40s**, so the slow integration tests only need to run at the end of a feature.

## What changed

### Test tiers + parallelization
- New `ccp/tests/conftest.py` auto-marks the heavy integration modules (`test_app`, `test_compressor`, `test_evaluation`, `test_impeller`) as `slow`.
- `pytest-xdist` added as a dev dependency. `--dist loadfile` keeps each file in a single worker: within-file ordering is preserved and each file gets process isolation. Use `-n 4` (not `-n auto`) for the full suite — the slow files spawn their own multiprocessing pools, and 16 workers exhaust a 16 GB machine.
- `pytest.ini`: registers the `slow` marker, sets `testpaths = ccp` (a bare `pytest` from the repo root no longer fails collecting `docs/`), adds `--durations=20`.

### Shared fixtures (no semantic changes)
Expensive objects that tests only read are now built once per module: the `BackToBack(reynolds_correction="ptc1997")` compressor (was built identically by 3 tests), `impeller_example()` (was built by 4 tests across files), the surrogate `maps`, and the evaluation impellers. All existing expected values pass unchanged.

| File | Before | After |
|------|--------|-------|
| test_evaluation | 45.6 min | 2m08s |
| test_compressor | 10.6 min | 7m00s |
| test_surrogate | 2m28s | 18s |
| test_impeller | 2m03s | 31s |

### test_evaluation delta_p tests re-scoped (reviewers: please check)
The two dominant tests each recomputed all 5780 rows of `data_delta_p.parquet` (~17 and ~25 min). They now run on contiguous slices (`df[:100]` / `df[:400]`, 64 valid points) with re-baselined expected values computed from current `main`; `test_evaluation_delta_p` now verifies that init-time point calculation matches an explicit `calculate_points()` call. Slices must be contiguous because the fluctuation-window filter drops non-adjacent rows. Note the previous ~96s timing of the flag test on full data was an artifact of the numpy 2.4 breakage making points fail fast — on healthy code it costs ~14 min, hence the re-scope.

### Root cause fix for the long-standing test isolation flakiness
`test_global_polytropic_method` set `ccp.config.POLYTROPIC_METHOD = "huntington"` and then "restored" it to `"schultz"` — but the default is `"sandberg_colby"`. Every test running after `test_point` in the same process silently used the wrong polytropic method, which is why `test_impeller` failed when run together with `test_state`/`test_point`. Two `test_point` tests (`test_point_casing_heat_loss`, `test_ptc10_c6_sample_calculation`) had expected values that depended on the leaked schultz setting and failed when run alone; they now set schultz explicitly (PTC-10 C.6 is a Schultz-based sample calculation). A `restore_global_config` autouse fixture resets `EOS` and `POLYTROPIC_METHOD` after every test. `test_state + test_point + test_impeller` now pass 84/84 in a single process.

## Verification
- Each restructured file run individually: all pass with existing expected values (except the documented delta_p re-baselines).
- Full suite `-n 4 --dist loadfile`: **153 passed** in 6m41s.
- Fast tier `-m "not slow" -n auto`: **108 passed** in 41s.
- Historically flaky single-process combo (state+point+impeller): **84 passed**.

Follow-up (separate PR): GitHub Actions workflow running the fast tier on PRs and the full suite on merge.