### PR TITLE
Distribute a ccp cookbook as an agent skill with a pip-shipped installer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,14 @@ This is **ccp** (Centrifugal Compressor Performance), a Python library for calcu
 - **Streamlit App**: Web interface located in `ccp/app/` with example files and pages
 - **Data I/O**: CSV/Excel reading utilities in `ccp/data_io/`
 
+### Agent Skill
+- `ccp/agent_skills/ccp/` holds the ccp cookbook (SKILL.md + recipe files) shipped
+  with the package and installed for AI coding agents via the `ccp-install-skill`
+  console script (`ccp/agent_skills/install.py`). Recipes must stay self-contained
+  (only link to files inside the folder) and their code examples are expected to
+  run against the current API — update them when the API changes
+  (tests: `ccp/tests/test_agent_skills.py`).
+
 ## Common Development Commands
 
 ### Package Manager

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include ccp/tests *
 recursive-include ccp/app *
+recursive-include ccp/agent_skills *.md

--- a/README.md
+++ b/README.md
@@ -56,6 +56,26 @@ imp.head_plot()
 imp.disch.T_plot()
 ```
 
+# Installation
+
+Install ccp with:
+
+```bash
+pip install ccp-performance
+```
+
+If you work with an AI coding agent (Claude Code, GitHub Copilot, Cursor, Codex), install the ccp agent skill so your agent knows how to build states, points and impellers and run performance analyses:
+
+```bash
+ccp-install-skill
+```
+
+The skill activates automatically whenever you ask your agent about centrifugal compressor performance with ccp. In Claude Code you can also invoke it explicitly:
+
+```
+/ccp create an impeller from these test points and convert the curves to the new suction condition
+```
+
 # Documentation 
 Access the documentation [here](https://ccp-centrifugal-compressor-performance.readthedocs.io/en/stable/).
 

--- a/ccp/agent_skills/__init__.py
+++ b/ccp/agent_skills/__init__.py
@@ -1,0 +1,3 @@
+from ccp.agent_skills.install import install_skill, uninstall_skill
+
+__all__ = ["install_skill", "uninstall_skill"]

--- a/ccp/agent_skills/ccp/SKILL.md
+++ b/ccp/agent_skills/ccp/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: ccp
+description: >-
+  Centrifugal compressor performance analysis with ccp (the ccp-performance
+  Python package). Use when computing thermodynamic states with REFPROP or
+  CoolProp (gas mixtures, equations of state), defining compressor operating
+  points (suction/discharge, polytropic head and efficiency, Schultz,
+  Huntington, Mallen-Saville, Sandberg-Colby methods), building impellers and
+  performance maps (head/efficiency/power curves, Engauge digitized curves),
+  converting curves to new suction conditions by similitude, checking ASME PTC
+  10 similarity limits (Mach, Reynolds, volume ratio), measuring flow with
+  orifice plates (ISO 5167), or evaluating operational data against expected
+  performance.
+license: Apache-2.0
+---
+
+# ccp Cookbook
+
+Concise recipes for centrifugal compressor performance analysis with ccp. Each file is self-contained — read only the recipe you need.
+
+> Skill version: development (repo checkout)
+
+| Recipe | File | Key Methods |
+|--------|------|-------------|
+| Thermodynamic states and fluids | [states_and_fluids.md](states_and_fluids.md) | `State`, `fluid_list`, `plot_envelope` |
+| Performance points | [points.md](points.md) | `Point`, `ccp.config.POLYTROPIC_METHOD` |
+| Impellers and performance maps | [impellers.md](impellers.md) | `Impeller`, `point`, `curve`, `head_plot`, `save`/`load` |
+| Importing curves from charts (Engauge) | [engauge_import.md](engauge_import.md) | `Impeller.load_from_engauge_csv` |
+| Converting to new suction conditions | [conversion.md](conversion.md) | `Impeller.convert_from`, `Point.convert_from` |
+| Similarity and ASME PTC 10 limits | [similarity.md](similarity.md) | `check_similarity`, `similarity_table`, `plot_similarity` |
+| Flow orifice metering | [flow_orifice.md](flow_orifice.md) | `FlowOrifice` |
+| Evaluating operational data | [evaluation.md](evaluation.md) | `Evaluation` |
+| Common gotchas | [gotchas.md](gotchas.md) | — |
+
+All values are SI internally: pressure in Pa, temperature in K, head in J/kg, power in W, volumetric flow in m³/s, mass flow in kg/s, speed in rad/s. Convert with `ccp.Q_(value, "unit")`, e.g. `ccp.Q_(7941, "RPM").to("rad/s").m`.
+
+If the recipes disagree with the installed ccp (missing methods, changed signatures), the skill may be stale — compare the version above with `python -c "import ccp; print(ccp.__version__)"` and re-run `ccp-install-skill` after upgrading.

--- a/ccp/agent_skills/ccp/conversion.md
+++ b/ccp/agent_skills/ccp/conversion.md
@@ -1,0 +1,45 @@
+# Converting to New Suction Conditions
+
+Source: `docs/user_guide/tutorial.ipynb`, `ccp/impeller.py`, `ccp/point.py`
+
+Performance maps are measured (or specified) at one suction condition. To predict performance with a different gas, pressure or temperature, convert the map using similitude: for each point, volume ratio is kept constant and a new speed and discharge state are calculated.
+
+## Convert an impeller
+
+```python
+import ccp
+
+Q_ = ccp.Q_
+
+imp = ccp.impeller_example()
+
+new_fluid = {"co2": 0.7, "n2": 0.3}
+new_suc = ccp.State(p=Q_(30, "bar"), T=Q_(40, "degC"), fluid=new_fluid)
+
+imp_conv = ccp.Impeller.convert_from(imp, suc=new_suc)
+```
+
+- The converted impeller has new speeds computed from similarity. To keep the original speed values instead: `ccp.Impeller.convert_from(imp, suc=new_suc, speed="same")`.
+- A **list** of impellers can be passed; the one with suction speed of sound closest to `new_suc` is used.
+- `method="gp_surrogate"` fits a Gaussian-process surrogate `psi, eff = f(phi, M_tip)` over the points of all supplied maps instead of similarity rescaling — useful with several measured maps or dense/supercritical suctions (requires scikit-learn).
+
+The converted impeller has all the usual methods:
+
+```python
+imp_conv.head_plot(similarity=True)   # shade points outside PTC 10 similarity limits
+imp_conv.disch.p_plot(speed_units="RPM")
+imp.head_compare(imp_conv)            # original vs converted on one figure
+```
+
+## Convert a single point
+
+```python
+p0 = imp.points[0]
+p_conv = ccp.Point.convert_from(p0, suc=new_suc, find="speed")
+```
+
+- `find="speed"` (default): keep volume ratio, solve for the new speed.
+- `find="volume_ratio"`: impose `speed=...`, solve for the new volume ratio.
+- `reynolds_correction=True` applies the ASME PTC 10 (2022) Reynolds correction to efficiency, head and flow coefficients during conversion (`"ptc1997"` selects the 1997 correction).
+
+The converted point records how far it moved from the original: `p_conv.phi_ratio`, `p_conv.psi_ratio`, `p_conv.volume_ratio_ratio`, `p_conv.reynolds_ratio`, `p_conv.mach_diff` — see the similarity recipe for the acceptable limits.

--- a/ccp/agent_skills/ccp/engauge_import.md
+++ b/ccp/agent_skills/ccp/engauge_import.md
@@ -1,0 +1,56 @@
+# Importing Curves from Charts (Engauge)
+
+Source: `docs/user_guide/engauge.md`, `docs/user_guide/evaluation_tutorial.ipynb`, `ccp/impeller.py`
+
+Performance maps from datasheets are usually pictures. Digitize them with [Engauge Digitizer](https://markummitchell.github.io/engauge-digitizer/) and load the exported CSV files with `Impeller.load_from_engauge_csv`.
+
+## CSV files expected
+
+For a `curve_name` of `"sec1"`, place in `curve_path`:
+
+- `sec1-head.csv` — head vs. flow, one curve per speed
+- `sec1-eff.csv` — efficiency vs. flow
+
+Optionally also `sec1-power.csv`, `sec1-power_shaft.csv`, `sec1-pressure_ratio.csv`, `sec1-disch_T.csv`, `sec1-disch_p.csv`.
+
+In Engauge, name each digitized curve with its speed value (e.g. `10322` for 10322 RPM; for shaft power curves, `10322, 82` also records power losses of 82 in `power_losses_units`) and export with "Raw X's and Y's, one curve on each line".
+
+## Load
+
+```python
+import ccp
+from pathlib import Path
+
+Q_ = ccp.Q_
+
+data_dir = Path(ccp.__file__).parent / "tests/data"
+
+suc = ccp.State(
+    p=Q_(4.08, "bar"),
+    T=Q_(33.6, "degC"),
+    fluid={"methane": 58.976, "co2": 36.605, "ethane": 3.099,
+           "propane": 0.6, "n2": 0.55, "n-butane": 0.08, "i-butane": 0.05,
+           "n-pentane": 0.01, "i-pentane": 0.01, "h2s": 0.02},
+)
+
+imp = ccp.Impeller.load_from_engauge_csv(
+    suc=suc,
+    curve_name="lp-sec1-caso-a",
+    curve_path=data_dir,
+    b=Q_(5.7, "mm"),          # impeller width
+    D=Q_(550, "mm"),          # impeller diameter
+    flow_units="m³/h",        # units used when digitizing
+    head_units="kJ/kg",
+    speed_units="RPM",
+    number_of_points=7,       # points interpolated per curve
+)
+```
+
+Key arguments:
+
+- `flow_units`, `head_units`, `eff_units`, `power_units`, `speed_units`, ...: the units of the axes as digitized. If head was in meters, use `head_units="m*g0"`.
+- `flow_units_head`, `flow_units_eff`, ...: per-curve flow units when the charts use different flow axes.
+- `number_of_points`: how many points to interpolate along each digitized curve.
+- `b`, `D`: impeller width and diameter — required for meaningful `phi`/`psi`/Mach/Reynolds and for conversions.
+
+The result is a normal `Impeller` — see the impellers recipe for plots and interpolation, and the conversion recipe to move it to other suction conditions.

--- a/ccp/agent_skills/ccp/evaluation.md
+++ b/ccp/agent_skills/ccp/evaluation.md
@@ -1,0 +1,88 @@
+# Evaluating Operational Data
+
+Source: `docs/user_guide/evaluation_tutorial.ipynb`, `ccp/evaluation.py`
+
+`Evaluation` compares plant operational data (a pandas DataFrame of pressures, temperatures, flows and speeds over time) against reference performance curves, computing for each sample the expected performance and the deviation from it.
+
+## Run an evaluation
+
+```python
+import pandas as pd
+from pathlib import Path
+import ccp
+
+Q_ = ccp.Q_
+data_path = Path(ccp.__file__).parent / "tests/data"
+
+df = pd.read_parquet(data_path / "data.parquet")
+# df columns: ps, Ts, pd, Td, flow_v (or delta_p + p_downstream), speed
+
+operation_fluid = {"methane": 44.04, "co2": 51.55, "ethane": 3.18,
+                   "propane": 0.66, "n-butane": 0.15, "i-butane": 0.05,
+                   "n-pentane": 0.03, "i-pentane": 0.02, "n2": 0.25, "h2s": 0.06}
+
+# Reference impeller (e.g. loaded from digitized curves — see the engauge recipe)
+test_fluid = {"methane": 58.976, "co2": 36.605, "ethane": 3.099,
+              "propane": 0.6, "n-butane": 0.08, "i-butane": 0.05,
+              "n-pentane": 0.01, "i-pentane": 0.01, "n2": 0.55, "h2s": 0.02}
+suc_a = ccp.State(p=Q_(4, "bar"), T=Q_(40, "degC"), fluid=test_fluid)
+imp_a = ccp.Impeller.load_from_engauge_csv(
+    suc=suc_a, curve_name="eval-lp-sec1-caso-a", curve_path=data_path,
+    flow_units="m³/h", head_units="kJ/kg", number_of_points=4,
+)
+
+evaluation = ccp.Evaluation(
+    data=df,
+    operation_fluid=operation_fluid,
+    data_units={
+        "ps": "bar", "Ts": "degC", "pd": "bar", "Td": "degC",
+        "flow_v": "m³/s", "speed": "RPM",
+    },
+    impellers=[imp_a],     # reference curves; converted to each operating suction
+    n_clusters=2,          # cluster operating conditions to reuse conversions
+)
+```
+
+## Results
+
+`evaluation.df` is the input DataFrame plus computed columns:
+
+- `eff`, `head`, `power`, `p_disch`: actual values calculated from the data (SI units, except `p_disch` in bar)
+- `expected_eff`, `expected_head`, `expected_power`, `expected_p_disch`: from the reference curves converted to the sample's suction condition
+- `delta_eff`: `(eff - expected_eff) * 100` — difference in efficiency percentage points (positive = better than expected)
+- `delta_head`, `delta_power`, `delta_p_disch`: relative deviation from the expected value in %
+
+```python
+evaluation.df["delta_eff"].mean()
+```
+
+## Flow from orifice delta-p
+
+If the data has `delta_p` (and optionally `p_downstream`) instead of `flow_v`, pass the orifice geometry and ccp computes the flow internally:
+
+```python
+df_delta_p = pd.read_parquet(data_path / "data_delta_p.parquet")
+
+evaluation = ccp.Evaluation(
+    data=df_delta_p,
+    operation_fluid=operation_fluid,
+    data_units={"ps": "bar", "Ts": "degC", "pd": "bar", "Td": "degC",
+                "delta_p": "mmH2O", "p_downstream": "bar", "speed": "RPM"},
+    impellers=[imp_a],
+    D=Q_(0.590550, "m"),   # pipe diameter
+    d=Q_(0.366130, "m"),   # orifice diameter
+    tappings="flange",
+    n_clusters=2,
+)
+```
+
+## Save / load
+
+```python
+evaluation.save("run1.ccp_eval")
+loaded = ccp.Evaluation.load("run1.ccp_eval")
+```
+
+## Manual control
+
+`calculate_points=False` creates the object without processing; then call `evaluation.calculate_points(df, drop_invalid_values=True)` on any subset.

--- a/ccp/agent_skills/ccp/flow_orifice.md
+++ b/ccp/agent_skills/ccp/flow_orifice.md
@@ -1,0 +1,32 @@
+# Flow Orifice Metering
+
+Source: `ccp/fo.py`
+
+`FlowOrifice` calculates mass flow from the differential pressure across an orifice plate (ISO 5167 flow coefficient correlation), which is how flow is usually measured around a compressor.
+
+## Calculate flow from delta-p
+
+```python
+import ccp
+
+Q_ = ccp.Q_
+
+fluid = {"R134A": 0.018, "R1234ZE": 31.254, "N2": 67.588, "o2": 1.14}
+state = ccp.State(p=Q_(10, "bar"), T=Q_(40, "degC"), fluid=fluid)
+
+fo = ccp.FlowOrifice(
+    state,
+    delta_p=Q_(0.1, "bar"),   # pressure drop across the orifice
+    D=Q_(250, "mm"),          # pipe internal diameter
+    d=Q_(170, "mm"),          # orifice bore diameter
+    tappings="flange",        # "flange" (default), "corner" or "D D/2"
+)
+
+fo.flow_m.to("kg/h")   # mass flow (also available as fo.qm)
+fo.flow_v              # volumetric flow at the state conditions, m³/s
+```
+
+- `state` is the fluid state at the orifice. By default it is taken as the **upstream** state; pass `state_upstream=False` if the measurement is downstream of the plate (ccp then adds `delta_p` back).
+- The discharge coefficient is iterated on the Reynolds number automatically.
+
+Use the resulting `flow_m`/`flow_v` to build performance points (see the points recipe). The `Evaluation` class accepts `delta_p` data directly and does this internally (see the evaluation recipe).

--- a/ccp/agent_skills/ccp/gotchas.md
+++ b/ccp/agent_skills/ccp/gotchas.md
@@ -1,0 +1,45 @@
+# Common Gotchas
+
+## Units
+
+- **Bare floats are SI**: `T=300` is kelvin, `p=101325` is Pa, `speed=900` is rad/s, `flow_v=5.5` is m³/s. For anything else use pint: `ccp.Q_(7941, "RPM")`, `Q_(40, "degC")`, `Q_(30, "bar")`, `Q_(34203.6, "kg/hr")`.
+- Results are pint quantities: convert with `.to("kJ/kg")`, take the magnitude with `.m` or `.magnitude`. Never divide by 1000 by hand.
+- Head in meters from a datasheet: multiply by g0 — `head_units="m*g0"` in `load_from_engauge_csv`, or `Q_(1500, "m*g0")`.
+- Efficiency is a fraction (0.75), not a percent.
+
+## States and fluids
+
+- `State` properties are **methods**: `state.T()`, `state.rho()`, not attributes. Pass units to convert: `state.p("bar")`.
+- The `fluid` dict uses **mole fractions** and is normalized automatically (percentages work). Repeated aliases that resolve to the same component (e.g. `"butane"` and `"n-butane"`) raise an error.
+- Creating a `State` requires keyword arguments, including `fluid=`.
+- Without REFPROP installed, ccp warns and falls back to CoolProp's `HEOS` backend — same API, slightly different property values. `ccp.config.EOS` controls the default.
+
+## Points and impellers
+
+- `b` (impeller width) and `D` (impeller diameter) have defaults (0.005 m / 0.5 m); head/eff/power are unaffected, but `phi`, `psi`, Mach, Reynolds — and therefore conversions and similarity checks — need the real geometry.
+- A `Point` needs a *sufficient* argument combination (e.g. `suc + disch + speed + flow`); otherwise `ValueError` is raised listing what it received. Efficiency outside 0.3–1.0 is treated as out of range.
+- `Impeller` deep-copies its points: changing `point0` afterwards does not change `imp.points[0]`.
+- `Impeller.point(flow_v=..., speed=...)` interpolates and extrapolates without complaint — check the map range (`imp.flow_v`, `imp.speed`) or the returned point's `_extrapolated` flag.
+- Speed grouping into curves is exact: points on the "same" curve must have identical speed values.
+
+## Plotting
+
+- All plot methods return a plotly `Figure` — call `fig.show()` to display or `fig.write_image("f.png")` to save.
+- Default plot units are SI (flow in m³/s, speed in rad/s); pass `flow_v_units="m³/h"`, `speed_units="RPM"`, `head_units="kJ/kg"`, etc. for readable axes.
+- `_plot` methods accept `flow_v`/`flow_m` and `speed` to highlight an interpolated point/curve; these arguments are in SI unless given as `Q_`.
+
+## Multiprocessing
+
+- ccp parallelizes impeller construction, conversion and evaluation internally with a **forkserver/spawn** multiprocessing context (`ccp/parallel.py`). Workers re-import your `__main__` module, so a plain script that builds an `Impeller` (including `load_from_engauge_csv`), calls `Impeller.convert_from` or creates an `Evaluation` at module top level dies with `RuntimeError: An attempt has been made to start a new process before the current process has finished its bootstrapping phase`. Put the code under a guard:
+
+```python
+if __name__ == "__main__":
+    imp = ccp.Impeller.load_from_engauge_csv(...)
+```
+
+- Interactive sessions (IPython, Jupyter, `python` REPL) are not affected.
+
+## Performance
+
+- REFPROP flash calculations dominate runtime. Creating points (especially `Impeller` construction and `convert_from`) takes seconds — expect map conversions to take minutes for many curves; ccp parallelizes conversions internally with multiprocessing.
+- Prefer `state.update(...)` over creating new `State` objects in loops.

--- a/ccp/agent_skills/ccp/impellers.md
+++ b/ccp/agent_skills/ccp/impellers.md
@@ -1,0 +1,95 @@
+# Impellers and Performance Maps
+
+Source: `docs/user_guide/tutorial.ipynb`, `ccp/impeller.py`
+
+An `Impeller` is a container of `Point` objects. Points with the same speed are grouped into `Curve` objects, forming the performance map.
+
+## Build from points
+
+```python
+import ccp
+
+Q_ = ccp.Q_
+
+fluid = {"CarbonDioxide": 0.79585, "Nitrogen": 0.16751, "Oxygen": 0.02903}
+suc = ccp.State(fluid=fluid, p=Q_(3, "bar"), T=300)
+
+# see the points recipe for the ways to define a Point
+point0 = ccp.Point(
+    suc=suc,
+    disch=ccp.State(fluid=fluid, p=Q_(7.255, "bar"), T=391.1),
+    speed=Q_(7941, "RPM"),
+    flow_m=Q_(34203.6, "kg/hr"),
+    b=0.0285,
+    D=0.365,
+)
+point1 = ccp.Point(
+    suc=suc,
+    disch=ccp.State(fluid=fluid, p=Q_(6.754, "bar"), T=382.1),
+    speed=Q_(7941, "RPM"),
+    flow_m=Q_(36204.8, "kg/hr"),
+    b=0.0285,
+    D=0.365,
+)
+
+imp = ccp.Impeller([point0, point1])
+```
+
+A ready-made example (natural gas + CO2 map loaded from digitized curves) is available for experimenting:
+
+```python
+imp = ccp.impeller_example()
+```
+
+## Interpolate a point or a curve anywhere in the map
+
+```python
+p = imp.point(flow_v=5.5, speed=900)        # SI: m³/s, rad/s
+p = imp.point(flow_m=60, speed=Q_(8594, "RPM"))
+c = imp.curve(speed=900)                    # a ccp.Curve at that speed
+```
+
+Speeds outside the mapped range are extrapolated (the returned objects carry an `_extrapolated` flag).
+
+## Access data
+
+```python
+imp.points               # list of all points
+imp.curves               # list of ccp.Curve (one per speed)
+c = imp.curves[0]
+c.speed                  # curve speed, rad/s
+c.flow_v, c.head, c.eff, c.power   # arrays (pint) along the curve
+c.disch.p()              # discharge pressure array along the curve
+c.head_interpolated(5.5) # interpolate head at a flow_v (m³/s) on this curve
+```
+
+## Plotting
+
+Every result has a `<attr>_plot` method returning a plotly Figure. Passing `flow_v` and `speed` also draws the interpolated curve and marks the point:
+
+```python
+fig = imp.head_plot(flow_v=5.5, speed=900)
+fig = imp.eff_plot(speed_units="RPM", flow_v_units="m³/h")
+fig = imp.power_plot()
+fig = imp.disch.T_plot(flow_v=5.5, speed=900)   # discharge temperature
+fig = imp.disch.p_plot(speed_units="RPM")       # discharge pressure
+fig = imp.disch.rho_plot(
+    flow_v=Q_(20000, "m³/h"),
+    speed=Q_(8594, "RPM"),
+    flow_v_units="m³/h",
+    speed_units="RPM",
+    rho_units="g/cm³",
+)
+```
+
+Available on `imp`: `head_plot`, `eff_plot`, `power_plot`, `power_shaft_plot`, `torque_plot`, `phi_plot`, `psi_plot`, and `disch.p_plot`, `disch.T_plot`, `disch.h_plot`, `disch.s_plot`, `disch.rho_plot`. Unit keywords follow the pattern `<attr>_units`, plus `flow_v_units`/`flow_m_units` and `speed_units`.
+
+To compare two impellers (e.g. original vs. converted): `imp.head_compare(other_imp)`, `imp.eff_compare(other_imp)`, etc.
+
+## Save / load / export
+
+```python
+imp.save("map.toml")                 # .toml or .json
+imp2 = ccp.Impeller.load("map.toml")
+imp.export_to_excel("map.xlsx")      # one sheet per curve
+```

--- a/ccp/agent_skills/ccp/points.md
+++ b/ccp/agent_skills/ccp/points.md
@@ -1,0 +1,93 @@
+# Performance Points
+
+Source: `docs/user_guide/tutorial.ipynb`, `docs/user_guide/polytropic_methods.ipynb`, `ccp/point.py`
+
+A `Point` is one operating point of the compressor map. Give it a sufficient combination of arguments and ccp solves for everything else (head, efficiency, power, discharge state, ...).
+
+## From suction + discharge states (test data)
+
+```python
+import ccp
+
+Q_ = ccp.Q_
+
+fluid = {"CarbonDioxide": 0.79585, "Nitrogen": 0.16751, "Oxygen": 0.02903}
+suc = ccp.State(fluid=fluid, p=Q_(3, "bar"), T=300)
+disch = ccp.State(fluid=fluid, p=Q_(7.255, "bar"), T=391.1)
+
+point = ccp.Point(
+    suc=suc,
+    disch=disch,
+    speed=Q_(7941, "RPM"),
+    flow_m=Q_(34203.6, "kg/hr"),
+    b=0.0285,   # impeller width at outer blade diameter (m)
+    D=0.365,    # impeller outer diameter (m)
+)
+```
+
+## Other sufficient combinations
+
+Always with `speed`, one flow (`flow_v` or `flow_m`), `b` and `D`:
+
+- `suc`, `disch` — measured suction and discharge states
+- `suc`, `disch_p`, `eff` — design data with discharge pressure and efficiency
+- `suc`, `head`, `eff` — design data with head (J/kg) and efficiency
+- `suc`, `head`, `power` — head and gas power (W)
+- `suc`, `head`, `power_shaft`, `power_losses` — with shaft power and mechanical losses
+- `suc`, `eff`, `volume_ratio` — used internally for conversions
+- `suc`, `pressure_ratio`, `disch_T` — pressure ratio and discharge temperature
+
+Optional extras: `power_shaft`, `power_losses`, `torque`, `surface_roughness`, and casing heat-loss inputs (`casing_area`, `casing_temperature`, `ambient_temperature`, `convection_constant`).
+
+## Results
+
+```python
+point.head          # polytropic head, J/kg
+point.eff           # polytropic efficiency, dimensionless
+point.power         # gas power, W
+point.power_shaft   # shaft power, W (includes losses)
+point.disch.T()     # solved discharge state (a ccp.State)
+point.flow_v        # m³/s
+point.phi           # flow coefficient
+point.psi           # head coefficient
+point.volume_ratio  # suc.v() / disch.v()
+point.mach          # impeller tip Mach number
+point.reynolds      # Reynolds number
+```
+
+All are pint quantities: convert with `.to("kJ/kg")`, take magnitude with `.m`.
+
+`print(point)` shows a summary table. `point.save("point.toml")` / `ccp.Point.load("point.toml")` persist a point (`.toml` or `.json`).
+
+## Polytropic methods
+
+The default head/efficiency calculation is Schultz (`"schultz"`, as in ASME PTC 10). Change globally or per point:
+
+```python
+ccp.config.POLYTROPIC_METHOD = "huntington"   # global — affects every Point created afterwards
+ccp.config.POLYTROPIC_METHOD = "schultz"      # restore the default when done
+
+# or per point, leaving the global default alone:
+point = ccp.Point(
+    suc=suc,
+    disch=disch,
+    speed=Q_(7941, "RPM"),
+    flow_m=Q_(34203.6, "kg/hr"),
+    b=0.0285,
+    D=0.365,
+    polytropic_method="sandberg_colby",
+)
+```
+
+Options: `"schultz"`, `"huntington"` (3-point, most accurate vs. reference integration, slower), `"mallen_saville"`, `"sandberg_colby"`, `"sandberg_colby_multistep"`.
+
+The individual functions are also available, taking suction and discharge states:
+
+```python
+ccp.point.head_pol_schultz(suc, disch)         # and eff_pol_schultz
+ccp.point.head_pol_huntington(suc, disch)      # and eff_pol_huntington
+ccp.point.head_pol_mallen_saville(suc, disch)
+ccp.point.head_pol_sandberg_colby(suc, disch)
+ccp.point.head_reference_2017(suc, disch)      # reference integration → (head, eff)
+ccp.point.head_isentropic(suc, disch)          # and eff_isentropic
+```

--- a/ccp/agent_skills/ccp/similarity.md
+++ b/ccp/agent_skills/ccp/similarity.md
@@ -1,0 +1,58 @@
+# Similarity and ASME PTC 10 Limits
+
+Source: `ccp/similarity.py`, `ccp/point.py`
+
+When a point is converted to another suction condition (see the conversion recipe), ASME PTC 10 defines how far the flow coefficient, volume ratio, Mach and Reynolds numbers may deviate for the test still to represent the specified operation.
+
+## Quick check between two points
+
+```python
+import ccp
+
+imp = ccp.impeller_example()
+p_sp = imp.points[0]          # specified (reference) point
+p_t = imp.points[1]           # test point
+
+print(ccp.check_similarity(p_sp, p_t))
+```
+
+`check_similarity` returns a printable report with, line by line: flow coefficient ratio (limits 0.96–1.04), volume ratio ratio (limits 0.95–1.05), Mach number difference and Reynolds number ratio with their PTC 10 limits (which depend on the specified point's Mach and Reynolds values).
+
+## Per-point similarity results
+
+Converted points carry their deviation from the original point:
+
+```python
+Q_ = ccp.Q_
+
+new_suc = ccp.State(p=Q_(5, "bar"), T=Q_(45, "degC"), fluid=p_sp.suc.fluid)
+p_conv = ccp.Point.convert_from(p_sp, suc=new_suc)  # see the conversion recipe
+
+p_conv.phi_ratio           # flow coefficient ratio (target: 0.96–1.04)
+p_conv.volume_ratio_ratio  # volume ratio ratio (target: 0.95–1.05)
+p_conv.mach_diff           # Mach difference vs. PTC 10 figure 3.2 limits
+p_conv.reynolds_ratio      # Reynolds ratio vs. PTC 10 figure 3.3 limits
+```
+
+The PTC 10 ranges for a given point:
+
+```python
+p_conv.mach_limits()       # {"lower": ..., "upper": ..., "within_limits": bool}
+p_conv.reynolds_limits()
+```
+
+## Plots and tables
+
+```python
+fig = p_conv.plot_mach()         # point and allowable Mach envelope
+fig = p_conv.plot_reynolds()     # point and allowable Reynolds envelope
+fig = p_conv.plot_similarity()   # combined view with table
+fig = p_conv.similarity_table()  # plotly table with the values and limits
+```
+
+On impeller plots, `similarity=True` marks points that fall outside the limits:
+
+```python
+imp_conv = ccp.Impeller.convert_from(imp, suc=new_suc, speed="same")
+imp_conv.head_plot(similarity=True)
+```

--- a/ccp/agent_skills/ccp/states_and_fluids.md
+++ b/ccp/agent_skills/ccp/states_and_fluids.md
@@ -1,0 +1,65 @@
+# Thermodynamic States and Fluids
+
+Source: `docs/user_guide/tutorial.ipynb`, `ccp/state.py`, `ccp/config/fluids.py`
+
+## Create a State
+
+```python
+import ccp
+
+Q_ = ccp.Q_
+
+fluid = {
+    "CarbonDioxide": 0.79585,
+    "Nitrogen": 0.16751,
+    "Oxygen": 0.02903,
+}
+
+suc = ccp.State(fluid=fluid, p=Q_(3, "bar"), T=300)
+```
+
+- `fluid` (dict, required keyword): component name → mole fraction. Fractions are normalized automatically, so percentages (summing to 100) work as well.
+- Any **two** of `p`, `T`, `h`, `s`, `rho` define the state (e.g. `ccp.State(fluid=fluid, h=..., s=...)` for an isentropic discharge).
+- Plain floats are SI: `T=300` means 300 K, `p=101325` means Pa. Use `Q_` for anything else: `T=Q_(40, "degC")`, `p=Q_(30, "bar")`.
+- `EOS` (str, optional): `"REFPROP"` (default when available), `"HEOS"` (CoolProp), `"PR"` or `"SRK"`. The global default is `ccp.config.EOS`; ccp automatically falls back to `"HEOS"` when REFPROP is not installed.
+- `phase` (str, optional): skip the phase flash by declaring `"gas"`, `"liquid"`, `"supercritical"`, etc.
+
+## Fluid names
+
+Names are case-insensitive and common aliases are accepted: `"co2"`, `"n2"`, `"o2"`, `"h2s"`, `"methane"`, `"propane"`, `"i-butane"`, `"n-pentane"`, ... The full table is in `ccp.fluid_list` (maps CoolProp names to their accepted aliases). Mixing aliases that resolve to the same component (e.g. `"butane"` and `"n-butane"`) raises an error.
+
+## Properties
+
+All properties are methods that return pint quantities in SI; pass a unit string to convert:
+
+```python
+suc.T()            # Quantity in kelvin
+suc.p("bar")       # Quantity in bar
+suc.rho()          # kg/m³
+suc.h()            # J/kg
+suc.s()            # J/(kg·K)
+suc.z()            # compressibility factor (dimensionless)
+suc.molar_mass("g/mol")
+suc.cp()           # J/(kg·K)
+suc.cv()
+suc.speed_sound()  # m/s
+suc.viscosity()    # Pa·s
+suc.kinematic_viscosity()
+suc.v()            # specific volume m³/kg
+suc.p_critical(), suc.T_critical()
+```
+
+Take the magnitude with `.m` or `.magnitude`: `suc.rho().m`.
+
+## Update a state in place
+
+```python
+suc.update(p=Q_(5, "bar"), T=Q_(50, "degC"))
+```
+
+## Phase envelope
+
+```python
+fig = suc.plot_envelope()   # plotly Figure with the P-T envelope
+fig = suc.plot_point(fig=fig)  # mark the state point on the envelope
+```

--- a/ccp/agent_skills/install.py
+++ b/ccp/agent_skills/install.py
@@ -1,0 +1,210 @@
+"""Install the ccp cookbook as an agent skill for AI coding agents.
+
+The skill follows the Agent Skills open standard (https://agentskills.io):
+a folder with a SKILL.md entry point plus self-contained recipe files, read
+on demand by skills-compatible agents such as Claude Code, GitHub Copilot,
+Cursor and Codex.
+
+Run ``ccp-install-skill`` after installing or upgrading ccp to copy the
+skill into the personal skills directory of each agent found on this
+machine, or ``ccp-install-skill --project`` to install it into the current
+project so it is shared with anyone working on the repository.
+"""
+
+import argparse
+import shutil
+import sys
+from importlib import metadata, resources
+from pathlib import Path
+
+SKILL_NAME = "ccp"
+
+VERSION_PLACEHOLDER = "> Skill version: development (repo checkout)"
+
+AGENTS = {
+    "claude": {
+        "detect": Path("~/.claude"),
+        "user": Path("~/.claude/skills"),
+        "project": Path(".claude/skills"),
+    },
+    "copilot": {
+        "detect": Path("~/.copilot"),
+        "user": Path("~/.copilot/skills"),
+        "project": Path(".github/skills"),
+    },
+    "cursor": {
+        "detect": Path("~/.cursor"),
+        "user": Path("~/.cursor/skills"),
+        "project": Path(".cursor/skills"),
+    },
+    "codex": {
+        "detect": Path("~/.codex"),
+        "user": Path("~/.codex/skills"),
+        "project": Path(".codex/skills"),
+    },
+}
+
+
+def ccp_version():
+    """Return the installed ccp-performance version.
+
+    Falls back to importing ccp when package metadata is unavailable
+    (e.g. running from a plain repository checkout).
+    """
+    try:
+        return metadata.version("ccp-performance")
+    except metadata.PackageNotFoundError:
+        import ccp
+
+        return ccp.__version__
+
+
+def install_skill(skills_dir):
+    """Copy the skill folder into ``skills_dir`` and stamp the ccp version.
+
+    Parameters
+    ----------
+    skills_dir : str or pathlib.Path
+        Directory that holds skills (e.g. ``~/.claude/skills``). The skill
+        is written to ``<skills_dir>/ccp``, replacing any
+        previous installation.
+
+    Returns
+    -------
+    target : pathlib.Path
+        Path of the installed skill folder.
+    """
+    skills_dir = Path(skills_dir).expanduser()
+    target = skills_dir / SKILL_NAME
+    source = resources.files("ccp") / "agent_skills" / SKILL_NAME
+
+    if target.exists():
+        shutil.rmtree(target)
+
+    with resources.as_file(source) as source_path:
+        shutil.copytree(source_path, target)
+
+    version = ccp_version()
+    skill_md = target / "SKILL.md"
+    stamp = (
+        f"> Skill version: ccp {version} — if "
+        f'`python -c "import ccp; print(ccp.__version__)"` reports a '
+        f"different version, re-run `ccp-install-skill` to refresh this skill."
+    )
+    skill_md.write_text(
+        skill_md.read_text(encoding="utf-8").replace(VERSION_PLACEHOLDER, stamp),
+        encoding="utf-8",
+    )
+
+    return target
+
+
+def uninstall_skill(skills_dir):
+    """Remove the skill folder from ``skills_dir``.
+
+    Parameters
+    ----------
+    skills_dir : str or pathlib.Path
+        Directory that holds skills (e.g. ``~/.claude/skills``).
+
+    Returns
+    -------
+    removed : bool
+        True if a skill folder was found and removed.
+    """
+    target = Path(skills_dir).expanduser() / SKILL_NAME
+    if target.exists():
+        shutil.rmtree(target)
+        return True
+    return False
+
+
+def detected_agents():
+    """Return the names of agents whose config directory exists in HOME."""
+    return [
+        name for name, spec in AGENTS.items() if spec["detect"].expanduser().exists()
+    ]
+
+
+def resolve_skills_dirs(agent_names, project, dest):
+    """Map the CLI targeting options to a list of skills directories."""
+    if dest is not None:
+        return [Path(dest)]
+
+    if not agent_names:
+        if project:
+            return [AGENTS["claude"]["project"]]
+        agent_names = detected_agents()
+
+    scope = "project" if project else "user"
+    return [AGENTS[name][scope] for name in agent_names]
+
+
+def main(argv=None):
+    """Run the ccp-install-skill command line interface."""
+    parser = argparse.ArgumentParser(
+        prog="ccp-install-skill",
+        description=(
+            "Install the ccp cookbook as an agent skill for AI coding agents "
+            "(Claude Code, GitHub Copilot, Cursor, Codex). With no options, "
+            "installs to the personal skills directory of every agent "
+            "detected on this machine."
+        ),
+    )
+    parser.add_argument(
+        "--agent",
+        action="append",
+        choices=[*AGENTS, "all"],
+        help=(
+            "install for a specific agent instead of auto-detecting "
+            "(repeat for several agents; 'all' selects every known agent)"
+        ),
+    )
+    parser.add_argument(
+        "--project",
+        action="store_true",
+        help=(
+            "install into the current project instead of the home directory "
+            "(default .claude/skills/, which Claude Code, Copilot and Cursor "
+            "all read; combine with --agent for another agent's project path)"
+        ),
+    )
+    parser.add_argument(
+        "--dest",
+        help="install into this skills directory, ignoring --agent/--project",
+    )
+    parser.add_argument(
+        "--uninstall",
+        action="store_true",
+        help="remove the skill from the selected locations instead",
+    )
+    args = parser.parse_args(argv)
+
+    agent_names = args.agent or []
+    if "all" in agent_names:
+        agent_names = list(AGENTS)
+
+    skills_dirs = resolve_skills_dirs(agent_names, args.project, args.dest)
+    if not skills_dirs:
+        print(
+            "No AI coding agents detected (looked for "
+            + ", ".join(str(spec["detect"]) for spec in AGENTS.values())
+            + ").\nUse --agent, --project or --dest to choose a location."
+        )
+        return 1
+
+    for skills_dir in skills_dirs:
+        if args.uninstall:
+            if uninstall_skill(skills_dir):
+                print(f"Removed {Path(skills_dir).expanduser() / SKILL_NAME}")
+            else:
+                print(f"Nothing to remove in {Path(skills_dir).expanduser()}")
+        else:
+            target = install_skill(skills_dir)
+            print(f"Installed {SKILL_NAME} (ccp {ccp_version()}) at {target}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ccp/tests/test_agent_skills.py
+++ b/ccp/tests/test_agent_skills.py
@@ -1,0 +1,84 @@
+import re
+from importlib import resources
+from pathlib import Path
+
+import pytest
+
+from ccp.agent_skills import install_skill, uninstall_skill
+from ccp.agent_skills.install import (
+    AGENTS,
+    SKILL_NAME,
+    VERSION_PLACEHOLDER,
+    ccp_version,
+    main,
+    resolve_skills_dirs,
+)
+
+
+@pytest.fixture
+def skill_source():
+    return Path(resources.files("ccp") / "agent_skills" / SKILL_NAME)
+
+
+def test_skill_md_frontmatter(skill_source):
+    text = (skill_source / "SKILL.md").read_text(encoding="utf-8")
+    frontmatter = re.match(r"---\n(.*?)\n---\n", text, re.DOTALL)
+    assert frontmatter is not None
+    assert f"name: {SKILL_NAME}" in frontmatter.group(1)
+    assert "description:" in frontmatter.group(1)
+    assert VERSION_PLACEHOLDER in text
+
+
+def test_skill_is_self_contained(skill_source):
+    recipe_files = {p.name for p in skill_source.glob("*.md")} - {"SKILL.md"}
+    indexed = set()
+    for md_file in skill_source.glob("*.md"):
+        for link in re.findall(r"\]\(([^)]+\.md)\)", md_file.read_text()):
+            assert "/" not in link, f"{md_file.name} links outside the skill: {link}"
+            assert (skill_source / link).exists(), f"{md_file.name}: broken link {link}"
+            if md_file.name == "SKILL.md":
+                indexed.add(link)
+    assert indexed == recipe_files
+
+
+def test_install_stamps_version(tmp_path):
+    target = install_skill(tmp_path)
+    assert target == tmp_path / SKILL_NAME
+    text = (target / "SKILL.md").read_text(encoding="utf-8")
+    assert VERSION_PLACEHOLDER not in text
+    assert f"ccp {ccp_version()}" in text
+    assert (target / "points.md").exists()
+
+
+def test_reinstall_removes_stale_files(tmp_path):
+    stale = install_skill(tmp_path) / "old_recipe.md"
+    stale.write_text("stale")
+    install_skill(tmp_path)
+    assert not stale.exists()
+
+
+def test_uninstall(tmp_path):
+    install_skill(tmp_path)
+    assert uninstall_skill(tmp_path) is True
+    assert not (tmp_path / SKILL_NAME).exists()
+    assert uninstall_skill(tmp_path) is False
+
+
+def test_resolve_skills_dirs():
+    assert resolve_skills_dirs([], False, "some/dir") == [Path("some/dir")]
+    assert resolve_skills_dirs(["claude"], False, None) == [Path("~/.claude/skills")]
+    assert resolve_skills_dirs(["copilot"], True, None) == [Path(".github/skills")]
+    assert resolve_skills_dirs([], True, None) == [Path(".claude/skills")]
+
+
+def test_main_with_dest(tmp_path, capsys):
+    assert main(["--dest", str(tmp_path)]) == 0
+    assert (tmp_path / SKILL_NAME / "SKILL.md").exists()
+    assert str(tmp_path / SKILL_NAME) in capsys.readouterr().out
+    assert main(["--dest", str(tmp_path), "--uninstall"]) == 0
+    assert not (tmp_path / SKILL_NAME).exists()
+
+
+def test_agents_registry():
+    for spec in AGENTS.values():
+        assert set(spec) == {"detect", "user", "project"}

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -34,6 +34,38 @@ You can also combine extras:
 pip install ccp-performance[dev,app]
 ```
 
+## AI assistance
+
+ccp ships with an agent skill — a set of concise compressor-performance
+recipes in the [Agent Skills](https://agentskills.io) open standard that
+teaches AI coding agents how to build states, points and impellers and run
+performance analyses with ccp. After installing ccp, install the skill with:
+
+```{code-block}
+ccp-install-skill
+```
+
+This detects the AI coding agents on your machine (Claude Code, GitHub
+Copilot, Cursor, Codex) and copies the skill to each one's personal skills
+directory. Useful variations:
+
+```{code-block}
+ccp-install-skill --project          # install into the current project (shared with your team)
+ccp-install-skill --agent claude     # install for a specific agent only
+ccp-install-skill --uninstall        # remove the skill
+```
+
+Once installed, the skill activates automatically whenever you ask your agent
+about centrifugal compressor performance with ccp — for example, "create an
+impeller from these test points and convert the curves to the new suction
+condition". In Claude Code you can also invoke it explicitly with the `/ccp`
+slash command.
+
+The skill is a snapshot of the recipes for the installed ccp version, so
+re-run `ccp-install-skill` after upgrading ccp.
+
+## REFPROP
+
 To run `ccp` you need to have `REFPROP` in your computer, and an environment variable called `RPPREFIX` pointing to the `REFPROP` path.
 
 If you have not set a `RPPREFIX` environment variable, you can do the following before importing ccp:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ Documentation = "https://ccp-centrifugal-compressor-performance.readthedocs.io/e
 
 [project.scripts]
 ccp-app = "ccp.app.cli:main"
+ccp-install-skill = "ccp.agent_skills.install:main"
 
 [project.optional-dependencies]
 app = [
@@ -67,6 +68,7 @@ version = {attr = "ccp.__version__"}
 include = ["ccp*"]
 
 [tool.setuptools.package-data]
+"ccp.agent_skills" = ["ccp/*.md"]
 "ccp.config" = ["new_units.txt", "legacy_water_units.txt"]
 "ccp.tests" = ["*.py"]
 "ccp.tests.data" = ["*"]


### PR DESCRIPTION
## Summary

Distributes a ccp cookbook as an [Agent Skill](https://agentskills.io) that ships inside the `ccp-performance` package, so any ccp user can teach their AI coding agent how to run compressor performance analyses (same scheme as petrobras/ross#1355):

```bash
pip install ccp-performance
ccp-install-skill
```

### What's included

- **Self-contained skill folder** at `ccp/agent_skills/ccp/`: ccp had no agent-facing cookbook, so this PR authors one — nine concise recipes based on the tutorials and source, covering thermodynamic states and fluids, performance points and polytropic methods, impellers and performance maps, Engauge curve import, conversion to new suction conditions, ASME PTC 10 similarity, flow orifice metering, operational data evaluation, and common gotchas. The skill name `ccp` doubles as the explicit slash command in Claude Code (`/ccp`); in Copilot, Cursor and Codex the skill activates automatically when the prompt is about compressor performance with ccp.
- **`ccp-install-skill` console script**: with no arguments it detects the agents installed on the machine (Claude Code, GitHub Copilot, Cursor, Codex) and copies the skill to each one's personal skills directory. Options: `--agent claude|copilot|cursor|codex|all`, `--project` (installs to `.claude/skills/`, which Claude Code, Copilot and Cursor all scan, so it can be committed and shared with a team), `--dest PATH`, `--uninstall`. The installed `SKILL.md` is stamped with the ccp version so agents can flag a stale skill after an upgrade and suggest re-running the installer.
- **Recipes verified by execution**: every python block in every recipe was executed against `main`. The states, points and flow orifice recipes ran at full fidelity; for the REFPROP-heavy recipes (impeller construction, conversion, evaluation over the 5,780-row orifice dataset) a validation harness cached the expensive builds once, validated call signatures against the real functions, and truncated the bulk data — cutting validation from hours to minutes while still catching real bugs (several blocks referenced variables defined only in other recipes, and one leaked `ccp.config.POLYTROPIC_METHOD` globally; all fixed).
- **Docs**: README gains an Installation section with the agent-skill step, and the installation guide gets an "AI assistance" section. CLAUDE.md points at the skill folder so the recipes are kept in sync with API changes.
- **Tests**: `ccp/tests/test_agent_skills.py` covers the installer (version stamping, clean reinstall, uninstall, CLI) and enforces that the skill folder stays self-contained (every link in every recipe must resolve inside it, and the SKILL.md index must match the recipe files exactly).

### Verification

- Built the wheel and confirmed the skill files and the `ccp-install-skill` entry point are included; installed it into a fresh venv and exercised `ccp-install-skill --dest` end to end (version stamp rendered correctly).
- All recipe code blocks execute against `main`; `pytest -m "not slow"` passes (156 tests) and the new module is ruff-clean.

### Found during verification

ccp parallelizes impeller construction, conversion and evaluation with a forkserver/spawn multiprocessing context whose workers re-import `__main__` — a plain script that builds an `Impeller` at module top level dies with `RuntimeError: An attempt has been made to start a new process before the current process has finished its bootstrapping phase`. This is now documented in the skill's gotchas recipe (guard with `if __name__ == "__main__":`); interactive sessions are unaffected.
