### PR TITLE
Add drivers subpackage with induction motor power estimation

### DIFF
--- a/ccp/__init__.py
+++ b/ccp/__init__.py
@@ -192,6 +192,7 @@ from .impeller import Impeller, impeller_example
 from .fo import FlowOrifice
 from .similarity import check_similarity
 from .evaluation import Evaluation
+from .drivers import Driver, InductionMotor
 
 __all__ = [
     "State",
@@ -203,4 +204,6 @@ __all__ = [
     "check_similarity",
     "impeller_example",
     "Evaluation",
+    "Driver",
+    "InductionMotor",
 ]

--- a/ccp/config/units.py
+++ b/ccp/config/units.py
@@ -117,6 +117,15 @@ units = {
     "reynolds_ratio": "dimensionless",
     "mach_diff": "dimensionless",
     "volume_ratio_ratio": "dimensionless",
+    "voltage": "volt",
+    "current": "ampere",
+    # full-name entries: the token scan would match "power" -> watt
+    "power_factor": "dimensionless",
+    "rated_power_factor": "dimensionless",
+    "efficiency": "dimensionless",
+    # full-name entries: the token scan would match "frequency" -> radian/second
+    "rated_frequency": "hertz",
+    "supply_frequency": "hertz",
 }
 for i, unit in zip(["k", "c"], ["N/m", "N*s/m"]):
     for j in ["x", "y", "z"]:

--- a/ccp/drivers/__init__.py
+++ b/ccp/drivers/__init__.py
@@ -1,0 +1,12 @@
+"""Compressor drivers.
+
+Classes to estimate the power delivered by a compressor driver from field
+measurements (e.g. an induction motor's voltage, current and power factor),
+so it can be compared with the thermodynamic power calculated by ccp
+(``Point.power_shaft``).
+"""
+
+from .driver import Driver, PowerComparison
+from .motor import InductionMotor, MotorEstimate
+
+__all__ = ["Driver", "PowerComparison", "InductionMotor", "MotorEstimate"]

--- a/ccp/drivers/driver.py
+++ b/ccp/drivers/driver.py
@@ -1,0 +1,134 @@
+"""Base class for compressor drivers.
+
+A driver delivers shaft power to the compressor (e.g. an electric motor, a
+steam turbine or a gas turbine). Driver classes estimate that power from
+field measurements, so it can be compared with the thermodynamic power
+calculated by ccp (``Point.power_shaft``).
+"""
+
+from dataclasses import dataclass
+
+import pint
+
+from ccp.config.units import check_units
+from ccp.data_io.serializers import Serializable
+
+
+@dataclass(frozen=True)
+class PowerComparison:
+    """Result of comparing driver power with a performance point.
+
+    Attributes
+    ----------
+    driver_power : pint.Quantity
+        Driver shaft power (Watt).
+    transmitted_power : pint.Quantity
+        Power delivered at the compressor coupling (Watt):
+        driver power times coupling and gearbox efficiencies.
+    point_power : pint.Quantity
+        Compressor shaft power from the performance point (Watt).
+    delta : pint.Quantity
+        transmitted_power - point_power (Watt). Positive means the driver
+        delivers more power than the thermodynamic calculation requires.
+    delta_ratio : pint.Quantity
+        delta / point_power (dimensionless).
+    method : str
+        Load estimation method used by the driver.
+    load : pint.Quantity
+        Driver load fraction (dimensionless).
+    """
+
+    driver_power: pint.Quantity
+    transmitted_power: pint.Quantity
+    point_power: pint.Quantity
+    delta: pint.Quantity
+    delta_ratio: pint.Quantity
+    method: str
+    load: pint.Quantity
+
+    def __str__(self):
+        return (
+            f"Driver Power: {self.driver_power.to('kW'):.2f~P}"
+            f"\nTransmitted Power: {self.transmitted_power.to('kW'):.2f~P}"
+            f"\nPoint Shaft Power: {self.point_power.to('kW'):.2f~P}"
+            f"\nDelta: {self.delta.to('kW'):.2f~P}"
+            f"\nDelta Ratio: {self.delta_ratio.m:.4f}"
+            f"\nMethod: {self.method}"
+            f"\nLoad: {self.load.m:.4f}"
+        )
+
+
+class Driver(Serializable):
+    """Base class for compressor drivers.
+
+    Subclasses hold the driver's fixed (nameplate) data and implement
+    :meth:`estimate`, which computes the driver shaft power from field
+    measurements passed as keyword arguments.
+
+    Parameters
+    ----------
+    rated_power : float, pint.Quantity
+        Rated shaft output power (Watt).
+    rated_speed : float, pint.Quantity
+        Rated speed (rad/s).
+    tag : str, optional
+        Tag to identify the driver.
+    """
+
+    @check_units
+    def __init__(self, rated_power=None, rated_speed=None, tag=None):
+        self.rated_power = rated_power
+        self.rated_speed = rated_speed
+        self.tag = tag
+
+    def estimate(self, **measurements):
+        """Estimate driver load and shaft power from field measurements."""
+        raise NotImplementedError
+
+    def power_output(self, **measurements):
+        """Driver shaft power (Watt) estimated from field measurements."""
+        return self.estimate(**measurements).power_output
+
+    @check_units
+    def compare(
+        self, point, coupling_efficiency=1.0, gearbox_efficiency=1.0, **measurements
+    ):
+        """Compare driver power with the shaft power of a performance point.
+
+        Parameters
+        ----------
+        point : ccp.Point
+            Performance point with the compressor shaft power
+            (``point.power_shaft``).
+        coupling_efficiency : float, pint.Quantity, optional
+            Coupling efficiency between driver and compressor.
+            Default is 1.0.
+        gearbox_efficiency : float, pint.Quantity, optional
+            Gearbox efficiency between driver and compressor.
+            Default is 1.0.
+        **measurements
+            Field measurements passed to :meth:`estimate`
+            (e.g. voltage, current, power_factor for an induction motor).
+
+        Returns
+        -------
+        comparison : ccp.drivers.PowerComparison
+            Comparison with driver power, transmitted power, point power and
+            deltas.
+        """
+        estimate = self.estimate(**measurements)
+        transmitted_power = (
+            estimate.power_output * coupling_efficiency * gearbox_efficiency
+        ).to("watt")
+        point_power = point.power_shaft.to("watt")
+        delta = transmitted_power - point_power
+
+        return PowerComparison(
+            driver_power=estimate.power_output.to("watt"),
+            transmitted_power=transmitted_power,
+            point_power=point_power,
+            delta=delta,
+            delta_ratio=(delta / point_power).to("dimensionless"),
+            method=estimate.method,
+            load=estimate.load,
+        )

--- a/ccp/drivers/motor.py
+++ b/ccp/drivers/motor.py
@@ -1,0 +1,484 @@
+"""Induction motor driver.
+
+Estimates motor load and shaft power from field electrical measurements
+using the methods of the U.S. DOE fact sheet "Determining Electric Motor
+Load and Efficiency" (IEEE 112 field practice): input power, line current
+and slip.
+"""
+
+import warnings
+from dataclasses import dataclass
+
+import numpy as np
+import pint
+from scipy.interpolate import interp1d
+
+from ccp.config.units import Q_, check_units
+from ccp.drivers.driver import Driver
+
+
+@dataclass(frozen=True)
+class MotorEstimate:
+    """Result of a motor load/power estimation.
+
+    Attributes
+    ----------
+    method : str
+        Load estimation method used ("input_power", "current" or "slip").
+    load : pint.Quantity
+        Motor load fraction (shaft power / rated power, dimensionless).
+    efficiency : pint.Quantity or None
+        Motor efficiency at the estimated load (None for the current and
+        slip methods, which do not use the efficiency).
+    input_power : pint.Quantity or None
+        Three-phase electrical input power (Watt). None for the slip method.
+    power_output : pint.Quantity
+        Motor shaft power (Watt).
+    """
+
+    method: str
+    load: pint.Quantity
+    efficiency: pint.Quantity
+    input_power: pint.Quantity
+    power_output: pint.Quantity
+
+    def __str__(self):
+        efficiency = f"{self.efficiency.m:.4f}" if self.efficiency is not None else "-"
+        input_power = (
+            f"{self.input_power.to('kW'):.2f~P}"
+            if self.input_power is not None
+            else "-"
+        )
+        return (
+            f"Method: {self.method}"
+            f"\nLoad: {self.load.m:.4f}"
+            f"\nEfficiency: {efficiency}"
+            f"\nInput Power: {input_power}"
+            f"\nPower Output: {self.power_output.to('kW'):.2f~P}"
+        )
+
+
+class InductionMotor(Driver):
+    """Induction motor driver.
+
+    Holds the motor nameplate data and estimates load and shaft power from
+    field measurements (voltage, current, power factor, speed), following the
+    U.S. DOE fact sheet "Determining Electric Motor Load and Efficiency":
+
+    - Input power method (preferred): three-phase input power
+      P = sqrt(3) * V * I * PF times the motor efficiency. When an efficiency
+      curve is given, the efficiency at the estimated load is found
+      iteratively.
+    - Current method: load = (I / rated current) * (V / rated voltage);
+      unreliable below 50% load, where the current-load relation becomes
+      non-linear.
+    - Slip method: load = slip / rated slip, optionally voltage compensated
+      by (V / rated voltage)**2. Accuracy is limited by the NEMA tolerance
+      on the nameplate full-load speed.
+
+    For motors fed by a variable frequency drive (VFD), pass the drive output
+    frequency as ``supply_frequency`` to the estimation methods (synchronous
+    speed follows it) and set ``vfd_efficiency`` if the electrical
+    measurements are taken at the drive input rather than at the motor
+    terminals. The slip method under VFD assumes constant rated slip in
+    absolute speed units (constant V/f), a reasonable approximation for
+    ~30-100% of rated frequency.
+
+    Note that pint treats radian as dimensionless, so converting between
+    "Hz" and "rad/s" does not apply a 2*pi factor. Electrical frequencies
+    are kept in Hz and the synchronous speed is computed explicitly as
+    4*pi*f/poles.
+
+    Parameters
+    ----------
+    rated_power : float, pint.Quantity
+        Rated (nameplate) shaft output power (Watt).
+    rated_voltage : float, pint.Quantity
+        Rated line-to-line RMS voltage (Volt).
+    rated_current : float, pint.Quantity
+        Rated line RMS current (Ampere).
+    rated_speed : float, pint.Quantity
+        Nameplate full-load speed (rad/s).
+    rated_frequency : float, pint.Quantity
+        Rated supply frequency (Hz).
+    poles : int, optional
+        Number of poles (even). If not given, it is derived from
+        rated_frequency and rated_speed.
+    rated_power_factor : float, pint.Quantity, optional
+        Power factor at rated load (dimensionless).
+    efficiency : float, pint.Quantity, optional
+        Full-load efficiency (dimensionless). Provide either efficiency or
+        efficiency_curve, not both.
+    efficiency_curve : array-like, optional
+        (N, 2) array with (load fraction, efficiency) rows, e.g.
+        [[0.25, 0.90], [0.5, 0.93], [0.75, 0.936], [1.0, 0.93]].
+        Interpolated with degree 3 when more than 3 points are given
+        (degree 1 otherwise) and clamped at the end points.
+    vfd_efficiency : float, pint.Quantity, optional
+        Variable frequency drive efficiency (dimensionless). Set only when
+        the electrical measurements are taken at the drive input; the input
+        power is multiplied by this value to obtain the power at the motor
+        terminals.
+    tag : str, optional
+        Tag to identify the motor.
+
+    Examples
+    --------
+    >>> import ccp
+    >>> Q_ = ccp.Q_
+    >>> motor = ccp.InductionMotor(
+    ...     rated_power=Q_(40, "hp"),
+    ...     rated_voltage=Q_(460, "volt"),
+    ...     rated_current=Q_(46, "ampere"),
+    ...     rated_speed=Q_(1780, "rpm"),
+    ...     rated_frequency=Q_(60, "Hz"),
+    ...     rated_power_factor=0.86,
+    ...     efficiency=0.93,
+    ... )
+    >>> motor.input_power(voltage=469.7, current=37, power_factor=0.763).to("kW")
+    <Quantity(22.9671681, 'kilowatt')>
+    >>> motor.power_output(voltage=469.7, current=37, power_factor=0.763).to("kW")
+    <Quantity(21.3594664, 'kilowatt')>
+    """
+
+    @check_units
+    def __init__(
+        self,
+        rated_power=None,
+        rated_voltage=None,
+        rated_current=None,
+        rated_speed=None,
+        rated_frequency=None,
+        poles=None,
+        rated_power_factor=None,
+        efficiency=None,
+        efficiency_curve=None,
+        vfd_efficiency=None,
+        tag=None,
+    ):
+        super().__init__(rated_power=rated_power, rated_speed=rated_speed, tag=tag)
+        self.rated_voltage = rated_voltage
+        self.rated_current = rated_current
+        self.rated_frequency = rated_frequency
+        self.rated_power_factor = rated_power_factor
+        self.vfd_efficiency = vfd_efficiency
+
+        if efficiency is not None and efficiency_curve is not None:
+            raise ValueError("Provide either efficiency or efficiency_curve, not both.")
+        self.efficiency = efficiency
+
+        self._efficiency_interp = None
+        if efficiency_curve is not None:
+            curve = np.asarray(getattr(efficiency_curve, "m", efficiency_curve))
+            if curve.ndim != 2 or curve.shape[1] != 2:
+                raise ValueError(
+                    "efficiency_curve must be an (N, 2) array with "
+                    "(load fraction, efficiency) rows."
+                )
+            curve = curve[np.argsort(curve[:, 0])]
+            self._efficiency_interp = interp1d(
+                curve[:, 0],
+                curve[:, 1],
+                kind=3 if len(curve) > 3 else 1,
+                bounds_error=False,
+                fill_value=(curve[0, 1], curve[-1, 1]),
+            )
+            self.efficiency_curve = curve
+        else:
+            self.efficiency_curve = None
+
+        if poles is None and rated_frequency is not None and rated_speed is not None:
+            # poles from the synchronous speed immediately above the
+            # full-load speed: 120 * f / rpm rounded down to an even number
+            poles = 2 * int(60 * rated_frequency.to("Hz").m / rated_speed.to("rpm").m)
+        self.poles = poles
+
+    @check_units
+    def input_power(self, voltage=None, current=None, power_factor=None):
+        """Three-phase electrical input power (Watt).
+
+        P = sqrt(3) * V * I * PF, with V the mean line-to-line RMS voltage
+        and I the mean RMS current.
+
+        Parameters
+        ----------
+        voltage : float, pint.Quantity
+            Line-to-line RMS voltage (Volt), mean of the 3 phases.
+        current : float, pint.Quantity
+            RMS current (Ampere), mean of the 3 phases.
+        power_factor : float, pint.Quantity
+            Power factor (dimensionless), mean of the 3 phases.
+
+        Returns
+        -------
+        input_power : pint.Quantity
+            Three-phase input power (Watt).
+        """
+        if voltage is None or current is None or power_factor is None:
+            raise ValueError(
+                "voltage, current and power_factor are required to calculate "
+                "the input power."
+            )
+        return (np.sqrt(3) * voltage * current * power_factor).to("watt")
+
+    def efficiency_at_load(self, load):
+        """Motor efficiency at a given load fraction.
+
+        Interpolated from the efficiency curve when available, otherwise the
+        single efficiency value is returned.
+
+        Parameters
+        ----------
+        load : float
+            Load fraction (shaft power / rated power, dimensionless).
+
+        Returns
+        -------
+        efficiency : pint.Quantity
+            Efficiency at the given load (dimensionless).
+        """
+        load = getattr(load, "m", load)
+        if self._efficiency_interp is not None:
+            return Q_(float(self._efficiency_interp(load)), "dimensionless")
+        if self.efficiency is not None:
+            return self.efficiency
+        raise ValueError(
+            "No efficiency information. Provide efficiency or efficiency_curve "
+            "to use the input power method."
+        )
+
+    @check_units
+    def synchronous_speed(self, supply_frequency=None):
+        """Synchronous speed for a supply frequency.
+
+        Parameters
+        ----------
+        supply_frequency : float, pint.Quantity, optional
+            Supply frequency (Hz). Defaults to the rated frequency.
+
+        Returns
+        -------
+        synchronous_speed : pint.Quantity
+            Synchronous speed (rad/s): 4 * pi * f / poles.
+        """
+        if supply_frequency is None:
+            supply_frequency = self.rated_frequency
+        if supply_frequency is None or self.poles is None:
+            raise ValueError(
+                "supply_frequency (or rated_frequency) and poles are required "
+                "to calculate the synchronous speed."
+            )
+        return Q_(4 * np.pi * supply_frequency.to("Hz").m / self.poles, "rad/s")
+
+    @check_units
+    def estimate(
+        self,
+        voltage=None,
+        current=None,
+        power_factor=None,
+        input_power=None,
+        speed=None,
+        supply_frequency=None,
+        method=None,
+    ):
+        """Estimate motor load and shaft power from field measurements.
+
+        The method is selected automatically from the available measurements
+        (input_power or voltage + current + power_factor -> "input_power";
+        current -> "current"; speed -> "slip") and can be forced with the
+        method argument.
+
+        Parameters
+        ----------
+        voltage : float, pint.Quantity, optional
+            Measured line-to-line RMS voltage (Volt), mean of the 3 phases.
+        current : float, pint.Quantity, optional
+            Measured RMS current (Ampere), mean of the 3 phases.
+        power_factor : float, pint.Quantity, optional
+            Measured power factor (dimensionless).
+        input_power : float, pint.Quantity, optional
+            Measured three-phase input power (Watt), when directly available.
+        speed : float, pint.Quantity, optional
+            Measured motor speed (rad/s), for the slip method.
+        supply_frequency : float, pint.Quantity, optional
+            Supply frequency (Hz) when different from rated (VFD operation).
+        method : str, optional
+            Force the estimation method: "input_power", "current" or "slip".
+
+        Returns
+        -------
+        estimate : ccp.drivers.MotorEstimate
+            Estimation result with method, load, efficiency, input power and
+            power output.
+        """
+        if method is None:
+            if input_power is not None or (
+                voltage is not None and current is not None and power_factor is not None
+            ):
+                method = "input_power"
+            elif current is not None:
+                method = "current"
+            elif speed is not None:
+                method = "slip"
+            else:
+                raise ValueError(
+                    "Insufficient measurements. Provide input_power (or "
+                    "voltage, current and power_factor), current, or speed."
+                )
+
+        if method == "input_power":
+            return self._estimate_input_power(
+                voltage, current, power_factor, input_power
+            )
+        elif method == "current":
+            return self._estimate_current(current, voltage)
+        elif method == "slip":
+            return self._estimate_slip(speed, supply_frequency, voltage)
+        raise ValueError(
+            f"Unknown method {method!r}. "
+            'Options are "input_power", "current" or "slip".'
+        )
+
+    def estimate_load(self, **measurements):
+        """Motor load fraction (dimensionless) estimated from measurements."""
+        return self.estimate(**measurements).load
+
+    def _estimate_input_power(self, voltage, current, power_factor, input_power):
+        if input_power is None:
+            input_power = self.input_power(
+                voltage=voltage, current=current, power_factor=power_factor
+            )
+        motor_input = input_power
+        if self.vfd_efficiency is not None:
+            motor_input = motor_input * self.vfd_efficiency
+
+        if self.rated_power is None:
+            raise ValueError("rated_power is required to estimate the motor load.")
+
+        efficiency = self.efficiency_at_load(1.0)
+        if self._efficiency_interp is not None:
+            for _ in range(50):
+                load = (motor_input * efficiency / self.rated_power).to("dimensionless")
+                new_efficiency = self.efficiency_at_load(load.m)
+                converged = abs(new_efficiency.m - efficiency.m) < 1e-6
+                efficiency = new_efficiency
+                if converged:
+                    break
+
+        power_output = (motor_input * efficiency).to("watt")
+        load = (power_output / self.rated_power).to("dimensionless")
+
+        return MotorEstimate(
+            method="input_power",
+            load=load,
+            efficiency=efficiency,
+            input_power=input_power.to("watt"),
+            power_output=power_output,
+        )
+
+    def _estimate_current(self, current, voltage):
+        if current is None:
+            raise ValueError("current is required for the current method.")
+        if self.rated_current is None or self.rated_power is None:
+            raise ValueError(
+                "rated_current and rated_power are required for the current method."
+            )
+
+        load = (current / self.rated_current).to("dimensionless")
+        if voltage is not None:
+            if self.rated_voltage is None:
+                raise ValueError("rated_voltage is required for voltage compensation.")
+            load = (load * voltage / self.rated_voltage).to("dimensionless")
+
+        if load.m < 0.5:
+            warnings.warn(
+                "The current method is unreliable below 50% load, where the "
+                "current-load relation becomes non-linear."
+            )
+
+        return MotorEstimate(
+            method="current",
+            load=load,
+            efficiency=None,
+            input_power=None,
+            power_output=(load * self.rated_power).to("watt"),
+        )
+
+    def _estimate_slip(self, speed, supply_frequency, voltage):
+        if speed is None:
+            raise ValueError("speed is required for the slip method.")
+        if (
+            self.rated_frequency is None
+            or self.rated_speed is None
+            or self.rated_power is None
+        ):
+            raise ValueError(
+                "rated_frequency, rated_speed and rated_power are required "
+                "for the slip method."
+            )
+
+        if supply_frequency is None:
+            supply_frequency = self.rated_frequency
+        synchronous_speed = self.synchronous_speed(supply_frequency=supply_frequency)
+        rated_slip = self.synchronous_speed() - self.rated_speed
+
+        load = ((synchronous_speed - speed) / rated_slip).to("dimensionless")
+        if voltage is not None:
+            if self.rated_voltage is None:
+                raise ValueError("rated_voltage is required for voltage compensation.")
+            load = (load * (voltage / self.rated_voltage) ** 2).to("dimensionless")
+
+        # under VFD (constant V/f), rated slip is assumed constant in absolute
+        # speed units, and available power scales with frequency
+        frequency_ratio = (supply_frequency / self.rated_frequency).to("dimensionless")
+        power_output = (load * self.rated_power * frequency_ratio).to("watt")
+
+        return MotorEstimate(
+            method="slip",
+            load=load,
+            efficiency=None,
+            input_power=None,
+            power_output=power_output,
+        )
+
+    def to_dict(self):
+        """Return motor parameters as a dict (None fields omitted)."""
+        parameters = {}
+        for attr in [
+            "rated_power",
+            "rated_voltage",
+            "rated_current",
+            "rated_speed",
+            "rated_frequency",
+            "rated_power_factor",
+            "efficiency",
+            "vfd_efficiency",
+        ]:
+            value = getattr(self, attr)
+            if value is not None:
+                parameters[attr] = str(value)
+        if self.poles is not None:
+            parameters["poles"] = int(self.poles)
+        if self.efficiency_curve is not None:
+            parameters["efficiency_curve"] = self.efficiency_curve.tolist()
+        if self.tag is not None:
+            parameters["tag"] = self.tag
+        return parameters
+
+    @classmethod
+    def from_dict(cls, dict_parameters):
+        """Create motor from a dict created with :meth:`to_dict`."""
+        parameters = {k: v for k, v in dict_parameters.items() if k != "ccp_version"}
+        for k in [
+            "rated_power",
+            "rated_voltage",
+            "rated_current",
+            "rated_speed",
+            "rated_frequency",
+            "rated_power_factor",
+            "efficiency",
+            "vfd_efficiency",
+        ]:
+            if k in parameters:
+                parameters[k] = Q_(parameters[k])
+        return cls(**parameters)

--- a/ccp/tests/test_drivers.py
+++ b/ccp/tests/test_drivers.py
@@ -1,0 +1,292 @@
+import pytest
+from numpy.testing import assert_allclose
+
+from ccp import Q_
+from ccp.drivers import InductionMotor, MotorEstimate, PowerComparison
+from ccp.point import Point
+from ccp.state import State
+
+
+@pytest.fixture
+def motor():
+    """DOE fact sheet example: 40 hp, 1800 rpm class motor."""
+    return InductionMotor(
+        rated_power=Q_(40, "hp"),
+        rated_voltage=Q_(460, "volt"),
+        rated_current=Q_(46, "ampere"),
+        rated_speed=Q_(1780, "rpm"),
+        rated_frequency=Q_(60, "Hz"),
+        rated_power_factor=0.86,
+        efficiency=0.93,
+    )
+
+
+@pytest.fixture
+def motor_other_units():
+    return InductionMotor(
+        rated_power=Q_(29828.0, "W"),
+        rated_voltage=Q_(0.460, "kV"),
+        rated_current=Q_(46, "ampere"),
+        rated_speed=Q_(186.4158, "rad/s"),
+        rated_frequency=Q_(60, "Hz"),
+        rated_power_factor=0.86,
+        efficiency=Q_(93, "percent"),
+    )
+
+
+@pytest.fixture
+def motor_si_floats():
+    return InductionMotor(
+        rated_power=29828.0,
+        rated_voltage=460.0,
+        rated_current=46.0,
+        rated_speed=186.4158,
+        rated_frequency=60.0,
+        rated_power_factor=0.86,
+        efficiency=0.93,
+    )
+
+
+@pytest.fixture
+def motor_slip():
+    """DOE fact sheet slip example: 25 hp, sync 1800 rpm, rated 1750 rpm."""
+    return InductionMotor(
+        rated_power=Q_(25, "hp"),
+        rated_voltage=Q_(460, "volt"),
+        rated_speed=Q_(1750, "rpm"),
+        rated_frequency=Q_(60, "Hz"),
+    )
+
+
+def test_input_power_doe_example(motor):
+    # DOE fact sheet: 469.7 V, 37 A, PF 0.763 -> 22.9 kW
+    input_power = motor.input_power(voltage=469.7, current=37, power_factor=0.763)
+    assert_allclose(input_power.to("kW").m, 22.9672, rtol=1e-4)
+
+
+def test_input_power_method(motor):
+    estimate = motor.estimate(voltage=469.7, current=37, power_factor=0.763)
+    assert estimate.method == "input_power"
+    assert_allclose(estimate.power_output.m, 22967.1681 * 0.93, rtol=1e-4)
+    assert_allclose(estimate.load.m, 0.71608, rtol=1e-4)
+    assert_allclose(estimate.efficiency.m, 0.93)
+    # direct power measurement gives the same result
+    estimate_direct = motor.estimate(input_power=Q_(22.9671681, "kW"))
+    assert_allclose(estimate_direct.power_output.m, estimate.power_output.m, rtol=1e-6)
+
+
+def test_units_variants(motor, motor_other_units, motor_si_floats):
+    measurements = dict(voltage=469.7, current=37, power_factor=0.763)
+    reference = motor.estimate(**measurements)
+    for m in [motor_other_units, motor_si_floats]:
+        estimate = m.estimate(**measurements)
+        assert_allclose(estimate.power_output.m, reference.power_output.m, rtol=1e-4)
+        assert_allclose(estimate.load.m, reference.load.m, rtol=1e-4)
+    # measurement units are also converted
+    estimate_kv = motor.estimate(
+        voltage=Q_(0.4697, "kV"), current=37, power_factor=0.763
+    )
+    assert_allclose(estimate_kv.power_output.m, reference.power_output.m)
+
+
+def test_power_factor_not_converted_to_watt(motor):
+    # regression: "rated_power_factor"/"power_factor" must resolve to
+    # dimensionless in check_units, not match the "power" token -> watt
+    assert motor.rated_power_factor.units == Q_(1, "dimensionless").units
+    estimate = motor.estimate(
+        voltage=469.7, current=37, power_factor=Q_(0.763, "dimensionless")
+    )
+    assert_allclose(estimate.load.m, 0.71608, rtol=1e-4)
+
+
+def test_current_method(motor):
+    estimate = motor.estimate(current=37, voltage=469.7, method="current")
+    assert estimate.method == "current"
+    assert_allclose(estimate.load.m, (37 / 46) * (469.7 / 460), rtol=1e-6)
+    assert_allclose(estimate.power_output.to("hp").m, 32.8524, rtol=1e-4)
+    assert estimate.efficiency is None
+    # without voltage compensation
+    estimate_no_v = motor.estimate(current=37, method="current")
+    assert_allclose(estimate_no_v.load.m, 37 / 46, rtol=1e-6)
+
+
+def test_current_method_low_load_warns(motor):
+    with pytest.warns(UserWarning, match="unreliable below 50%"):
+        motor.estimate(current=20, method="current")
+
+
+def test_slip_method_doe_example(motor_slip):
+    # sync 1800, rated 1750, measured 1770 rpm -> load 60% -> 15 hp
+    assert motor_slip.poles == 4
+    assert_allclose(motor_slip.synchronous_speed().to("rpm").m, 1800)
+    estimate = motor_slip.estimate(speed=Q_(1770, "rpm"))
+    assert estimate.method == "slip"
+    assert_allclose(estimate.load.m, 0.6, rtol=1e-6)
+    assert_allclose(estimate.power_output.to("hp").m, 15.0, rtol=1e-6)
+
+
+def test_slip_method_voltage_compensated(motor_slip):
+    estimate = motor_slip.estimate(speed=Q_(1770, "rpm"), voltage=450.8)
+    assert_allclose(estimate.load.m, 0.6 * (450.8 / 460) ** 2, rtol=1e-6)
+
+
+def test_slip_method_vfd(motor_slip):
+    # 45 Hz: sync 1350 rpm, measured 1320 rpm -> load 60%,
+    # power scaled by 45/60 -> 11.25 hp
+    estimate = motor_slip.estimate(speed=Q_(1320, "rpm"), supply_frequency=Q_(45, "Hz"))
+    assert_allclose(estimate.load.m, 0.6, rtol=1e-6)
+    assert_allclose(estimate.power_output.to("hp").m, 11.25, rtol=1e-6)
+    assert_allclose(estimate.power_output.m, 8389.12, rtol=1e-4)
+
+
+def test_vfd_efficiency():
+    motor = InductionMotor(
+        rated_power=Q_(40, "hp"),
+        efficiency=0.93,
+        vfd_efficiency=0.97,
+    )
+    estimate = motor.estimate(input_power=Q_(22.9671681, "kW"))
+    assert_allclose(estimate.power_output.m, 22967.1681 * 0.97 * 0.93, rtol=1e-6)
+
+
+def test_efficiency_curve_iteration():
+    motor = InductionMotor(
+        rated_power=Q_(40, "hp"),
+        efficiency_curve=[
+            [0.25, 0.894],
+            [0.50, 0.925],
+            [0.75, 0.936],
+            [1.00, 0.930],
+        ],
+    )
+    input_power = Q_(22.9671681, "kW")
+    estimate = motor.estimate(input_power=input_power)
+    # self-consistency: load, efficiency and input power must close
+    assert_allclose(
+        estimate.load.m,
+        (input_power * estimate.efficiency / motor.rated_power).to("dimensionless").m,
+        atol=1e-6,
+    )
+    assert_allclose(
+        estimate.efficiency.m,
+        motor.efficiency_at_load(estimate.load.m).m,
+        atol=1e-6,
+    )
+    # at ~77% load the interpolated efficiency is above the full-load value
+    assert estimate.efficiency.m > 0.930
+
+
+def test_efficiency_at_load_clamped():
+    motor = InductionMotor(
+        rated_power=Q_(40, "hp"),
+        efficiency_curve=[[0.25, 0.894], [0.50, 0.925], [1.00, 0.930]],
+    )
+    assert_allclose(motor.efficiency_at_load(0.1).m, 0.894)
+    assert_allclose(motor.efficiency_at_load(1.2).m, 0.930)
+
+
+def test_efficiency_and_curve_raises():
+    with pytest.raises(ValueError, match="either efficiency or efficiency_curve"):
+        InductionMotor(
+            rated_power=Q_(40, "hp"),
+            efficiency=0.93,
+            efficiency_curve=[[0.5, 0.925], [1.0, 0.93]],
+        )
+
+
+def test_method_auto_selection(motor_slip):
+    # speed only -> slip; current only -> current
+    assert motor_slip.estimate(speed=Q_(1770, "rpm")).method == "slip"
+    motor_current = InductionMotor(
+        rated_power=Q_(25, "hp"), rated_current=Q_(30, "ampere")
+    )
+    assert motor_current.estimate(current=25).method == "current"
+
+
+def test_insufficient_measurements_raises(motor):
+    with pytest.raises(ValueError, match="Insufficient measurements"):
+        motor.estimate()
+    with pytest.raises(ValueError, match="Unknown method"):
+        motor.estimate(current=37, method="torque")
+
+
+def test_poles_derivation():
+    for rpm, expected_poles in [(1780, 4), (3550, 2), (1180, 6), (880, 8)]:
+        motor = InductionMotor(
+            rated_power=Q_(40, "hp"),
+            rated_speed=Q_(rpm, "rpm"),
+            rated_frequency=Q_(60, "Hz"),
+        )
+        assert motor.poles == expected_poles
+
+
+def test_save_load_roundtrip(motor, tmp_path):
+    for file_name in ["motor.toml", "motor.json"]:
+        file = tmp_path / file_name
+        motor.save(file)
+        motor_loaded = InductionMotor.load(file)
+        assert_allclose(motor_loaded.rated_power.m, motor.rated_power.m)
+        assert_allclose(motor_loaded.rated_voltage.m, motor.rated_voltage.m)
+        assert_allclose(motor_loaded.rated_speed.m, motor.rated_speed.m)
+        assert_allclose(motor_loaded.efficiency.m, motor.efficiency.m)
+        assert motor_loaded.poles == motor.poles
+        estimate = motor_loaded.estimate(voltage=469.7, current=37, power_factor=0.763)
+        assert_allclose(estimate.load.m, 0.71608, rtol=1e-4)
+
+
+def test_save_load_efficiency_curve(tmp_path):
+    motor = InductionMotor(
+        rated_power=Q_(40, "hp"),
+        efficiency_curve=[[0.25, 0.894], [0.50, 0.925], [1.00, 0.930]],
+    )
+    file = tmp_path / "motor.toml"
+    motor.save(file)
+    motor_loaded = InductionMotor.load(file)
+    assert_allclose(motor_loaded.efficiency_curve, motor.efficiency_curve)
+
+
+@pytest.fixture
+def point_0():
+    fluid = dict(CarbonDioxide=0.76064, Nitrogen=0.23581, Oxygen=0.00284)
+    suc = State(p=Q_(1.839, "bar"), T=291.5, fluid=fluid)
+    disch = State(p=Q_(5.902, "bar"), T=405.7, fluid=fluid)
+    return Point(suc=suc, disch=disch, flow_v=1, speed=1, b=1, D=1)
+
+
+def test_compare_with_point(point_0):
+    # motor sized so that measurements give a driver power near the point's
+    # shaft power (~319.2 kW gas power, zero mechanical losses)
+    motor = InductionMotor(
+        rated_power=Q_(400, "kW"),
+        rated_voltage=Q_(4160, "volt"),
+        rated_current=Q_(60, "ampere"),
+        efficiency=0.95,
+    )
+    comparison = motor.compare(
+        point_0,
+        coupling_efficiency=0.98,
+        gearbox_efficiency=0.97,
+        input_power=Q_(350, "kW"),
+    )
+    assert isinstance(comparison, PowerComparison)
+    driver_power = 350e3 * 0.95
+    transmitted_power = driver_power * 0.98 * 0.97
+    assert_allclose(comparison.driver_power.m, driver_power)
+    assert_allclose(comparison.transmitted_power.m, transmitted_power)
+    assert_allclose(comparison.point_power.m, point_0.power_shaft.m)
+    assert_allclose(
+        comparison.delta.m, transmitted_power - point_0.power_shaft.m, rtol=1e-6
+    )
+    assert_allclose(
+        comparison.delta_ratio.m,
+        (transmitted_power - point_0.power_shaft.m) / point_0.power_shaft.m,
+        rtol=1e-6,
+    )
+    assert comparison.method == "input_power"
+
+
+def test_estimate_repr(motor):
+    estimate = motor.estimate(voltage=469.7, current=37, power_factor=0.763)
+    assert isinstance(estimate, MotorEstimate)
+    assert "input_power" in str(estimate)
+    assert "22.97 kW" in str(estimate)


### PR DESCRIPTION
## Summary

Adds a new `ccp/drivers/` subpackage to estimate the shaft power delivered by the compressor **driver** from field measurements, so it can be compared with the thermodynamic shaft power calculated by ccp (`Point.power_shaft`). Today ccp can only compare calculated power against expected power from design curves — both derived from p/T/flow; this enables a genuine cross-check against an independently measured quantity.

## What's included

- **`Driver`** base class (extensible to steam/gas turbines, torque meters later) with a `compare(point, coupling_efficiency=, gearbox_efficiency=, **measurements)` helper returning a `PowerComparison` (driver power, transmitted power at the compressor coupling, point shaft power, absolute and relative deltas).
- **`InductionMotor`** implementing the standard DOE/IEEE 112 field methods, auto-selected from the available measurements or forced with `method=`:
  - *Input power*: `sqrt(3)·V·I·PF` × efficiency — single full-load value or part-load efficiency curve (interpolated, load found iteratively);
  - *Line current*: `(I/I_r)·(V/V_r)`, warns below 50 % load where the relation becomes non-linear;
  - *Slip*: `slip/rated slip`, optional voltage compensation, synchronous speed from poles and frequency (poles derived from nameplate data when omitted).
- **VFD support**: `supply_frequency` rescales synchronous speed (slip power scaled by `f/f_rated`, constant V/f approximation); `vfd_efficiency` for measurements taken at the drive input.
- **Serialization** to toml/json via the existing `Serializable` mixin.
- **Units**: new electrical entries in the `check_units` dict (`voltage`, `current`, `power_factor`, `rated_frequency`/`supply_frequency` in Hz, `efficiency`). Full-name keys prevent the token scan from matching `power` (watt) for power factors and `frequency` (rad/s) for electrical frequencies.

The motor object holds only nameplate data and measurements are passed per call, so a single instance can later be applied row-wise to `Evaluation` time-series data (planned follow-up, along with app integration and other driver types).

## Usage

```python
import ccp
Q_ = ccp.Q_

motor = ccp.InductionMotor(
    rated_power=Q_(400, "kW"), rated_voltage=Q_(4160, "V"),
    rated_current=Q_(60, "A"), rated_speed=Q_(1780, "rpm"),
    rated_frequency=Q_(60, "Hz"), efficiency=0.95,
)
comparison = motor.compare(point, coupling_efficiency=0.98,
                           voltage=4100, current=52, power_factor=0.88)
print(comparison)   # driver power, point power, delta, delta ratio ...
```

## Test plan

- [x] 20 new tests in `ccp/tests/test_drivers.py` validating against the DOE fact sheet worked examples (22.9 kW input power case, 60 % slip-load case), unit-handling variants (hp/kV/rpm/percent vs bare SI floats), efficiency-curve iteration self-consistency, VFD scaling, save/load roundtrip, and `compare()` against a real `ccp.Point`
- [x] Doctests pass (`pytest --doctest-modules ccp/drivers/`)
- [x] Full suite: 179 passed (`pytest ccp/tests -n 4 --dist loadfile`)
- [x] Ruff format + check clean on new files

https://claude.ai/code/session_01WyMR1NRSvmSxaQxkP2xHfx