### PR TITLE
Add GitHub Actions test workflow with private REFPROP

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --locked --all-extras
+        run: uv sync --all-extras
 
       - name: Check REFPROP is loaded
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,74 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # REFPROP is proprietary (NIST license), so the compiled library lives in a
+  # private repository and is fetched with a read-only deploy key stored as
+  # the REFPROP_DEPLOY_KEY secret. Secrets are never exposed to workflows
+  # triggered by pull requests from forks, so the test job is skipped there:
+  # forks need their own private REFPROP repository and secret to run CI.
+  # Do NOT convert the pull_request trigger to pull_request_target - that
+  # would expose the secret to arbitrary code from fork PRs.
+  check-secret:
+    name: Check REFPROP secret
+    runs-on: ubuntu-latest
+    outputs:
+      has-key: ${{ steps.check.outputs.has-key }}
+    steps:
+      - id: check
+        env:
+          KEY: ${{ secrets.REFPROP_DEPLOY_KEY }}
+        run: |
+          if [ -n "$KEY" ]; then
+            echo "has-key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-key=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  test:
+    name: Tests (REFPROP)
+    needs: check-secret
+    if: needs.check-secret.outputs.has-key == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      RPPREFIX: ${{ github.workspace }}/refprop
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch REFPROP (private repository)
+        uses: actions/checkout@v4
+        with:
+          repository: raphaeltimbo/refprop-linux
+          ssh-key: ${{ secrets.REFPROP_DEPLOY_KEY }}
+          path: refprop
+
+      - name: Install libgfortran
+        run: sudo apt-get update -q && sudo apt-get install -y -q libgfortran5
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --locked --all-extras
+
+      - name: Check REFPROP is loaded
+        run: |
+          uv run python -c "
+          import ccp
+          assert ccp.REFPROP_AVAILABLE, 'librefprop.so not found at RPPREFIX'
+          print(ccp.__version__full)
+          "
+
+      - name: Run tests
+        run: uv run pytest ccp/tests -n 4 --dist loadfile

--- a/ccp/__init__.py
+++ b/ccp/__init__.py
@@ -116,7 +116,9 @@ _library_path = _path / _shared_library
 
 # Auto-switch to HEOS if REFPROP is not available
 
-if not _library_path.is_file():
+REFPROP_AVAILABLE = _library_path.is_file()
+
+if not REFPROP_AVAILABLE:
     _warnings.warn(
         f"{_library_path}.\nREFPROP not configured. "
         f"Automatically switching to EOS='HEOS' (CoolProp backend)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,3 +112,7 @@ dev = [
 
 [tool.uv]
 package = true
+# Dev/CI resolution constraint only (does not affect published metadata):
+# CoolProp 8 changed the exception type raised for unknown fluids and the
+# cubic-EOS roundoff, breaking three tests. Remove once ccp is adapted.
+constraint-dependencies = ["coolprop<8"]


### PR DESCRIPTION
Adds CI that runs the full test suite (`pytest ccp/tests -n 4 --dist loadfile`) with REFPROP.

**How REFPROP is kept private:**
- The compiled Linux build (`librefprop.so` + `FLUIDS`/`MIXTURES`) lives in the **private** repo `raphaeltimbo/refprop-linux`.
- CI fetches it with a **read-only deploy key** stored as the `REFPROP_DEPLOY_KEY` actions secret (already configured), and points `RPPREFIX` at the checkout.
- GitHub never provides secrets to workflows triggered by fork PRs, so the test job skips itself there — the binary cannot be exfiltrated via a malicious PR. Post-merge pushes to `main` (and `workflow_dispatch`) run the full REFPROP suite.
- ⚠️ The `pull_request` trigger must never be changed to `pull_request_target`, which would expose the secret to fork PR code.

Also exposes `ccp.REFPROP_AVAILABLE` so CI can assert REFPROP was actually loaded instead of silently falling back to HEOS.

A validation run of this exact workflow (with the secret) is linked in the comments.