### PR TITLE
Fix white boxes behind card icons in docs dark mode

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -42,3 +42,11 @@ nav.bd-links ul.nav.sidenav_l1 {
 img {
     margin-bottom: 1em;
 }
+
+/* In dark mode pydata-sphinx-theme paints a white box behind every content
+   image (html[data-theme=dark] .bd-content img). The landing-page card icons
+   are transparent-background SVGs that read fine on the dark card surface,
+   so drop the box. */
+html[data-theme="dark"] .sd-card img[src*=".svg"] {
+    background-color: transparent;
+}


### PR DESCRIPTION
## Summary

In dark mode, the four landing-page card icons rendered on white/gray rounded boxes instead of sitting directly on the dark card surface.

**Root cause:** pydata-sphinx-theme (the base of sphinx-book-theme) paints `background-color: #fff` behind every content image in dark mode (`html[data-theme=dark] .bd-content img:not(.only-dark,.dark-light)`). The card SVG icons are transparent-background glyphs, so the forced white background showed as a box.

**Fix:** override the background to transparent for card SVGs in dark mode, in `docs/_static/custom.css`. No invert filter is needed — the icons are solid blue (`#3480a8`) and read well directly on the dark card surface.

Same issue was found and fixed in the ross docs.

## Verification

Rebuilt the docs and screenshotted the landing page in dark mode with and without the rule: before, each icon has a light rounded box behind it; after, icons sit cleanly on the dark card.