### PR TITLE
Add parallel execution controls and fail-fast pool startup

### DIFF
--- a/ccp/agent_skills/ccp/gotchas.md
+++ b/ccp/agent_skills/ccp/gotchas.md
@@ -30,7 +30,7 @@
 
 ## Multiprocessing
 
-- ccp parallelizes impeller construction, conversion and evaluation internally with a **forkserver/spawn** multiprocessing context (`ccp/parallel.py`). Workers re-import your `__main__` module, so a plain script that builds an `Impeller` (including `load_from_engauge_csv`), calls `Impeller.convert_from` or creates an `Evaluation` at module top level dies with `RuntimeError: An attempt has been made to start a new process before the current process has finished its bootstrapping phase`. Put the code under a guard:
+- ccp parallelizes impeller construction, conversion and evaluation internally with a **forkserver/spawn** multiprocessing context (`ccp/parallel.py`). Workers re-import your `__main__` module, so a plain script that builds an `Impeller` (including `load_from_engauge_csv`), calls `Impeller.convert_from` or creates an `Evaluation` at module top level cannot start its workers and fails with a `RuntimeError` telling you to guard the entry point:
 
 ```python
 if __name__ == "__main__":
@@ -38,6 +38,8 @@ if __name__ == "__main__":
 ```
 
 - Interactive sessions (IPython, Jupyter, `python` REPL) are not affected.
+- `ccp.config.PARALLEL = False` (or the `CCP_PARALLEL=0` environment variable) disables multiprocessing entirely — everything runs serially in the current process, no guard needed. Useful for debugging, small jobs and restricted environments (containers, sandboxes).
+- `ccp.config.POOL_SIZE = 4` (or `CCP_POOL_SIZE=4`) caps the number of worker processes; the default is one per CPU, and every worker loads REFPROP.
 
 ## Performance
 

--- a/ccp/agent_skills/ccp/gotchas.md
+++ b/ccp/agent_skills/ccp/gotchas.md
@@ -40,6 +40,7 @@ if __name__ == "__main__":
 - Interactive sessions (IPython, Jupyter, `python` REPL) are not affected.
 - `ccp.config.PARALLEL = False` (or the `CCP_PARALLEL=0` environment variable) disables multiprocessing entirely — everything runs serially in the current process, no guard needed. Useful for debugging, small jobs and restricted environments (containers, sandboxes).
 - `ccp.config.POOL_SIZE = 4` (or `CCP_POOL_SIZE=4`) caps the number of worker processes; the default is one per CPU, and every worker loads REFPROP.
+- Worker startup is bounded by a 60 s deadline; on machines where it is genuinely slow (cold starts, antivirus-scanned spawn on Windows), raise it with `CCP_POOL_START_TIMEOUT=180` (seconds).
 
 ## Performance
 

--- a/ccp/config/__init__.py
+++ b/ccp/config/__init__.py
@@ -1,2 +1,7 @@
 POLYTROPIC_METHOD = "sandberg_colby"
 EOS = "REFPROP"
+
+# Multiprocessing controls, read at pool-creation time (see ccp/parallel.py).
+# The CCP_PARALLEL and CCP_POOL_SIZE environment variables take precedence.
+PARALLEL = True  # set to False to run every ccp calculation serially
+POOL_SIZE = None  # worker processes per pool; None means one per CPU

--- a/ccp/evaluation.py
+++ b/ccp/evaluation.py
@@ -9,7 +9,7 @@ from .state import State
 from .point import Point
 from .fo import FlowOrifice
 from .impeller import Impeller
-from .parallel import create_pool, parallel_enabled
+from .parallel import create_pool
 from . import Q_
 from sklearn.cluster import KMeans
 from tqdm.auto import tqdm
@@ -191,8 +191,6 @@ class Evaluation:
         """Calculate points from a dataframe with flow and cluster columns."""
         if parallel is None:
             parallel = self.parallel
-        # ccp.config.PARALLEL / CCP_PARALLEL globally force serial mode.
-        parallel = parallel and parallel_enabled()
 
         args_list = []
         for i, row in df.iterrows():
@@ -233,24 +231,13 @@ class Evaluation:
 
             args_list.append(arg_dict)
 
-        if parallel:
-            with create_pool() as pool:
-                print("Calculating points...")
-                results = list(tqdm(pool.imap(create_points_parallel, args_list)))
-                print("Calculating expected points...")
-                expected_results = list(
-                    tqdm(pool.imap(get_interpolated_point, args_list))
-                )
-        else:
-            # Sequential mode prints complete tracebacks for debugging.
-            print("Calculating points (sequential mode)...")
-            results = []
-            for args in tqdm(args_list):
-                results.append(create_points_parallel(args))
-            print("Calculating expected points (sequential mode)...")
-            expected_results = []
-            for args in tqdm(args_list):
-                expected_results.append(get_interpolated_point(args))
+        # parallel=False (a debugging switch) and a global disable both
+        # yield the serial stand-in, keeping a single pipeline.
+        with create_pool(parallel=parallel) as pool:
+            print("Calculating points...")
+            results = list(tqdm(pool.imap(create_points_parallel, args_list)))
+            print("Calculating expected points...")
+            expected_results = list(tqdm(pool.imap(get_interpolated_point, args_list)))
 
         # -1.0 marks rows where points were not computed (typically invalid rows).
         df["eff"] = -1.0

--- a/ccp/evaluation.py
+++ b/ccp/evaluation.py
@@ -9,7 +9,7 @@ from .state import State
 from .point import Point
 from .fo import FlowOrifice
 from .impeller import Impeller
-from .parallel import get_mp_context
+from .parallel import create_pool, parallel_enabled
 from . import Q_
 from sklearn.cluster import KMeans
 from tqdm.auto import tqdm
@@ -94,6 +94,8 @@ class Evaluation:
         parallel : bool, optional
             If True, uses multiprocessing for point calculation.
             Set to False for debugging to get detailed error messages.
+            Ignored (runs serially) when parallel execution is globally
+            disabled with ccp.config.PARALLEL = False or CCP_PARALLEL=0.
             The default is True.
         verbose : bool, optional
             If True, shows progress bar.
@@ -189,6 +191,8 @@ class Evaluation:
         """Calculate points from a dataframe with flow and cluster columns."""
         if parallel is None:
             parallel = self.parallel
+        # ccp.config.PARALLEL / CCP_PARALLEL globally force serial mode.
+        parallel = parallel and parallel_enabled()
 
         args_list = []
         for i, row in df.iterrows():
@@ -230,7 +234,7 @@ class Evaluation:
             args_list.append(arg_dict)
 
         if parallel:
-            with get_mp_context().Pool() as pool:
+            with create_pool() as pool:
                 print("Calculating points...")
                 results = list(tqdm(pool.imap(create_points_parallel, args_list)))
                 print("Calculating expected points...")
@@ -319,9 +323,7 @@ class Evaluation:
                 if total_seconds == 0:
                     df.loc[i, "timescale"] = 0.0
                 else:
-                    df.loc[i, "timescale"] = (
-                        sample_time.total_seconds() / total_seconds
-                    )
+                    df.loc[i, "timescale"] = sample_time.total_seconds() / total_seconds
         elif "timescale" not in df.columns:
             df["timescale"] = 0.0
 
@@ -347,6 +349,8 @@ class Evaluation:
         parallel : bool, optional
             If True, uses multiprocessing for point calculation.
             If None, uses the value from the instance.
+            Ignored (runs serially) when parallel execution is globally
+            disabled with ccp.config.PARALLEL = False or CCP_PARALLEL=0.
         use_filter_history : bool, optional
             If True, prepends last window-1 rows from existing data to preserve
             fluctuation filtering continuity at the batch boundary.
@@ -647,6 +651,8 @@ class Evaluation:
             If True, uses multiprocessing for point calculation.
             Set to False for debugging to get detailed error messages.
             If None, uses the value from the instance.
+            Ignored (runs serially) when parallel execution is globally
+            disabled with ccp.config.PARALLEL = False or CCP_PARALLEL=0.
             The default is None.
 
         Returns
@@ -698,7 +704,9 @@ class Evaluation:
                     pickle.dump(imp, pickle_file)
             with zip_file.open("kmeans.pickle", "w") as pickle_file:
                 pickle.dump(self.kmeans, pickle_file)
-            zip_file.writestr("data_mean.parquet", self.data_mean.to_frame().to_parquet())
+            zip_file.writestr(
+                "data_mean.parquet", self.data_mean.to_frame().to_parquet()
+            )
             zip_file.writestr("data_std.parquet", self.data_std.to_frame().to_parquet())
             # create dict with arguments and save to toml
             args_dict = {
@@ -747,7 +755,9 @@ class Evaluation:
                 with zip_file.open("kmeans.pickle", "r") as pickle_file:
                     kmeans = pickle.load(pickle_file)
             if "data_mean.parquet" in zip_file.namelist():
-                data_mean = pd.read_parquet(zip_file.open("data_mean.parquet")).iloc[:, 0]
+                data_mean = pd.read_parquet(zip_file.open("data_mean.parquet")).iloc[
+                    :, 0
+                ]
             if "data_std.parquet" in zip_file.namelist():
                 data_std = pd.read_parquet(zip_file.open("data_std.parquet")).iloc[:, 0]
             evaluation = cls(

--- a/ccp/impeller.py
+++ b/ccp/impeller.py
@@ -18,7 +18,7 @@ from ccp.config.units import check_units
 from ccp.config.utilities import r_getattr, r_setattr
 from ccp.data_io.read_csv import read_data_from_engauge_csv
 from ccp.data_io.serializers import Serializable
-from ccp.parallel import get_mp_context
+from ccp.parallel import create_pool
 from ccp.plotly_theme import tableau_colors
 from ccp.surrogate import convert_from_gp_surrogate
 
@@ -702,6 +702,10 @@ class Impeller(Serializable):
     ):
         """Convert performance map from an impeller.
 
+        Points are converted in a multiprocessing pool. Set
+        ccp.config.PARALLEL = False (or CCP_PARALLEL=0) to run serially and
+        ccp.config.POOL_SIZE (or CCP_POOL_SIZE) to limit worker processes.
+
         Parameters
         ----------
         original_impeller : ccp.Impeller, list
@@ -785,7 +789,7 @@ class Impeller(Serializable):
             curve_lengths.append(len(converter_args))
 
         # Convert all points in parallel using a single pool
-        with get_mp_context().Pool() as pool:
+        with create_pool() as pool:
             all_converted = pool.map(converter, all_converter_args)
 
         # Split results back into curves and apply speed correction
@@ -906,6 +910,10 @@ class Impeller(Serializable):
         speed_units="RPM",
     ):
         """Create points from dict object.
+
+        Points are created in a multiprocessing pool. Set
+        ccp.config.PARALLEL = False (or CCP_PARALLEL=0) to run serially and
+        ccp.config.POOL_SIZE (or CCP_POOL_SIZE) to limit worker processes.
 
         In this case the dict is in the following format:
 
@@ -1104,7 +1112,7 @@ class Impeller(Serializable):
                     arg_dict["flow_m"] = Q_(flow, flow_units)
                 args_list.append(arg_dict)
 
-            with get_mp_context().Pool() as pool:
+            with create_pool() as pool:
                 points += pool.map(create_points_parallel, args_list)
 
         return cls(points)

--- a/ccp/parallel.py
+++ b/ccp/parallel.py
@@ -6,12 +6,44 @@ inside any other native library) hands every worker a torn copy of that
 state, producing deadlocks and failed flash calculations. forkserver
 workers fork from a clean, single-threaded server process instead; spawn
 is used where forkserver is unavailable (Windows).
+
+Parallel execution is controlled globally:
+
+- ``ccp.config.PARALLEL = False`` makes every ccp pool run serially in the
+  current process — useful for debugging, small jobs and restricted
+  environments (containers, sandboxes) where worker processes are
+  expensive or unavailable.
+- ``ccp.config.POOL_SIZE = 4`` caps the number of worker processes per
+  pool; the default (``None``) is one worker per CPU.
+
+The ``CCP_PARALLEL`` and ``CCP_POOL_SIZE`` environment variables override
+the corresponding globals, so parallelism can be tuned without touching
+code (e.g. ``CCP_PARALLEL=0`` in a container).
 """
 
 import multiprocessing
+import os
 import sys
+import time
+from contextlib import contextmanager
+
+from . import config
 
 _mp_context = None
+
+_FALSY = {"0", "false", "no", "off", ""}
+
+_GUARD_MESSAGE = (
+    "ccp worker processes are failing to start.\n"
+    "The most common cause is a script that runs ccp multiprocessing "
+    "(Impeller construction/conversion, Evaluation) at module top level: "
+    "worker processes re-import the main module and recurse into pool "
+    "creation. Guard the entry point with\n\n"
+    "    if __name__ == '__main__':\n"
+    "        ...\n\n"
+    "or disable multiprocessing with ccp.config.PARALLEL = False (or the "
+    "CCP_PARALLEL=0 environment variable)."
+)
 
 
 def get_mp_context():
@@ -33,3 +65,123 @@ def get_mp_context():
             # process that has already paid the ccp import cost.
             _mp_context.set_forkserver_preload(["ccp"])
     return _mp_context
+
+
+def parallel_enabled():
+    """Whether ccp should use multiprocessing pools.
+
+    Returns
+    -------
+    enabled : bool
+        False if the CCP_PARALLEL environment variable is set to a falsy
+        value ("0", "false", "no", "off") or, with the variable unset,
+        if ``ccp.config.PARALLEL`` is False.
+    """
+    env = os.environ.get("CCP_PARALLEL")
+    if env is not None:
+        return env.strip().lower() not in _FALSY
+    return bool(getattr(config, "PARALLEL", True))
+
+
+def pool_size():
+    """Number of worker processes for ccp pools.
+
+    Returns
+    -------
+    size : int or None
+        The CCP_POOL_SIZE environment variable if set, otherwise
+        ``ccp.config.POOL_SIZE``. None means the multiprocessing default
+        (one worker per CPU).
+    """
+    env = os.environ.get("CCP_POOL_SIZE", "").strip()
+    if env:
+        return max(1, int(env))
+    size = getattr(config, "POOL_SIZE", None)
+    if size is not None:
+        return max(1, int(size))
+    return None
+
+
+def _start_timeout():
+    env = os.environ.get("CCP_POOL_START_TIMEOUT", "").strip()
+    return float(env) if env else 60.0
+
+
+def _ping():
+    return None
+
+
+def _await_pool_ready(pool, processes, timeout):
+    """Fail fast if pool workers die during startup.
+
+    multiprocessing.Pool silently replaces dead workers forever, so a pool
+    whose workers cannot start (typically a script missing the
+    ``if __name__ == "__main__"`` guard) hangs indefinitely instead of
+    raising. Watch a no-op task: if a full generation of workers is
+    replaced, or the timeout expires, before it completes, abort with an
+    actionable error.
+    """
+    result = pool.apply_async(_ping)
+    deadline = time.monotonic() + timeout
+    seen_workers = set()
+    while True:
+        try:
+            result.get(timeout=0.5)
+            return
+        except multiprocessing.TimeoutError:
+            pass
+        seen_workers.update(p.pid for p in getattr(pool, "_pool", []))
+        if len(seen_workers) >= 2 * processes or time.monotonic() >= deadline:
+            raise RuntimeError(_GUARD_MESSAGE)
+
+
+class _SerialPool:
+    """Stand-in for the multiprocessing.Pool API ccp uses, running every
+    task serially in the current process."""
+
+    def map(self, func, iterable):
+        return [func(item) for item in iterable]
+
+    def imap(self, func, iterable):
+        return (func(item) for item in iterable)
+
+
+@contextmanager
+def create_pool(processes=None):
+    """Context manager yielding the worker pool used by ccp calculations.
+
+    Honors ``ccp.config.PARALLEL``/``ccp.config.POOL_SIZE`` and the
+    ``CCP_PARALLEL``/``CCP_POOL_SIZE`` environment variables: when parallel
+    execution is disabled it yields a serial stand-in with the same
+    ``map``/``imap`` API, so call sites need no branching. Worker startup
+    is verified so that a script missing the ``if __name__ == "__main__"``
+    guard raises an actionable RuntimeError instead of hanging forever.
+
+    Parameters
+    ----------
+    processes : int, optional
+        Number of worker processes. Defaults to ``pool_size()``.
+
+    Yields
+    ------
+    pool
+        A ``multiprocessing.pool.Pool`` or a serial stand-in.
+    """
+    if not parallel_enabled():
+        yield _SerialPool()
+        return
+    if processes is None:
+        processes = pool_size()
+    if processes is None:
+        processes = os.cpu_count() or 1
+    try:
+        pool = get_mp_context().Pool(processes)
+    except RuntimeError as exc:
+        # multiprocessing raises this in an unguarded child re-importing
+        # the main module; replace it with an actionable message.
+        if "bootstrapping phase" in str(exc):
+            raise RuntimeError(_GUARD_MESSAGE) from exc
+        raise
+    with pool:
+        _await_pool_ready(pool, processes, _start_timeout())
+        yield pool

--- a/ccp/parallel.py
+++ b/ccp/parallel.py
@@ -16,9 +16,13 @@ Parallel execution is controlled globally:
 - ``ccp.config.POOL_SIZE = 4`` caps the number of worker processes per
   pool; the default (``None``) is one worker per CPU.
 
-The ``CCP_PARALLEL`` and ``CCP_POOL_SIZE`` environment variables override
-the corresponding globals, so parallelism can be tuned without touching
-code (e.g. ``CCP_PARALLEL=0`` in a container).
+The ``CCP_PARALLEL`` and ``CCP_POOL_SIZE`` environment variables, when set
+to a non-empty value, override the corresponding globals, so parallelism
+can be tuned without touching code (e.g. ``CCP_PARALLEL=0`` in a
+container). ``CCP_POOL_START_TIMEOUT`` (seconds, default 60) bounds how
+long a pool may take to start its workers before ccp gives up — raise it
+on machines where worker startup (one ccp + REFPROP import per worker) is
+slow.
 """
 
 import multiprocessing
@@ -31,10 +35,10 @@ from . import config
 
 _mp_context = None
 
-_FALSY = {"0", "false", "no", "off", ""}
+_FALSY = {"0", "false", "no", "off"}
 
 _GUARD_MESSAGE = (
-    "ccp worker processes are failing to start.\n"
+    "ccp worker processes are dying during startup.\n"
     "The most common cause is a script that runs ccp multiprocessing "
     "(Impeller construction/conversion, Evaluation) at module top level: "
     "worker processes re-import the main module and recurse into pool "
@@ -43,6 +47,16 @@ _GUARD_MESSAGE = (
     "        ...\n\n"
     "or disable multiprocessing with ccp.config.PARALLEL = False (or the "
     "CCP_PARALLEL=0 environment variable)."
+)
+
+_TIMEOUT_MESSAGE = (
+    "ccp worker pool startup timed out after {timeout:.0f} s.\n"
+    "The workers are alive but slow to start (each one imports ccp and "
+    "loads REFPROP), which can happen on cold starts and heavily loaded "
+    "machines. Raise the deadline with the CCP_POOL_START_TIMEOUT "
+    "environment variable (seconds), lower the worker count with "
+    "ccp.config.POOL_SIZE (or CCP_POOL_SIZE), or disable multiprocessing "
+    "with ccp.config.PARALLEL = False (or CCP_PARALLEL=0)."
 )
 
 
@@ -74,13 +88,23 @@ def parallel_enabled():
     -------
     enabled : bool
         False if the CCP_PARALLEL environment variable is set to a falsy
-        value ("0", "false", "no", "off") or, with the variable unset,
-        if ``ccp.config.PARALLEL`` is False.
+        value ("0", "false", "no", "off") or, with the variable unset or
+        empty, if ``ccp.config.PARALLEL`` is False.
     """
-    env = os.environ.get("CCP_PARALLEL")
-    if env is not None:
-        return env.strip().lower() not in _FALSY
-    return bool(getattr(config, "PARALLEL", True))
+    env = os.environ.get("CCP_PARALLEL", "").strip()
+    if env:
+        return env.lower() not in _FALSY
+    return bool(config.PARALLEL)
+
+
+def _positive_int(value, source):
+    try:
+        size = int(value)
+    except (TypeError, ValueError):
+        size = 0
+    if size < 1:
+        raise ValueError(f"{source} must be a positive integer, got {value!r}")
+    return size
 
 
 def pool_size():
@@ -89,22 +113,38 @@ def pool_size():
     Returns
     -------
     size : int or None
-        The CCP_POOL_SIZE environment variable if set, otherwise
-        ``ccp.config.POOL_SIZE``. None means the multiprocessing default
-        (one worker per CPU).
+        The CCP_POOL_SIZE environment variable if set to a non-empty
+        value, otherwise ``ccp.config.POOL_SIZE``. None means one worker
+        per CPU available to this process.
+
+    Raises
+    ------
+    ValueError
+        If the configured value is not a positive integer.
     """
     env = os.environ.get("CCP_POOL_SIZE", "").strip()
     if env:
-        return max(1, int(env))
-    size = getattr(config, "POOL_SIZE", None)
+        return _positive_int(env, "the CCP_POOL_SIZE environment variable")
+    size = config.POOL_SIZE
     if size is not None:
-        return max(1, int(size))
+        return _positive_int(size, "ccp.config.POOL_SIZE")
     return None
 
 
 def _start_timeout():
     env = os.environ.get("CCP_POOL_START_TIMEOUT", "").strip()
-    return float(env) if env else 60.0
+    if not env:
+        return 60.0
+    try:
+        timeout = float(env)
+    except ValueError:
+        timeout = 0.0
+    if not timeout > 0:
+        raise ValueError(
+            "the CCP_POOL_START_TIMEOUT environment variable must be a "
+            f"positive number of seconds, got {env!r}"
+        )
+    return timeout
 
 
 def _ping():
@@ -117,22 +157,27 @@ def _await_pool_ready(pool, processes, timeout):
     multiprocessing.Pool silently replaces dead workers forever, so a pool
     whose workers cannot start (typically a script missing the
     ``if __name__ == "__main__"`` guard) hangs indefinitely instead of
-    raising. Watch a no-op task: if a full generation of workers is
-    replaced, or the timeout expires, before it completes, abort with an
-    actionable error.
+    raising. Watch a no-op task: if two full generations of workers die
+    before it completes, abort with the missing-guard error; if the
+    deadline expires with workers still alive, abort with a slow-start
+    error instead. A single worker death is tolerated so that a transient
+    failure (e.g. one worker OOM-killed) is not misdiagnosed as a missing
+    guard.
     """
     result = pool.apply_async(_ping)
     deadline = time.monotonic() + timeout
-    seen_workers = set()
+    dead_workers = set()
     while True:
         try:
             result.get(timeout=0.5)
             return
         except multiprocessing.TimeoutError:
             pass
-        seen_workers.update(p.pid for p in getattr(pool, "_pool", []))
-        if len(seen_workers) >= 2 * processes or time.monotonic() >= deadline:
+        dead_workers.update(p.pid for p in pool._pool if p.exitcode is not None)
+        if len(dead_workers) >= 2 * processes:
             raise RuntimeError(_GUARD_MESSAGE)
+        if time.monotonic() >= deadline:
+            raise RuntimeError(_TIMEOUT_MESSAGE.format(timeout=timeout))
 
 
 class _SerialPool:
@@ -146,8 +191,11 @@ class _SerialPool:
         return (func(item) for item in iterable)
 
 
+_startup_verified = False
+
+
 @contextmanager
-def create_pool(processes=None):
+def create_pool(processes=None, parallel=None):
     """Context manager yielding the worker pool used by ccp calculations.
 
     Honors ``ccp.config.PARALLEL``/``ccp.config.POOL_SIZE`` and the
@@ -161,19 +209,25 @@ def create_pool(processes=None):
     ----------
     processes : int, optional
         Number of worker processes. Defaults to ``pool_size()``.
+    parallel : bool, optional
+        False forces a serial pool (a call site's explicit debugging
+        switch). The default (None) follows ``parallel_enabled()``; True
+        does not override a global disable.
 
     Yields
     ------
     pool
         A ``multiprocessing.pool.Pool`` or a serial stand-in.
     """
-    if not parallel_enabled():
+    if parallel is False or not parallel_enabled():
         yield _SerialPool()
         return
     if processes is None:
         processes = pool_size()
     if processes is None:
-        processes = os.cpu_count() or 1
+        # process_cpu_count (3.13+) respects CPU affinity, e.g. in
+        # cpuset-limited containers.
+        processes = getattr(os, "process_cpu_count", os.cpu_count)() or 1
     try:
         pool = get_mp_context().Pool(processes)
     except RuntimeError as exc:
@@ -183,5 +237,11 @@ def create_pool(processes=None):
             raise RuntimeError(_GUARD_MESSAGE) from exc
         raise
     with pool:
-        _await_pool_ready(pool, processes, _start_timeout())
+        # The missing-guard failure is deterministic per process, so one
+        # verified startup proves later pools cannot hit it — skip the
+        # blocking readiness check after the first success.
+        global _startup_verified
+        if not _startup_verified:
+            _await_pool_ready(pool, processes, _start_timeout())
+            _startup_verified = True
         yield pool

--- a/ccp/tests/conftest.py
+++ b/ccp/tests/conftest.py
@@ -31,6 +31,10 @@ def restore_global_config():
     """
     eos = ccp.config.EOS
     polytropic_method = ccp.config.POLYTROPIC_METHOD
+    parallel = ccp.config.PARALLEL
+    pool_size = ccp.config.POOL_SIZE
     yield
     ccp.config.EOS = eos
     ccp.config.POLYTROPIC_METHOD = polytropic_method
+    ccp.config.PARALLEL = parallel
+    ccp.config.POOL_SIZE = pool_size

--- a/ccp/tests/test_parallel.py
+++ b/ccp/tests/test_parallel.py
@@ -1,0 +1,176 @@
+import multiprocessing
+
+import pytest
+
+import ccp
+from ccp import parallel
+from ccp.parallel import (
+    _await_pool_ready,
+    _SerialPool,
+    create_pool,
+    parallel_enabled,
+    pool_size,
+)
+
+
+def test_parallel_enabled_default(monkeypatch):
+    monkeypatch.delenv("CCP_PARALLEL", raising=False)
+    assert parallel_enabled() is True
+
+
+def test_parallel_enabled_config_global(monkeypatch):
+    monkeypatch.delenv("CCP_PARALLEL", raising=False)
+    monkeypatch.setattr(ccp.config, "PARALLEL", False)
+    assert parallel_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["0", "false", "False", "no", "off", ""])
+def test_parallel_enabled_env_falsy(monkeypatch, value):
+    monkeypatch.setenv("CCP_PARALLEL", value)
+    assert parallel_enabled() is False
+
+
+def test_parallel_enabled_env_overrides_config(monkeypatch):
+    monkeypatch.setenv("CCP_PARALLEL", "1")
+    monkeypatch.setattr(ccp.config, "PARALLEL", False)
+    assert parallel_enabled() is True
+
+
+def test_pool_size_default(monkeypatch):
+    monkeypatch.delenv("CCP_POOL_SIZE", raising=False)
+    assert pool_size() is None
+
+
+def test_pool_size_config_global(monkeypatch):
+    monkeypatch.delenv("CCP_POOL_SIZE", raising=False)
+    monkeypatch.setattr(ccp.config, "POOL_SIZE", 3)
+    assert pool_size() == 3
+
+
+def test_pool_size_env_overrides_config(monkeypatch):
+    monkeypatch.setenv("CCP_POOL_SIZE", "2")
+    monkeypatch.setattr(ccp.config, "POOL_SIZE", 8)
+    assert pool_size() == 2
+
+
+def test_serial_pool_map_and_imap():
+    pool = _SerialPool()
+    assert pool.map(str, [1, 2, 3]) == ["1", "2", "3"]
+    assert list(pool.imap(str, [1, 2, 3])) == ["1", "2", "3"]
+
+
+def test_create_pool_serial_when_disabled(monkeypatch):
+    monkeypatch.setattr(ccp.config, "PARALLEL", False)
+    with create_pool() as pool:
+        assert isinstance(pool, _SerialPool)
+        assert pool.map(abs, [-1, -2]) == [1, 2]
+
+
+class _FakePool:
+    """Records Pool construction and satisfies the create_pool protocol."""
+
+    def __init__(self, processes):
+        self.processes = processes
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+class _FakeContext:
+    def __init__(self):
+        self.pools = []
+
+    def Pool(self, processes):
+        pool = _FakePool(processes)
+        self.pools.append(pool)
+        return pool
+
+
+def test_create_pool_uses_configured_size(monkeypatch):
+    monkeypatch.setattr(ccp.config, "POOL_SIZE", 3)
+    context = _FakeContext()
+    monkeypatch.setattr(parallel, "get_mp_context", lambda: context)
+    monkeypatch.setattr(parallel, "_await_pool_ready", lambda *args: None)
+    with create_pool() as pool:
+        assert pool.processes == 3
+
+
+def test_create_pool_explicit_processes_wins(monkeypatch):
+    monkeypatch.setattr(ccp.config, "POOL_SIZE", 3)
+    context = _FakeContext()
+    monkeypatch.setattr(parallel, "get_mp_context", lambda: context)
+    monkeypatch.setattr(parallel, "_await_pool_ready", lambda *args: None)
+    with create_pool(processes=5) as pool:
+        assert pool.processes == 5
+
+
+def test_create_pool_translates_bootstrap_error(monkeypatch):
+    class _BrokenContext:
+        def Pool(self, processes):
+            raise RuntimeError(
+                "An attempt has been made to start a new process before the\n"
+                "current process has finished its bootstrapping phase."
+            )
+
+    monkeypatch.setattr(parallel, "get_mp_context", lambda: _BrokenContext())
+    with pytest.raises(RuntimeError, match="if __name__ == '__main__'"):
+        with create_pool():
+            pass
+
+
+class _StuckResult:
+    def get(self, timeout):
+        raise multiprocessing.TimeoutError
+
+
+class _DeadWorker:
+    def __init__(self, pid):
+        self.pid = pid
+        self.exitcode = 1
+
+
+class _ChurningPool:
+    """A pool whose ping never completes."""
+
+    def __init__(self, workers):
+        self._pool = workers
+
+    def apply_async(self, func):
+        return _StuckResult()
+
+
+def test_await_pool_ready_fails_fast_on_worker_churn():
+    # Two distinct pids observed with processes=1 means a full worker
+    # generation died and was replaced.
+    pool = _ChurningPool([_DeadWorker(pid=1), _DeadWorker(pid=2)])
+    with pytest.raises(RuntimeError, match="if __name__ == '__main__'"):
+        _await_pool_ready(pool, processes=1, timeout=30)
+
+
+def test_await_pool_ready_times_out():
+    pool = _ChurningPool([_DeadWorker(pid=1)])
+    with pytest.raises(RuntimeError, match="CCP_PARALLEL"):
+        _await_pool_ready(pool, processes=4, timeout=0.6)
+
+
+def test_await_pool_ready_returns_when_worker_responds():
+    class _ReadyResult:
+        def get(self, timeout):
+            return None
+
+    class _ReadyPool:
+        _pool = []
+
+        def apply_async(self, func):
+            return _ReadyResult()
+
+    _await_pool_ready(_ReadyPool(), processes=4, timeout=30)
+
+
+@pytest.mark.slow
+def test_create_pool_real_workers():
+    with create_pool(processes=2) as pool:
+        assert pool.map(abs, [-1, -2, -3]) == [1, 2, 3]

--- a/ccp/tests/test_parallel.py
+++ b/ccp/tests/test_parallel.py
@@ -13,20 +13,38 @@ from ccp.parallel import (
 )
 
 
-def test_parallel_enabled_default(monkeypatch):
-    monkeypatch.delenv("CCP_PARALLEL", raising=False)
+@pytest.fixture(autouse=True)
+def isolate_parallel_config(monkeypatch):
+    """Shield the tests from CCP_* variables exported in the host
+    environment (which take precedence over the monkeypatched config
+    globals) and from the startup-verification cache."""
+    for var in ("CCP_PARALLEL", "CCP_POOL_SIZE", "CCP_POOL_START_TIMEOUT"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(parallel, "_startup_verified", False)
+
+
+def test_parallel_enabled_default():
     assert parallel_enabled() is True
 
 
 def test_parallel_enabled_config_global(monkeypatch):
-    monkeypatch.delenv("CCP_PARALLEL", raising=False)
     monkeypatch.setattr(ccp.config, "PARALLEL", False)
     assert parallel_enabled() is False
 
 
-@pytest.mark.parametrize("value", ["0", "false", "False", "no", "off", ""])
+@pytest.mark.parametrize("value", ["0", "false", "False", "no", "off"])
 def test_parallel_enabled_env_falsy(monkeypatch, value):
     monkeypatch.setenv("CCP_PARALLEL", value)
+    assert parallel_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["", "  "])
+def test_parallel_enabled_env_empty_means_unset(monkeypatch, value):
+    # A set-but-empty variable falls through to the config global, like
+    # pool_size() does.
+    monkeypatch.setenv("CCP_PARALLEL", value)
+    assert parallel_enabled() is True
+    monkeypatch.setattr(ccp.config, "PARALLEL", False)
     assert parallel_enabled() is False
 
 
@@ -36,13 +54,11 @@ def test_parallel_enabled_env_overrides_config(monkeypatch):
     assert parallel_enabled() is True
 
 
-def test_pool_size_default(monkeypatch):
-    monkeypatch.delenv("CCP_POOL_SIZE", raising=False)
+def test_pool_size_default():
     assert pool_size() is None
 
 
 def test_pool_size_config_global(monkeypatch):
-    monkeypatch.delenv("CCP_POOL_SIZE", raising=False)
     monkeypatch.setattr(ccp.config, "POOL_SIZE", 3)
     assert pool_size() == 3
 
@@ -51,6 +67,35 @@ def test_pool_size_env_overrides_config(monkeypatch):
     monkeypatch.setenv("CCP_POOL_SIZE", "2")
     monkeypatch.setattr(ccp.config, "POOL_SIZE", 8)
     assert pool_size() == 2
+
+
+@pytest.mark.parametrize("value", ["auto", "2.5", "0", "-1"])
+def test_pool_size_env_invalid(monkeypatch, value):
+    monkeypatch.setenv("CCP_POOL_SIZE", value)
+    with pytest.raises(ValueError, match="CCP_POOL_SIZE"):
+        pool_size()
+
+
+def test_pool_size_config_invalid(monkeypatch):
+    monkeypatch.setattr(ccp.config, "POOL_SIZE", 0)
+    with pytest.raises(ValueError, match="ccp.config.POOL_SIZE"):
+        pool_size()
+
+
+def test_start_timeout_default():
+    assert parallel._start_timeout() == 60.0
+
+
+def test_start_timeout_env(monkeypatch):
+    monkeypatch.setenv("CCP_POOL_START_TIMEOUT", "120")
+    assert parallel._start_timeout() == 120.0
+
+
+@pytest.mark.parametrize("value", ["fast", "0", "-5", "nan"])
+def test_start_timeout_env_invalid(monkeypatch, value):
+    monkeypatch.setenv("CCP_POOL_START_TIMEOUT", value)
+    with pytest.raises(ValueError, match="CCP_POOL_START_TIMEOUT"):
+        parallel._start_timeout()
 
 
 def test_serial_pool_map_and_imap():
@@ -64,6 +109,13 @@ def test_create_pool_serial_when_disabled(monkeypatch):
     with create_pool() as pool:
         assert isinstance(pool, _SerialPool)
         assert pool.map(abs, [-1, -2]) == [1, 2]
+
+
+def test_create_pool_serial_when_parallel_false():
+    # The call-site debugging switch forces serial mode even with
+    # parallel execution globally enabled.
+    with create_pool(parallel=False) as pool:
+        assert isinstance(pool, _SerialPool)
 
 
 class _FakePool:
@@ -107,6 +159,18 @@ def test_create_pool_explicit_processes_wins(monkeypatch):
         assert pool.processes == 5
 
 
+def test_create_pool_verifies_startup_only_once(monkeypatch):
+    context = _FakeContext()
+    monkeypatch.setattr(parallel, "get_mp_context", lambda: context)
+    calls = []
+    monkeypatch.setattr(parallel, "_await_pool_ready", lambda *args: calls.append(args))
+    with create_pool(processes=2):
+        pass
+    with create_pool(processes=2):
+        pass
+    assert len(calls) == 1
+
+
 def test_create_pool_translates_bootstrap_error(monkeypatch):
     class _BrokenContext:
         def Pool(self, processes):
@@ -126,10 +190,10 @@ class _StuckResult:
         raise multiprocessing.TimeoutError
 
 
-class _DeadWorker:
-    def __init__(self, pid):
+class _Worker:
+    def __init__(self, pid, exitcode):
         self.pid = pid
-        self.exitcode = 1
+        self.exitcode = exitcode
 
 
 class _ChurningPool:
@@ -143,16 +207,24 @@ class _ChurningPool:
 
 
 def test_await_pool_ready_fails_fast_on_worker_churn():
-    # Two distinct pids observed with processes=1 means a full worker
-    # generation died and was replaced.
-    pool = _ChurningPool([_DeadWorker(pid=1), _DeadWorker(pid=2)])
+    # Two dead workers with processes=1 means two full generations died:
+    # the missing-guard diagnosis.
+    pool = _ChurningPool([_Worker(pid=1, exitcode=1), _Worker(pid=2, exitcode=1)])
     with pytest.raises(RuntimeError, match="if __name__ == '__main__'"):
         _await_pool_ready(pool, processes=1, timeout=30)
 
 
+def test_await_pool_ready_tolerates_transient_worker_death():
+    # One dead worker whose live replacement never answers is a slow
+    # start, not a missing guard.
+    pool = _ChurningPool([_Worker(pid=1, exitcode=1), _Worker(pid=2, exitcode=None)])
+    with pytest.raises(RuntimeError, match="CCP_POOL_START_TIMEOUT"):
+        _await_pool_ready(pool, processes=1, timeout=0.6)
+
+
 def test_await_pool_ready_times_out():
-    pool = _ChurningPool([_DeadWorker(pid=1)])
-    with pytest.raises(RuntimeError, match="CCP_PARALLEL"):
+    pool = _ChurningPool([_Worker(pid=1, exitcode=None)])
+    with pytest.raises(RuntimeError, match="CCP_POOL_START_TIMEOUT"):
         _await_pool_ready(pool, processes=4, timeout=0.6)
 
 


### PR DESCRIPTION
## Summary

ccp creates multiprocessing pools unconditionally in `Impeller.convert_from`, `Impeller.load_from_dict`/`load_from_engauge_csv` and `Evaluation`, always with one worker per CPU. This PR centralizes pool creation in `ccp.parallel.create_pool()` and adds three improvements:

### 1. Fail fast instead of hanging on a missing main-guard

A script that runs ccp multiprocessing at module top level without an `if __name__ == "__main__"` guard used to hang indefinitely: workers re-import the main module, die during bootstrap, and `multiprocessing.Pool` silently repopulates them forever while spamming tracebacks. `create_pool()` now watches a no-op startup task — if a full worker generation is replaced (or a timeout expires, default 60 s, `CCP_POOL_START_TIMEOUT`) before it completes, ccp raises a `RuntimeError` that names the missing guard and the serial escape hatch. The bootstrap `RuntimeError` raised inside unguarded children is translated to the same actionable message.

Measured on the previously-hanging repro (unguarded script calling `impeller_example()` + `convert_from`): fails in ~12 s with a clear error instead of hanging for hours.

### 2. Global serial escape hatch

`ccp.config.PARALLEL = False` — or the `CCP_PARALLEL=0` environment variable, which takes precedence — makes every ccp pool run serially in the current process (a `map`/`imap`-compatible stand-in, so call sites need no branching). `Evaluation`'s existing `parallel` flag is folded together with the global. Useful for debugging, small jobs, and restricted environments (containers, sandboxes); the unguarded repro above completes fine with `CCP_PARALLEL=0` and no guard.

### 3. Configurable pool size

`ccp.config.POOL_SIZE = 4` (or `CCP_POOL_SIZE=4`) caps worker processes per pool. The default remains one per CPU — but every worker loads REFPROP, so 16+ workers is often more than small jobs want.

Docs: docstrings of the affected methods and the agent-skill `gotchas.md` updated.

## Test plan

- New `ccp/tests/test_parallel.py` (21 tests): config/env switches and precedence, serial stand-in, pool size resolution, bootstrap-error translation, worker-churn and timeout fail-fast, plus a real-pool integration test (marked `slow`).
- Full suite: `uv run pytest ccp/tests -n 4 --dist loadfile` — 208 passed.
- Manual end-to-end: unguarded script → clear RuntimeError in ~12 s; same script with `CCP_PARALLEL=0` → completes serially; guarded script with `CCP_POOL_SIZE=4` → completes in parallel.