### PR TITLE
Fix module doctest failures

### DIFF
--- a/ccp/config/units.py
+++ b/ccp/config/units.py
@@ -143,21 +143,23 @@ def check_units(func):
     will be split into ['inlet', 'pressure'], and since we have the name 'pressure'
     in the dictionary mapped to 'Pa', we will automatically convert the value to
     this default unit.
-    For example:
-    >>> units = {
-    ... "L": "meter",
-    ... }
+    For example, 'L' is mapped to 'meter' in the units dictionary:
+
     >>> @check_units
     ... def foo(L=None):
     ...     print(L)
-    ...
-    If we call the function with the argument as a float:
+
+    If we call the function with the argument as a float, it is assumed to be
+    in the default unit:
+
     >>> foo(L=0.5)
-    0.5
+    0.5 meter
+
     If we call the function with a pint.Quantity object the value is automatically
     converted to the default:
+
     >>> foo(L=Q_(0.5, 'inches'))
-    0.0127
+    0.0127 meter
     """
 
     @wraps(func)

--- a/ccp/data_io/processing.py
+++ b/ccp/data_io/processing.py
@@ -11,7 +11,7 @@ def fluctuation(x):
 
     Parameters
     ----------
-    x : array-like
+    x : pandas.Series or numpy.ndarray
         Array of values.
 
     Returns
@@ -21,9 +21,10 @@ def fluctuation(x):
 
     Examples
     --------
-    >>> fluctuation([1, 2, 3, 4, 5])
-    80.0
-    >>> fluctuation([1, 1, 1, 1, 1])
+    >>> import pandas as pd
+    >>> float(fluctuation(pd.Series([1, 2, 3, 4, 5])))
+    133.33333333333334
+    >>> float(fluctuation(pd.Series([1, 1, 1, 1, 1])))
     0.0
     """
     if x.mean() == 0:
@@ -53,16 +54,12 @@ def fluctuation_data(df, window=3):
     >>> import pandas as pd
     >>> df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
     >>> fluctuation_data(df)
-         a    b
-    0  0.0  0.0
-    1  0.0  0.0
-    2  0.0  0.0
-    >>> df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
+           a     b
+    2  100.0  40.0
     >>> fluctuation_data(df, window=2)
-            a    b
-    0     0.0  0.0
-    1  1000.0  0.0
-    2  1000.0  0.0
+               a          b
+    1  66.666667  22.222222
+    2  40.000000  18.181818
     """
     fluctuation_df = (
         df.apply(pd.to_numeric)
@@ -98,17 +95,13 @@ def mean_data(df, window=3):
     --------
     >>> import pandas as pd
     >>> df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
-    >>> fluctuation_data(df)
+    >>> mean_data(df)
          a    b
-    0  0.0  0.0
-    1  0.0  0.0
-    2  0.0  0.0
-    >>> df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
-    >>> fluctuation_data(df, window=2)
-            a    b
-    0     0.0  0.0
-    1  1000.0  0.0
-    2  1000.0  0.0
+    2  2.0  5.0
+    >>> mean_data(df, window=2)
+         a    b
+    1  1.5  4.5
+    2  2.5  5.5
     """
     mean_df = (
         df.apply(pd.to_numeric)
@@ -180,6 +173,8 @@ def filter_data(
     >>> df = pd.DataFrame({'a': [1, 2, 3, 4, 4.01, 4.02], 'b': [4, 5, 6, 6.01, 6.02, 6.03]})
     >>> data_type = {'a': 'pressure', 'b': 'temperature'}
     >>> filter_data(df, window=3, data_type=data_type)
+          a     b  valid
+    5  4.01  6.02   True
     """
     fluctuation_df = fluctuation_data(df, window=window)
     mean_df = mean_data(df, window=window)

--- a/ccp/fo.py
+++ b/ccp/fo.py
@@ -54,7 +54,7 @@ class FlowOrifice:
         >>> state = ccp.State(p=p1, T=T1, fluid=fluid)
         >>> fo = ccp.FlowOrifice(state, delta_p, D, d)
         >>> fo.qm.to("kg/h")
-        <Quantity(36408.68715534, 'kilogram / hour')>
+        <Quantity(36408.6872, 'kilogram / hour')>
         """
         self.state = state
         self.delta_p = delta_p

--- a/ccp/impeller.py
+++ b/ccp/impeller.py
@@ -263,11 +263,13 @@ class CompareImpellerPlotFunction:
         --------
         >>> import ccp
         >>> imp = ccp.impeller_example()
-        >>> fig = imp.plot_head(
+        >>> other_imp = ccp.impeller_example()
+        >>> fig = imp.head_compare(
+        ...    other_imp,
         ...    flow_v=5.5,
         ...    speed=900,
         ...    flow_v_units='m³/h',
-        ...    head_units='j/kg',
+        ...    head_units='J/kg',
         ...    speed_units='RPM'
         ... )
 
@@ -1122,28 +1124,32 @@ class Impeller(Serializable):
     ):
         """Create points from dict object available in the ISIS platform.
 
-        The dict is in the following format:
-           head_curves_dict = [
-        {
-            "z": 11373,
-            "points": [
-                {"x": 94529, "y": 148.586},
-                {"x": 98641, "y": 148.211},
-                {"x": 101554, "y": 147.837},
-            ...]
-        ...,
-        },
-        ]
+        The dict is in the following format::
+
+            head_curves_dict = {
+                "CURVES": [
+                    {
+                        "z": 11373,
+                        "points": [
+                            {"x": 94529, "y": 148.586},
+                            {"x": 98641, "y": 148.211},
+                            {"x": 101554, "y": 147.837},
+                            ...
+                        ],
+                    },
+                    ...
+                ]
+            }
 
         Where z is the speed and each point is described as a dict with x and y
         pair where x is the flow and y is the head or eff.
 
         suc : ccp.State
             Suction state.
-        head_curve : dict
-            Dict with head/flow values.
-        eff_curve : dict
-            Dict with head/flow values.
+        head_curves : dict
+            Dict with head/flow curves.
+        eff_curves : dict
+            Dict with eff/flow curves.
         b : float, pint.Quantity
             Impeller width at the outer blade diameter (m).
         D : float, pint.Quantity
@@ -1161,6 +1167,30 @@ class Impeller(Serializable):
         Examples
         --------
         >>> import ccp
+        >>> head_curves_dict = {
+        ...    "CURVES": [
+        ...        {
+        ...            "z": 11373,
+        ...            "points": [
+        ...                {"x": 94529, "y": 148.586},
+        ...                {"x": 98641, "y": 148.211},
+        ...                {"x": 101554, "y": 147.837},
+        ...            ],
+        ...        },
+        ...    ]
+        ... }
+        >>> eff_curves_dict = {
+        ...    "CURVES": [
+        ...        {
+        ...            "z": 11373,
+        ...            "points": [
+        ...                {"x": 94529, "y": 82.767},
+        ...                {"x": 98641, "y": 82.520},
+        ...                {"x": 101554, "y": 82.270},
+        ...            ],
+        ...        },
+        ...    ]
+        ... }
         >>> composition_fd = dict(
         ...    n2=0.4,
         ...    co2=0.22,
@@ -1183,7 +1213,7 @@ class Impeller(Serializable):
         ...    number_of_points=6,
         ...    flow_units="kg/h",
         ...    head_units="kJ/kg",
-        ... )
+        ... )  # doctest: +SKIP
         """
         # change dict format from isis to that handled by the ccp method.
 
@@ -1421,7 +1451,9 @@ class Impeller(Serializable):
 
         Examples
         --------
-        >>> impeller.save_isis_txt("head.txt", parameter="head")
+        >>> import ccp
+        >>> imp = ccp.impeller_example()  # doctest: +SKIP
+        >>> imp.save_isis_txt("head.txt", parameter="head")  # doctest: +SKIP
         """
         # create dict with curves
 


### PR DESCRIPTION
## Summary

Fixes the 9 module doctests that fail whenever pytest collects doctests through `--doctest-modules` (the default in `pytest.ini`), e.g. when running the fast tier `pytest -m "not slow"`. CI runs `pytest ccp/tests`, which overrides `testpaths` and skips module doctests entirely — so these examples were never gated and most were broken since they were written (some since 2022).

## Root causes and fixes

**Examples wrong since authored (never executed):**
- `processing.py::fluctuation` — example passed a plain list to a function that calls `x.mean()`; now uses a `pd.Series` with the correct result (the old expected `80.0` was also wrong — `100*(max-min)/mean` of `[1..5]` is `133.33`).
- `processing.py::fluctuation_data` — expected outputs predated/never matched the rolling-window + `[window-1:]` implementation; replaced with actual outputs.
- `processing.py::mean_data` — examples were a copy-paste calling `fluctuation_data`; now call `mean_data` with correct outputs.
- `processing.py::filter_data` — example had no expected output; added it.
- `impeller.py::CompareImpellerPlotFunction.__call__` — example called `imp.plot_head(...)`, which never existed; the real API is `imp.head_compare(other_impeller, ...)`. Example now builds two example impellers and compares them (runs in ~18 s, same order as the existing `head_plot` doctest).
- `impeller.py::load_from_dict_isis` — example referenced undefined `head_curves_dict`/`eff_curves_dict`; they are now defined in the example. Also fixed the documented dict format, which was missing the `"CURVES"` key the code actually reads. The expensive `load_from_dict_isis` call itself is `+SKIP`.
- `impeller.py::save_isis_txt` — example referenced an undefined `impeller` variable; now a complete example, `+SKIP` since it writes a file.

**Doctest formatting bug:**
- `units.py::check_units` — a narrative line directly after the code block (no blank line) was parsed as expected output. Expected values were also missing the unit (`0.5` vs actual `0.5 meter`), and the example defined a local `units` dict that the decorator never uses (it closes over the module-level dictionary) — removed.

**Dependency drift:**
- `fo.py::FlowOrifice.__init__` — pint ≥ 0.24 rounds the magnitude in `Quantity.__repr__`; updated `36408.68715534` → `36408.6872`.

## Test plan

- [x] `uv run pytest --doctest-modules` on the four touched modules — all pass
- [x] `uv run pytest -m "not slow" -n auto --dist loadfile` — **148 passed, 0 failed** (previously 139 passed, 9 failed)
- [x] `ruff format --check` clean; `ruff check` unchanged vs main (27 pre-existing errors)

https://claude.ai/code/session_01WyMR1NRSvmSxaQxkP2xHfx