### PR TITLE
Add CoolProp 8 compatibility, drop coolprop<8 dev constraint

### DIFF
--- a/ccp/config/fluids.py
+++ b/ccp/config/fluids.py
@@ -81,10 +81,11 @@ def get_name(name):
 
     try:
         fluid_name = CP.get_REFPROPname(name)
-        # CoolProp returns empty string for invalid fluid names
-        if not fluid_name:
-            raise ValueError(f"Fluid {name} not available. See ccp.fluid_list. ")
-    except RuntimeError:
+    # CoolProp raises RuntimeError (v7) or ValueError (v8) for unknown fluids,
+    # and returns an empty string for invalid names
+    except (RuntimeError, ValueError):
+        fluid_name = ""
+    if not fluid_name:
         raise ValueError(f"Fluid {name} not available. See ccp.fluid_list. ")
 
     return fluid_name

--- a/ccp/tests/test_state.py
+++ b/ccp/tests/test_state.py
@@ -52,7 +52,7 @@ def test_eos():
     )
     assert state.p().units == "pascal"
     assert state.T().units == "kelvin"
-    assert state.p().magnitude == 100000
+    assert_allclose(state.p().magnitude, 100000)
     assert state.T().magnitude == 300
     assert_allclose(state.rhomass(), 0.6445687063978816, rtol=1e-6)
 
@@ -61,7 +61,7 @@ def test_eos():
     )
     assert state.p().units == "pascal"
     assert state.T().units == "kelvin"
-    assert state.p().magnitude == 100000
+    assert_allclose(state.p().magnitude, 100000)
     assert state.T().magnitude == 300
     assert_allclose(state.rhomass(), 0.6442384800595821, rtol=1e-6)
 
@@ -88,7 +88,7 @@ def test_eos_config():
     state = State(p=100000, T=300, fluid={"Methane": 1 - 1e-15, "Ethane": 1e-15})
     assert state.p().units == "pascal"
     assert state.T().units == "kelvin"
-    assert state.p().magnitude == 100000
+    assert_allclose(state.p().magnitude, 100000)
     assert state.T().magnitude == 300
     assert_allclose(state.rhomass(), 0.6445687063978816, rtol=1e-6)
 
@@ -96,7 +96,7 @@ def test_eos_config():
     state = State(p=100000, T=300, fluid={"Methane": 1 - 1e-15, "Ethane": 1e-15})
     assert state.p().units == "pascal"
     assert state.T().units == "kelvin"
-    assert state.p().magnitude == 100000
+    assert_allclose(state.p().magnitude, 100000)
     assert state.T().magnitude == 300
     assert_allclose(state.rhomass(), 0.6442384800595821, rtol=1e-6)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,3 @@ dev = [
 
 [tool.uv]
 package = true
-# Dev/CI resolution constraint only (does not affect published metadata):
-# CoolProp 8 changed the exception type raised for unknown fluids and the
-# cubic-EOS roundoff, breaking three tests. Remove once ccp is adapted.
-constraint-dependencies = ["coolprop<8"]


### PR DESCRIPTION
## Summary

Makes ccp compatible with CoolProp 8.0.0 and removes the temporary `coolprop<8` dev/CI resolution constraint added in #151.

- **`ccp/config/fluids.py`**: CoolProp 8 raises `ValueError` (v7 raised `RuntimeError`) from `get_REFPROPname` for unknown fluids — `get_name` now catches both and keeps raising ccp's own `ValueError` with the `ccp.fluid_list` hint.
- **`ccp/tests/test_state.py`**: CoolProp 8's reworked cubic-EOS saturation routines introduce ~1e-10 roundoff in the PR/SRK pressure roundtrip (100000.00000000015 Pa instead of exactly 100000), so `test_eos`/`test_eos_config` compare pressure with `assert_allclose` instead of `==`, matching the existing HEOS blocks.
- **`pyproject.toml`**: removed `constraint-dependencies = ["coolprop<8"]` from `[tool.uv]`. This was a dev/CI-only pin and never affected published metadata; with ccp now compatible with both major versions, fresh resolution is free to pick 8.x.

CoolProp 8 wheels are Python 3.12+ (abi3); since the dependency is unpinned and `requires-python >=3.9`, older Pythons keep resolving to 7.x automatically.

## Testing

Full test suite against a fresh resolution with CoolProp 8.0.0 (REFPROP available): **159 passed, 0 failed** (`uv run pytest ccp/tests -n 4 --dist loadfile`, 8:45). Fast tier also clean apart from the 9 pre-existing module-doctest failures tracked separately.